### PR TITLE
Fix line endings and 8-bit chars

### DIFF
--- a/Gauthier_vt/GauthierVT-jhr.tab
+++ b/Gauthier_vt/GauthierVT-jhr.tab
@@ -6,28 +6,154 @@ $titlesize=10
 {1. Toccada Nobiliss sonatoris Gautier - 7F8Ef9C/Mylius 1622, p. 23 i}
 B
 b
-Sc3#  dx ax bx  d
-2# fcx   c2#  d ex   f1Q daa  a2#  c cax bd d2# a ax  cc1Q bdc  //a2#    ax   aac2# a c dx    da2#   aabx  d2#  cccax   a1Q  dcd2# adacx  c
+Sc
+3#  d
+x a
+x b
+x  d
+2# fc
+x   c
+2#  d e
+x   f
+1Q daa  a
+2#  c ca
+x bd d
+2# a a
+x  cc
+1Q bdc  //a
+2#    a
+x   aac
+2# a c d
+x    da
+2#   aab
+x  d
+2#  ccca
+x   a
+1Q  dcd
+2# adac
+x  c
 1Q bdca
-2#    cx   a2#  bx    d1Q  dff2#   ex  g1Q aff
+2#    c
+x   a
+2#  b
+x    d
+1Q  dff
+2#   e
+x  g
+1Q aff
 b
 
-b2# fx edQe2# dccx bd2#  fcx    e2#  dx   f1Q  Qaa  a2#  dx     d2#     bx   c
+b
+2# f
+x edQe
+2# dcc
+x bd
+2#  fc
+x    e
+2#  d
+x   f
+1Q  Qaa  a
+2#  d
+x     d
+2#     b
+x   c
 3  da
-4#   cx   a4#   cx   ax   cx   a
-3#    dx   a
-2# abcx b2# ddex   ef2#    dx   fc2#   cdx  d2#   c ex    df2#   aa ax    d
+4#   c
+x   a
+4#   c
+x   a
+x   c
+x   a
+3#    d
+x   a
+2# abc
+x b
+2# dde
+x   ef
+2#    d
+x   fc
+2#   cd
+x  d
+2#   c e
+x    df
+2#   aa a
+x    d
 b
 
-b1Q adcQca2#  cx d0 bdc  //a2# fx  d2# cx   e2# dx   f1Q a2# fx   c2#   dx d
-3# fccx  dx     ax  c
-2#  daabx b c a2 a d d3# fcc ax d2 cdc  //a3#   cx   a3#    ex  d2   f2#  dax    a2   d
-3#    cx    a
-2# d c ex f  df2# ed  cx  f
+b
+1Q adcQca
+2#  c
+x d
+0 bdc  //a
+2# f
+x  d
+2# c
+x   e
+2# d
+x   f
+1Q a
+2# f
+x   c
+2#   d
+x d
+3# fcc
+x  d
+x     a
+x  c
+2#  daab
+x b c a
+2 a d d
+3# fcc a
+x d
+2 cdc  //a
+3#   c
+x   a
+3#    e
+x  d
+2   f
+2#  da
+x    a
+2   d
+3#    c
+x    a
+2# d c e
+x f  df
+2# ed  c
+x  f
 b
 
-b2# bd  ax  dd2 d3# f  ex   f3#   dax fx dx  g2# fdd  Qax d3# fg  ax   h2  fg2#  ghx h2# hffx f2# edex    a2# ff  ex d2# bdcx    a2# daa  ax b2# acccax  d d2aad  a
-3#  cx d
+b
+2# bd  a
+x  dd
+2 d
+3# f  e
+x   f
+3#   da
+x f
+x d
+x  g
+2# fdd  Qa
+x d
+3# fg  a
+x   h
+2  fg
+2#  gh
+x h
+2# hff
+x f
+2# ede
+x    a
+2# ff  e
+x d
+2# bdc
+x    a
+2# daa  a
+x b
+2# accca
+x  d d
+2aad  a
+3#  c
+x d
 Y cdc  //a
 b
 B
@@ -39,116 +165,301 @@ b
 Sc
 2.  dca //a
 3 a
-2# cx  d2#ax     a2#    cx   c
+2# c
+x  d
+2#a
+x     a
+2#    c
+x   c
 b
 2.aac
 3 d
-2# cx a2# cx     c2#    ex   e
-b2ccd3#  cx   e2#eccdxfc e2#e cxccd2#cacxb
-bQ2# cdex ccc
-3#   ax c
-2ca2a d e
-3#    cx    a3#aa c ex   a
+2# c
+x a
+2# c
+x     c
+2#    e
+x   e
+b
+2ccd
+3#  c
+x   e
+2#eccd
+xfc e
+2#e c
+xccd
+2#cac
+xb
+bQ
+2# cde
+x ccc
+3#   a
+x c
+2ca
+2a d e
+3#    c
+x    a
+3#aa c e
+x   a
 2 cdca
 bQ
 
 bQ
-3# aaacx cx dx  c
+3# aaac
+x c
+x d
+x  c
 3#    e
-x ax cx  d3#   ax cx ax  d3# axcx  ax  c
-bQ3#    ex  dx  cx  a3#   d
-x    c
-xcca bxa
-2# eb cxa c3#a a cx   cx e ex    a
+x a
+x c
+x  d
+3#   a
+x c
+x a
+x  d
+3# a
+xc
+x  a
+x  c
 bQ
-2#aa c exf    c2#cef cxh    e1Qeff  a
-3#f    cx     ex    ax    c
+3#    e
+x  d
+x  c
+x  a
+3#   d
+x    c
+xcca b
+xa
+2# eb c
+xa c
+3#a a c
+x   c
+x e e
+x    a
+bQ
+2#aa c e
+xf    c
+2#cef c
+xh    e
+1Qeff  a
+3#f    c
+x     e
+x    a
+x    c
 bQ
 
-bQ3#e   ex   ax   cx    e3#c  ax   cx   ax    e2. aa c3 c3# dx    ax     ex     c
-b2# a c ex   a3# cdcax     e
+bQ
+3#e   e
+x   a
+x   c
+x    e
+3#c  a
+x   c
+x   a
+x    e
+2. aa c
+3 c
+3# d
+x    a
+x     e
+x     c
+b
+2# a c e
+x   a
+3# cdca
+x     e
 2  db c
-3#  cccax      ax  dc  /ax      a
+3#  ccca
+x      a
+x  dc  /a
+x      a
 2aadccQa
-3#  cx d
+3#  c
+x d
 bQ
 2 cdc  //a
-3# ax c3# dxaxcx-Qe
+3# a
+x c
+3# d
+xa
+xc
+x-Qe
 Yf     //a
 b
 B
 
-p{3. Pauan Gauthier - 7F8Ef9D10C/GB-Cfm 689, f. 71v i}B
+p
+{3. Pauan Gauthier - 7F8Ef9D10C/GB-Cfm 689, f. 71v i}
+B
 b
 Sc
 1ffg  f
-2#   hx  f
-b2#f gx   h2#h-igx f
-b2fg h
-3# fx g
-2# f fxfd d
-b2#eff- axf-g2 f
-3# dfx  d
+2#   h
+x  f
+b
+2#f g
+x   h
+2#h-ig
+x f
+b
+2fg h
+3# f
+x g
+2# f f
+xfd d
+b
+2#eff- a
+xf-g
+2 f
+3# df
+x  d
 b
 2a- g
-3#  fx d3# bdx  bx d dxa
+3#  f
+x d
+3# bd
+x  b
+x d d
+xa
 b
-2#b daxba2#ab- ax  d
-b2# df- dx fg2# dgfx  fd-d
+2#b da
+xba
+2#ab- a
+x  d
+b
+2# df- d
+x fg
+2# dgf
+x  fd-d
 b
 
-b2 b ca
-3#      ///ax d
+b
+2 b ca
+3#      ///a
+x d
 2a
-3#dd -- //axb
+3#dd -- //a
+xb
 b
-2#ab -- /ax   c2   d- a
-3# ax  d
+2#ab -- /a
+x   c
+2   d- a
+3# a
+x  d
 b
-2# dcc ax bd2#aadccax dc
-b2 cdc- ///a
+2# dcc a
+x bd
+2#aadcca
+x dc
+b
+2 cdc- ///a
 3# d- a
-x    c3#a d-ex   fx  ddfx  f
-b3#  h - ///ax   hx fx   f3#   dax dx   fx   d
+x    c
+3#a d-e
+x   f
+x  ddf
+x  f
+b
+3#  h - ///a
+x   h
+x f
+x   f
+3#   da
+x d
+x   f
+x   d
 b
 2 d-d- ///a
-3#   cx   d
-2# c cx a a
+3#   c
+x   d
+2# c c
+x a a
 b
 
 b
-1 cdca1      ///a
+1 cdca
+1      ///a
 bb
-3#  ccx     ax  dx a3# bx    a
+3#  cc
+x     a
+x  d
+x a
+3# b
+x    a
 2 df- e
 b
 2. fg a
-3 h3# if- ax  gxfgi - axh
+3 h
+3# if- a
+x  g
+xfgi - a
+xh
 b
-2#if -- /ax    h2#   exh- g
-b2fg h
-3# fx   f
-2#ff dxhd
-b2#eff- axf-g2    a
-3#dd- cxb
+2#if -- /a
+x    h
+2#   e
+xh- g
 b
-2#a b dx  d
-3# dfax  d
+2fg h
+3# f
+x   f
+2#ff d
+xhd
+b
+2#eff- a
+xf-g
+2    a
+3#dd- c
+xb
+b
+2#a b d
+x  d
+3# dfa
+x  d
 2 dcc
 b
 
-b2  dd
-3# bx   c
-2# dgax gf
-b2# fg axf2fg
-3#efx d
 b
-2#f-gx    a2# fx d-d
-b2#  bcx bd2#db-axba
-b2#ab- dx  d2# da cx  c
-b2# bdcaxa -- d2#fb - bx d
+2  dd
+3# b
+x   c
+2# dga
+x gf
 b
-3#h -- ax fx  fx  i3#   gx fx  ghx h
+2# fg a
+xf
+2fg
+3#ef
+x d
+b
+2#f-g
+x    a
+2# f
+x d-d
+b
+2#  bc
+x bd
+2#db-a
+xba
+b
+2#ab- d
+x  d
+2# da c
+x  c
+b
+2# bdca
+xa -- d
+2#fb - b
+x d
+b
+3#h -- a
+x f
+x  f
+x  i
+3#   g
+x f
+x  gh
+x h
 b
 
 b
@@ -158,45 +469,88 @@ bb
 3      a
 2#f  -  /a
 xh  -  //a
-b2#if -- ///ax    a
+b
+2#if -- ///a
+x    a
 2.hif- a
 3 g
 b
 1ffg  f
-2#   hx gi
-b2# fgx    a2# ff- ex d
-b2#ab- axc2db - a
-3# ax  d
+2#   h
+x gi
 b
-2#d d - axba2ab-c
-3#fax  d
+2# fg
+x    a
+2# ff- e
+x d
 b
-2#f f  axed2fg h
-3#ifx   h
+2#ab- a
+xc
+2db - a
+3# a
+x  d
+b
+2#d d - a
+xba
+2ab-c
+3#fa
+x  d
+b
+2#f f  a
+xed
+2fg h
+3#if
+x   h
 b
 
 b
 2h  hh
-3#   gx    f
-2#ffd exd
-b2# g hfx  f2# fg- fx    a
-b2 f-fc
-3# e ex    a
-2#aff- ex d
-b2# fg axffg2if - a
-3#hx  i
+3#   g
+x    f
+2#ffd e
+xd
+b
+2# g hf
+x  f
+2# fg- f
+x    a
+b
+2 f-fc
+3# e e
+x    a
+2#aff- e
+x d
+b
+2# fg a
+xffg
+2if - a
+3#h
+x  i
 b
 1ffg
-2#eff- ax d
-b2fc -- ///a3Q a
-4# cx a4# cx ax cx a4# cx ax  dx a
+2#eff- a
+x d
+b
+2fc -- ///a
+3Q a
+4# c
+x a
+4# c
+x a
+x c
+x a
+4# c
+x a
+x  d
+x a
 b
 1 cdca
 Y      ///a
 b
 B
 
-p{4a. Courante Gauthier - 7F8E10C/GB-Cfm 689, f. 65r}
+p
+{4a. Courante Gauthier - 7F8E10C/GB-Cfm 689, f. 65r}
 BX
 bX
 S3
@@ -492,7 +846,8 @@ b
 B
 
 { }
-{4c. Currant - 7F8E9C/GB-Cu Nn.6.36, f. 25v}BX
+{4c. Currant - 7F8E9C/GB-Cu Nn.6.36, f. 25v}
+BX
 bX
 S3
 2 c
@@ -815,31 +1170,54 @@ Y  dc
 b
 B
 
-{ }{6a. Untitled - 7F8Ef10C/RUS-SPan O No 124, ff. 26v-27r}BX
+{ }
+{6a. Untitled - 7F8Ef10C/RUS-SPan O No 124, ff. 26v-27r}
+BX
 bX
 S3
 2a
-b2# bdc  ///a
+b
+2# bdc  ///a
 x    a
-x   cb2  d   a
+x   c
+b
+2  d   a
 3#   d
-x bx a
+x b
+x a
 x  d
 b
-2#  c  ax    cx   c
+2#  c  a
+x    c
+x   c
 b
 1aacc
 2d
-b2#dfg   /ax    dx   f
-b2#f g  fx    hx   h
-b2#h    ax    hx    f
-b2#a   dx  dx dQc c
+b
+2#dfg   /a
+x    d
+x   f
+b
+2#f g  f
+x    h
+x   h
+b
+2#h    a
+x    h
+x    f
+b
+2#a   d
+x  d
+x dQc c
 b
 
-b2# b  a
-x   Qcx  d
+b
+2# b  a
+x   Qc
+x  d
 bQ
-2#   dx d
+2#   d
+x d
 x bQ
 b
 2# a
@@ -850,16 +1228,24 @@ b
 3#   c
 x   a
 x    d
-x    cx    ax     db3#    a
+x    c
+x    a
+x     d
+b
+3#    a
 x     b
 2#   c  /a
 x   d  a
 bQ
 3#     a
-x   c2.   a d
-4#    dx   a
+x   c
+2.   a d
+4#    d
+x   a
 b
-2#    dx      /ax    d
+2#    d
+x      /a
+x    d
 b
 1 bbc
 bbX
@@ -867,133 +1253,362 @@ bbX
 b
 
 b
-3# b    ///ax ax  dx   cx  ax  c
-b3#  d   ax  bx   dx bx ax  d
-b3#  c  ax ax  dx  ax  cx   c
-b3#ax ax bx dxaxc
-b3#d   dx dx fx dx  g
-x  fb3#f   ax  gx  ix  gx  fx   h
+3# b    ///a
+x a
+x  d
+x   c
+x  a
+x  c
+b
+3#  d   a
+x  b
+x   d
+x b
+x a
+x  d
+b
+3#  c  a
+x a
+x  d
+x  a
+x  c
+x   c
+b
+3#a
+x a
+x b
+x d
+xa
+xc
+b
+3#d   d
+x d
+x f
+x d
+x  g
+x  f
+b
+3#f   a
+x  g
+x  i
+x  g
+x  f
+x   h
 b
 
-b3#h    ax  dx  bx  ax   cx   a
-b3#a - dx  dx d- cx  cx  ax  c
-b3# b  ax ax  d
-x  bx   dx   c
-b3#   dx  dx ax bx dx b
-b3# abx  dx  bx   dx  bcx   d
-b3#   cx   axa - dx    cx    ax     d
+b
+3#h    a
+x  d
+x  b
+x  a
+x   c
+x   a
+b
+3#a - d
+x  d
+x d- c
+x  c
+x  a
+x  c
+b
+3# b  a
+x a
+x  d
+x  b
+x   d
+x   c
+b
+3#   d
+x  d
+x a
+x b
+x d
+x b
+b
+3# ab
+x  d
+x  b
+x   d
+x  bc
+x   d
+b
+3#   c
+x   a
+xa - d
+x    c
+x    a
+x     d
 b
 
-b3#  d  bx     dx    ax    cxa - dx   a
-b3#   cx    d
+b
+3#  d  b
+x     d
+x    a
+x    c
+xa - d
+x   a
+b
+3#   c
+x    d
 2. aba d
-4#    dx   a
+4#    d
+x   a
 b
-2#   cx      /ax    d
+2#   c
+x      /a
+x    d
 b
 1 bbc
-bbX2 f
-b2# fgfx    d
+bbX
+2 f
+b
+2# fgf
+x    d
 x fgf
 b
-2# d   dx  fx f
-b2# g
-x      Qaxf
-b2#e    ax fx d
+2# d   d
+x  f
+x f
+b
+2# g
+x      Qa
+xf
+b
+2#e    a
+x f
+x d
 b
 
-b2#f gx    a
-3#dd  cxb
 b
-2#a   dx    cxc   a
-b2#ddf  dx    fx   f
-b2# dd  bxd    axb     a
+2#f g
+x    a
+3#dd  c
+xb
 b
-2#a     /ax    dx  d
-b2#    c
+2#a   d
+x    c
+xc   a
+b
+2#ddf  d
+x    f
+x   f
+b
+2# dd  b
+xd    a
+xb     a
+b
+2#a     /a
+x    d
+x  d
+b
+2#    c
 x dd
 xa c
-b2# b  ax  ddx d
-b2# a   dx b cx d   b
+b
+2# b  a
+x  dd
+x d
+b
+2# a   d
+x b c
+x d   b
 b
 
-b2#   a axacd exbdd   a
+b
+2#   a a
+xacd e
+xbdd   a
 b
 2 b
-2. a   a4#  dx a
+2. a   a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bbX
 2a
 b
-3#a   dx   ax   cx    dxbxa
-b3# d   dx  fx  gx dx   fx f
-b3# g    Qax  dx fx gx dxf
+3#a   d
+x   a
+x   c
+x    d
+xb
+xa
+b
+3# d   d
+x  f
+x  g
+x d
+x   f
+x f
+b
+3# g    Qa
+x  d
+x f
+x g
+x d
+xf
 b
 
-b3#     axex fx gx fx d
-b3#f   ax bx dx    cxdxb
-b3#a   dx    cx    axcxaxc
-b3#d    dxaxbx dx b  Qax a
-b3#  d  bx     ax      axbxdxb
-b3#      /axax    dx  dx  bx  d
+b
+3#     a
+xe
+x f
+x g
+x f
+x d
+b
+3#f   a
+x b
+x d
+x    c
+xd
+xb
+b
+3#a   d
+x    c
+x    a
+xc
+xa
+xc
+b
+3#d    d
+xa
+xb
+x d
+x b  Qa
+x a
+b
+3#  d  b
+x     a
+x      a
+xb
+xd
+xb
+b
+3#      /a
+xa
+x    d
+x  d
+x  b
+x  d
 b
 
-b3#    cx dx  dx  cxax d
-b3# b  ax  dx   dx bx dx b
-b3# a   dx   dx b ax   cx d - bx   a
-b3#     axdxa   ex  dxb  ax  d
-b3# d    ax b
+b
+3#    c
+x d
+x  d
+x  c
+xa
+x d
+b
+3# b  a
+x  d
+x   d
+x b
+x d
+x b
+b
+3# a   d
+x   d
+x b a
+x   c
+x d - b
+x   a
+b
+3#     a
+xd
+xa   e
+x  d
+xb  a
+x  d
+b
+3# d    a
+x b
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
-Y  dcb
+Y  dc
+b
 B
 
-{6b. Courante - 7F8Ef10C/D-Hs ND VI 3238, pp. 82-83}BX
+{6b. Courante - 7F8Ef10C/D-Hs ND VI 3238, pp. 82-83}
+BX
 bX
 S3
 2 b
-b2# bdca ///a
+b
+2# bdca ///a
 x    a
-x   cb2  d - a
+x   c
+b
+2  d - a
 2.   d
 4# a
 x  d.
 b
-2#  c- ax    cx   c
+2#  c- a
+x    c
+x   c
 b
 1aac
 2d
-b2#dfg - /ax    dx   f
-b2#ffg  fx    hx   h
-b2#h -- ax    hx    f
-b2#a - dx  dx dc c
+b
+2#dfg - /a
+x    d
+x   f
+b
+2#ffg  f
+x    h
+x   h
+b
+2#h -- a
+x    h
+x    f
+b
+2#a - d
+x  d
+x dc c
 b
 
-b2# b- ax   c
-x  db
+b
+2# b- a
+x   c
+x  d
+b
 2#   d
 x d
 x b
 b
 2 a -
 3#     d
-x  b.x   dx   cb3#   a
+x  b.
+x   d
+x   c
+b
+3#   a
 x    d
 x    c
 x    a
 x     d
 x    a
 b
-2#     bx    c a
+2#     b
+x    c a
 x    da
 b
-3#     bx   c2   a-d
+3#     b
+x   c
+2   a-d
 3#    d
 x   a
 b
@@ -1007,99 +1622,293 @@ bbX
 b
 
 b
-3# bx ax  dx   cx  ax  c
-b3#  d - ax  bx   dx bx ax  d
-b3#  c- ax ax  dx  ax   cx  c
-b3#ax ax bx dxaxc
-b3#d - dx dx fx dx  gx  f
-b3#    a
-xf -x  gx  fx  gx   h
+3# b
+x a
+x  d
+x   c
+x  a
+x  c
+b
+3#  d - a
+x  b
+x   d
+x b
+x a
+x  d
+b
+3#  c- a
+x a
+x  d
+x  a
+x   c
+x  c
+b
+3#a
+x a
+x b
+x d
+xa
+xc
+b
+3#d - d
+x d
+x f
+x d
+x  g
+x  f
+b
+3#    a
+xf -
+x  g
+x  f
+x  g
+x   h
 b
 
-b3#a -- ax  dx  bx  ax   cx   a
-b3#a - dx  dx d- cx  cx  ax  c
-b3# b  ax ax  d
-x  bx   dx   c
-b3#   dx  dx ax bx dx b
-b3# abx  dx  bx   dx b-cx   d
-b3#   cx   axa - dx    cx    ax     d
+b
+3#a -- a
+x  d
+x  b
+x  a
+x   c
+x   a
+b
+3#a - d
+x  d
+x d- c
+x  c
+x  a
+x  c
+b
+3# b  a
+x a
+x  d
+x  b
+x   d
+x   c
+b
+3#   d
+x  d
+x a
+x b
+x d
+x b
+b
+3# ab
+x  d
+x  b
+x   d
+x b-c
+x   d
+b
+3#   c
+x   a
+xa - d
+x    c
+x    a
+x     d
 b
 
-b3#  d- bx     dx    ax    cxa - dx   a
-b3#   cx    d
+b
+3#  d- b
+x     d
+x    a
+x    c
+xa - d
+x   a
+b
+3#   c
+x    d
 2. aba d
-4#    dx   a
+4#    d
+x   a
 b
-2#   cx      /ax    d
+2#   c
+x      /a
+x    d
 b
 1 bbc
 bX
-bX2 f
-b2# fgf  /ax    d
+bX
+2 f
+b
+2# fgf  /a
+x    d
 x fgf
 b
-2# d - dx  fx f
-b2# g -
-x      axf -
-b2#e -- Qax fx d
+2# d - d
+x  f
+x f
+b
+2# g -
+x      a
+xf -
+b
+2#e -- Qa
+x f
+x d
 b
 
-b2#f gx    a
-3#dd- cxc
 b
-2#a - dx    cxc - a
-b2#ddf- dx    fx   f
-b2# dd- bxd -- Qaxb  -  a
-b2#a     /ax    dx  d
-b2#    c
+2#f g
+x    a
+3#dd- c
+xc
+b
+2#a - d
+x    c
+xc - a
+b
+2#ddf- d
+x    f
+x   f
+b
+2# dd- b
+xd -- Qa
+xb  -  a
+b
+2#a     /a
+x    d
+x  d
+b
+2#    c
 x dd
 xa c
-b2# b- ax  ddx d
-b2# a a dx b cx d - b
+b
+2# b- a
+x  dd
+x d
+b
+2# a a d
+x b c
+x d - b
 b
 
-b2#d- a axa d exbdd - a
+b
+2#d- a a
+xa d e
+xbdd - a
 b
 2 b
-2. a - a4#  dx a
+2. a - a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 1  d
 bbX
 2a
 b
-3#a - dx   ax   cx    dxbxa
-b3# d - dx  fx  gx dx   Qfx f
-b3# Qg    Qa
+3#a - d
+x   a
+x   c
+x    d
+xb
+xa
+b
+3# d - d
+x  f
+x  g
+x d
+x   Qf
+x f
+b
+3# Qg    Qa
 x  Qd
 x Qf
 x Qg
 x Qd
 x-Qf
 bQ
-3#     Qax-Qex fx gx fx d
+3#     Qa
+x-Qe
+x f
+x g
+x f
+x d
 b
 
-b3#f - ax bx d -x    cxdxb
-b3#a - dx    cx    axc -xax-Qc
 b
-3#d -- dxaxbx dx bx a
-b3#  d- bx     ax      axbxdxb
-b3#      /axax    dx  dx  bx  d
-b3#    Qcx dx  dx  cxax d
+3#f - a
+x b
+x d -
+x    c
+xd
+xb
+b
+3#a - d
+x    c
+x    a
+xc -
+xa
+x-Qc
+b
+3#d -- d
+xa
+xb
+x d
+x b
+x a
+b
+3#  d- b
+x     a
+x      a
+xb
+xd
+xb
+b
+3#      /a
+xa
+x    d
+x  d
+x  b
+x  d
+b
+3#    Qc
+x d
+x  d
+x  c
+xa
+x d
 b
 
-b3# b- ax  dx   dx bx dx b
-b3# a - dx   dx b-x   cx d-  bx   a
-b3#d -- axa -x    ex  dxb- ax  d
-b3# d -- ax b
+b
+3# b- a
+x  d
+x   d
+x b
+x d
+x b
+b
+3# a - d
+x   d
+x b-
+x   c
+x d-  b
+x   a
+b
+3#d -- a
+xa -
+x    e
+x  d
+xb- a
+x  d
+b
+3# d -- a
+x b
 2. a - a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
-Y  dQcb
+Y  dQc
+b
 B
 
 { }
@@ -1108,23 +1917,44 @@ BX
 bX
 S3
 2 b
-b2# bdc- //a
+b
+2# bdc- //a
 x    a
-x   cb2#  d - a
-x   d3# a
+x   c
+b
+2#  d - a
+x   d
+3# a
 x  d
 b
-2#  c- ax    cx   c
+2#  c- a
+x    c
+x   c
 b
 1aac
 2d
-b2#dfg - /ax    dx   f
-b2#ffg- fx    hx   h
-b2#h -- ax    hx  f f
-b2# f  dx  dx dc c
+b
+2#dfg - /a
+x    d
+x   f
+b
+2#ffg- f
+x    h
+x   h
+b
+2#h -- a
+x    h
+x  f f
+b
+2# f  d
+x  d
+x dc c
 b
 
-b2# b- ax   cx  d
+b
+2# b- a
+x   c
+x  d
 b
 2   d
 2. d
@@ -1132,78 +1962,149 @@ b
 b
 2 a&+
 3#     d
-x  bx   dx   cb3#   a
+x  b
+x   d
+x   c
+b
+3#   a
 x    d
 x    c
 x    a
 x     d
 x    a
 b
-2#     bx    c ax    da
+2#     b
+x    c a
+x    da
 b
-3#     bx   c
+3#     b
+x   c
 2.   a d
-4#    dx   a
+4#    d
+x   a
 b
-2#   cx    d
-x      /ab
+2#   c
+x    d
+x      /a
+b
 1 bbc
-bbX2 f
+bbX
+2 f
 b
 
-b2# fgf  /ax    d
+b
+2# fgf  /a
+x    d
 x fgf
 b
-2# d - dx  fx f
-b2# g a- a
-x dxfg
-b2#e -- ax fx d
-b2#f gx    a
-3#d - cxc
+2# d - d
+x  f
+x f
 b
-2#a - dx    cxc - a
-b2#ddf  dx    fx   f
-b2# dd  bxd -- axb  -  a
+2# g a- a
+x d
+xfg
+b
+2#e -- a
+x f
+x d
+b
+2#f g
+x    a
+3#d - c
+xc
+b
+2#a - d
+x    c
+xc - a
+b
+2#ddf  d
+x    f
+x   f
+b
+2# dd  b
+xd -- a
+xb  -  a
 b
 
-b2#a --  /ax    dx  d
-b2#    c
+b
+2#a --  /a
+x    d
+x  d
+b
+2#    c
 x dd
 xa-c
-b2# b- ax  ddx d
-b2# a d dx b cx d - b
-b2#d- a axa d exbdd - a
+b
+2# b- a
+x  dd
+x d
+b
+2# a d d
+x b c
+x d - b
+b
+2#d- a a
+xa d e
+xbdd - a
 b
 2 b
-2.aa - a4#  dx a
+2.aa - a
+4#  d
+x a
 b
-2#  dx    ax      //a
+2#  d
+x    a
+x      //a
 b
 Y  dc
 b
 B
 
-{6d. Cor: de Ballardt - 7F8Ef10C/D-Ngm 33748 I, f. 46v}BX
+{6d. Cor: de Ballardt - 7F8Ef10C/D-Ngm 33748 I, f. 46v}
+BX
 bX
 S3
 2 b
-b2# bdc  ///a
+b
+2# bdc  ///a
 x    a
-x b cb2  d   a3#    ax b
+x b c
+b
+2  d   a
+3#    a
+x b
 x a
 x  d
 b
-2#  c  ax    cx   c
+2#  c  a
+x    c
+x   c
 b
 1aac
 2d
-b2#dfg   /ax    dxdfg
-b2#ffg  fx   hxffg
-b2#h    ax    hx  f f
-b2# f  dx  dx dc c
+b
+2#dfg   /a
+x    d
+xdfg
+b
+2#ffg  f
+x   h
+xffg
+b
+2#h    a
+x    h
+x  f f
+b
+2# f  d
+x  d
+x dc c
 b
 
-b2# b  ax   cx  d
+b
+2# b  a
+x   c
+x  d
 b
 2.   d
 3 d
@@ -1211,7 +2112,11 @@ b
 b
 2 a
 3#     d
-x  bx   dx   cb3#   a
+x  b
+x   d
+x   c
+b
+3#   a
 x    d
 x    c
 x    a
@@ -1222,118 +2127,245 @@ b
 x    Qc
 x    QaQd
 b
-3#     bx   c
+3#     b
+x   c
 2   a d
-3#    dx   a
+3#    d
+x   a
 b
-2#   cx    d
-x      /ab
+2#   c
+x    d
+x      /a
+b
 1 bbc
-bbX2 f
+bbX
+2 f
 b
 
-b2# fgfdx      /a
+b
+2# fgfd
+x      /a
 x fgf
 b
-2# d   dx  fx f
-b2# g    a
-x dxfg
-b2#e    ax fx d
-b2#f gx    a
-3#d   cxc
+2# d   d
+x  f
+x f
 b
-2#a   dx    cxc   a
-b2#ddf  dx   fxddf
-b2# d   bxd -- axb  -  a
+2# g    a
+x d
+xfg
+b
+2#e    a
+x f
+x d
+b
+2#f g
+x    a
+3#d   c
+xc
+b
+2#a   d
+x    c
+xc   a
+b
+2#ddf  d
+x   f
+xddf
+b
+2# d   b
+xd -- a
+xb  -  a
 b
 
-b2#a --  /ax    dx  d
-b2 dd c
-3#  cx  axa c
+b
+2#a --  /a
+x    d
+x  d
+b
+2 dd c
+3#  c
+x  a
+xa c
 x d
-b2# b  ax  ddx d
-b2# a d dx b cx d   b
-b2#d    axa   axbdd   a
+b
+2# b  a
+x  dd
+x d
+b
+2# a d d
+x b c
+x d   b
+b
+2#d    a
+xa   a
+xbdd   a
 b
 2 b
-2. a   a4#  dx a
+2. a   a
+4#  d
+x a
 b
-2#  dx      ///a
-x    ab
+2#  d
+x      ///a
+x    a
+b
 Y  dc
 b
 B
 
 p
-{6e. Courante par gautie - 7F8Ef10C/Moy 1631 f. 12r}BX
+{6e. Courante par gautie - 7F8Ef10C/Moy 1631 f. 12r}
+BX
 bX
 S3
 2 b
-b2# bdc  ///ax    ax   c
-b2#  d   ax   d
-3# ax  d
 b
-2#  cx     ax   c
+2# bdc  ///a
+x    a
+x   c
+b
+2#  d   a
+x   d
+3# a
+x  d
+b
+2#  c
+x     a
+x   c
 b
 1aac
 2d
-b2#dfg   /ax    dxdfg
-b2#ffg  fx   hxffg
-b2#h -- ax    hx    f
-b2# f  dx  dx d  c
+b
+2#dfg   /a
+x    d
+xdfg
+b
+2#ffg  f
+x   h
+xffg
+b
+2#h -- a
+x    h
+x    f
+b
+2# f  d
+x  d
+x d  c
 b
 
-b2# b  ax   cx  d
+b
+2# b  a
+x   c
+x  d
 b
 3#   d
-x  dx ax bx dx b
+x  d
+x a
+x b
+x d
+x b
 b
 2 a   d
-3#  bx   dx   cx   a
-b3#    dx    c
+3#  b
+x   d
+x   c
+x   a
+b
+3#    d
+x    c
 2.    a-
-4#     dx    a
+4#     d
+x    a
 b
-2#     bx    cx    da
+2#     b
+x    c
+x    da
 b
-3#     bx   c
+3#     b
+x   c
 2.   a d
-4#    dx   a
+4#    d
+x   a
 b
-2#    dx      /ax    d
+2#    d
+x      /a
+x    d
 b
 1 bbc
-bbX2 f
+bbX
+2 f
 b
 
-b2# fQg dx      /a
-3# gx f
 b
-2# d   dx  Qfxa
-b2# gx      axf
-b2#Qef   ax f-x d
-b2# bdx    a
-3#d   Qcxb
+2# fQg d
+x      /a
+3# g
+x f
 b
-2#a - dx    cxc   Qa
-b2#ddf  dx    fx   f
-b2#  d  bxd    axb
+2# d   d
+x  Qf
+xa
+b
+2# g
+x      a
+xf
+b
+2#Qef   a
+x f-
+x d
+b
+2# bd
+x    a
+3#d   Qc
+xb
+b
+2#a - d
+x    c
+xc   Qa
+b
+2#ddf  d
+x    f
+x   f
+b
+2#  d  b
+xd    a
+xb
 b
 
-b2#a --  /ax    dx  Qd
-b2#    cx ddxa c
-b2# b  ax  ddx d
-b2# a   dx b cx dd  b
-b2#d    axa - exbdd   Qa
+b
+2#a --  /a
+x    d
+x  Qd
+b
+2#    c
+x dd
+xa c
+b
+2# b  a
+x  dd
+x d
+b
+2# a   d
+x b c
+x dd  b
+b
+2#d    a
+xa - e
+xbdd   Qa
 b
 2.a  -  /a
-3# d x bx a
+3# d 
+x b
+x a
 b
 2 b    a
 2. a - a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b
@@ -1346,33 +2378,242 @@ b
 S3
 2-_a
 bQ
-3#    axa.x b:x  d.xa:x  b
-bQ3#   d&@x bx  dx      ax ax  dbQ3#     axa.x a:x  c.x   c:x    cbQ3#     axdxax axaxcbQ3#    d&@xdx fx  gxd:x  f.bQ3#     f&@xf.x f:x  g.xfx hbQ
-
-bQ3#     axhx ix  lxh&@:x   a
+3#    a
+xa.
+x b:
+x  d.
+xa:
+x  b
 bQ
-3#    d&@xa.x b:x  b.xa:x    cbQ3#    ax bx  dx   cx bx     d
-bQ3#     b&@x bx  dxa.x d:x bbQ3#     d&@x ax  bxfxdxbbQ3#ax     d&@x a:xb.xa:x d.bQ
-
-bQ3# b&@x    ax   cx d:xa    b&@xb.bQ3# d&@:x     dx   ax b.x d:xa
+3#   d&@
+x b
+x  d
+x      a
+x a
+x  d
 bQ
-3# bx    dx      /axd.xa:xc.bQ3#d&@:x    dx   c&@xcxax d
-bb3#      /axax bxdxcxa
-bQ3#     d&@x fx  gx dx fx gbQ
-
-bQ3#      axfx gxi.xh:xf.bQ3#     axex fxbxax d
+3#     a
+xa.
+x a:
+x  c.
+x   c:
+x    c
 bQ
-3#      ///axf.x f:x  g.xd     //axc&@bQ3#      /axa:
-x b.xc.xd&@:x a.bQ3#      axdxcxaxc&@  ax bbQ3#d --
-x     d&@x ax  dx ax  bbQ
+3#     a
+xd
+xa
+x a
+xa
+xc
+bQ
+3#    d&@
+xd
+x f
+x  g
+xd:
+x  f.
+bQ
+3#     f&@
+xf.
+x f:
+x  g.
+xf
+x h
+bQ
 
-bQ3#a    b&@xbxd -- axfxb  -  QaxdbQ3#a     /ax ax  dxbxaxbbQ3# d&@
-x    c&@x  bxa.x d:xa.bQ3# bx    ax   d&@x d.x b:x d.bQ3# a:x     d&@
-x   cx bx ax bbQ3#  d&@.x     b&@x   ax ax  dx abQ
+bQ
+3#     a
+xh
+x i
+x  l
+xh&@:
+x   a
+bQ
+3#    d&@
+xa.
+x b:
+x  b.
+xa:
+x    c
+bQ
+3#    a
+x b
+x  d
+x   c
+x b
+x     d
+bQ
+3#     b&@
+x b
+x  d
+xa.
+x d:
+x b
+bQ
+3#     d&@
+x a
+x  b
+xf
+xd
+xb
+bQ
+3#a
+x     d&@
+x a:
+xb.
+xa:
+x d.
+bQ
+
+bQ
+3# b&@
+x    a
+x   c
+x d:
+xa    b&@
+xb.
+bQ
+3# d&@:
+x     d
+x   a
+x b.
+x d:
+xa
+bQ
+3# b
+x    d
+x      /a
+xd.
+xa:
+xc.
+bQ
+3#d&@:
+x    d
+x   c&@
+xc
+xa
+x d
+bb
+3#      /a
+xa
+x b
+xd
+xc
+xa
+bQ
+3#     d&@
+x f
+x  g
+x d
+x f
+x g
+bQ
+
+bQ
+3#      a
+xf
+x g
+xi.
+xh:
+xf.
+bQ
+3#     a
+xe
+x f
+xb
+xa
+x d
+bQ
+3#      ///a
+xf.
+x f:
+x  g.
+xd     //a
+xc&@
+bQ
+3#      /a
+xa:
+x b.
+xc.
+xd&@:
+x a.
+bQ
+3#      a
+xd
+xc
+xa
+xc&@  a
+x b
+bQ
+3#d --
+x     d&@
+x a
+x  d
+x a
+x  b
+bQ
+
+bQ
+3#a    b&@
+xb
+xd -- a
+xf
+xb  -  Qa
+xd
+bQ
+3#a     /a
+x a
+x  d
+xb
+xa
+xb
+bQ
+3# d&@
+x    c&@
+x  b
+xa.
+x d:
+xa.
+bQ
+3# b
+x    a
+x   d&@
+x d.
+x b:
+x d.
+bQ
+3# a:
+x     d&@
+x   c
+x b
+x a
+x b
+bQ
+3#  d&@.
+x     b&@
+x   a
+x a
+x  d
+x a
+bQ
 
 -l "4 in"
-bQ3#  c&@x     ax      /ax  d.x a    ax bbQ3# dx bx a   ax  dx ax  c
-bQ3#  d&@
+bQ
+3#  c&@
+x     a
+x      /a
+x  d.
+x a    a
+x b
+bQ
+3# d
+x b
+x a   a
+x  d
+x a
+x  c
+bQ
+3#  d&@
 x    a
 x   c
 x a
@@ -1381,52 +2622,79 @@ Y d
 b
 B
 
-p{7a. Courante par gautie - 7F8Ef10C/Moy 1631, f. 16r}BX
+p
+{7a. Courante par gautie - 7F8Ef10C/Moy 1631, f. 16r}
+BX
 bX
 S3
 2      ///a
 b
 1 bdc
 2      a
-b2. dda
-3# bx ax  d
 b
-2#  cx     ax    c
+2. dda
+3# b
+x a
+x  d
+b
+2#  c
+x     a
+x    c
 b
 1.aacc
 b
-2#dfgx      /axf
-b2d
+2#dfg
+x      /a
+xf
+b
+2d
 2.c - c
-4# fx e
+4# f
+x e
 b
 1af-
 2     a
 b
 2.aac
-3#dxbxd
+3#d
+xb
+xd
 b
-2#ax    dx  Qd
+2#a
+x    d
+x  Qd
 b
-3#bxa
-2# d   dx  b
+3#b
+xa
+2# d   d
+x  b
 b
 
-b2a - d
-3# dx bx ax  d
+b
+2a - d
+3# d
+x b
+x a
+x  d
 b
 2#  Qd  Qb
 x      Qa
 3# Qa Qa
 x  Qd
 b
-2#  cc axax      /a
+2#  cc a
+xa
+x      /a
 b
-3# d    ax b
+3# d    a
+x b
 2. a - a
-4#  dx a
+4#  d
+x a
 b
-2#  d-x    ax      ///a
+2#  d-
+x    a
+x      ///a
 b
 1  dca
 bbX
@@ -1434,56 +2702,86 @@ bbX
 b
 1acd a
 2      ///a
-b2cdda
-3#      axdxcxa
+b
+2cdda
+3#      a
+xd
+xc
+xa
 b
 1 dba d
 2     c
 b
 
-b2#da   ax      axbdda
+b
+2#da   a
+x      a
+xbdda
 b
 2ab    /a
-3#    dx dx bx a
+3#    d
+x d
+x b
+x a
 b
 2 b   b
 2. a - d
-4#  dx a
+4#  d
+x a
 b
-2# bb dx      /ax bb
-b2  dd  a
-3#   ax bx ax  d
+2# bb d
+x      /a
+x bb
+b
+2  dd  a
+3#   a
+x b
+x a
+x  d
 b
 2  c  a
 1a  -  /a
 b
-3# d    ax b
+3# d    a
+x b
 2. a - a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 Y  dca
 b
 B
 
-{ }{7b. Cour - 7F8Ef10C/A-KR L81, f. 151r}BX
+{ }
+{7b. Cour - 7F8Ef10C/A-KR L81, f. 151r}
+BX
 bX
 S3
 2      ///a
 b
 1 bdc
 2      a
-b2. dda
-3# bx ax  d
 b
-1Q  c  a2Q   c
+2. dda
+3# b
+x a
+x  d
+b
+1Q  c  a
+2Q   c
 b
 1aacc
 2d
 b
-2#df  dxfxd
-b2#f   a
+2#df  d
+xf
+xd
+b
+2#f   a
 xef  e
 x e
 b
@@ -1492,27 +2790,42 @@ x     a
 x   c
 b
 2.aac
-3#dxbxd
+3#d
+xb
+xd
 b
 2Qa   d
-3#      /ax d
+3#      /a
+x d
 x b
 x a
 b
-2#  d  bx a   d
-3#  dx a
+2#  d  b
+x a   d
+3#  d
+x a
 b
 
-b2Q b
-3#    dx dx bx a
+b
+2Q b
+3#    d
+x d
+x b
+x a
 b
 2#  d  b
-x      a3# bx a
+x      a
+3# b
+x a
 b
-2#  dx  c  a
-3#      /axa
+2#  d
+x  c  a
+3#      /a
+xa
 b
-3# d    ax b2Q a&,   a
+3# d    a
+x b
+2Q a&,   a
 3#  d
 x a
 b
@@ -1524,38 +2837,57 @@ b
 bb
 1Qacd a
 2Q      ///a
-bQ2.cdda
-3#dxcxa
+bQ
+2.cdda
+3#d
+xc
+xa
 b
 2# d
 x     d
 x     b
 b
 
-b2#     axdxb  -  a
+b
+2#     a
+xd
+xb  -  a
 b
 2.a     /a
-3# dx bx a
+3# d
+x b
+x a
 b
 2Q  d  b
 2. a - d
-4#  dx a
+4#  d
+x a
 b
-2Q b3#      /ax d
+2Q b
+3#      /a
+x d
 x b
 x a
-b2Q  d  b
-3#      ax bx ax  d
+b
+2Q  d  b
+3#      a
+x b
+x a
+x  d
 b
 2#  c  a
 x      /a
 xa
 b
-3# d    ax b
+3# d    a
+x b
 2. a&,   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 Y  QdQc
 b
@@ -1569,17 +2901,24 @@ S3
 b
 1 b&+dca
 2      a
-b2. dda
-3# bx ax  d
+b
+2. dda
+3# b
+x a
+x  d
 b
 2#  c
-x     ax    c
+x     a
+x    c
 b
 1   c
 2d
 b
-2#dfgx      /axdfg
-b2#f   a
+2#dfg
+x      /a
+xdfg
+b
+2#f   a
 xc   c
 x e
 b
@@ -1588,27 +2927,38 @@ x a
 x   c
 b
 2.aacc
-4#dxb2d
+4#d
+xb
+2d
 bQ
 2#a
 x    d
 x  b
 b
 3#b d  b
-xa2# d
+xa
+2# d
 x     d
 b
 
-b2a
-3#    dx dx bx a
+b
+2a
+3#    d
+x d
+x b
+x a
 b
 2#  d  b
-x      a3# a ax  d
+x      a
+3# a a
+x  d
 b
 2#  c  a
-xax  d d
+xa
+x  d d
 b
-2 b2. ac  a
+2 b
+2. ac  a
 4#  d
 x a
 b
@@ -1621,60 +2971,85 @@ bbX
 2Qa
 b
 1.ac&+d a
-b2cdda  a
+b
+2cdda  a
 3#   a
-xdxcxa
+xd
+xc
+xa
 b
 1 dba d
 2     c
 b
 
-b2#da   ax      a
-xbb
+b
+2#da   a
+x      a
+xb
+b
 2ab    /a
 3#    d
-x dx bx a
+x d
+x b
+x a
 b
 2#  d  b
 x bba d
 x a
 b
-2# bbcdx      /ax bbc
-b2 dda  a
-3#   ax bx ax  d
+2# bbcd
+x      /a
+x bbc
+b
+2 dda  a
+3#   a
+x b
+x a
+x  d
 b
 2#  c  a
 x      /a
 xa d
 b
-2      a2. ac  a
-4#  dx a
+2      a
+2. ac  a
+4#  d
+x a
 b
-2#  d ax      ///a
-x    Qab
+2#  d a
+x      ///a
+x    Qa
+b
 Y   c
 b
 B
 
 { }
-{7d. Courante 3 - 7F8Ef9C/Fuhrmann 1615, p. 163}BX
+{7d. Courante 3 - 7F8Ef9C/Fuhrmann 1615, p. 163}
+BX
 bX
 S3
 2      //a
 b
 1 bdca
 2      a
-b2. dda
-3# bx ax  d
+b
+2. dda
+3# b
+x a
+x  d
 b
 2#  c
-x     ax   c
+x     a
+x   c
 b
 1aac
 2d
 b
-1dfg d2dfg
-b2#f   a
+1dfg d
+2dfg
+b
+2#f   a
 xcf  c
 x e
 b
@@ -1683,28 +3058,39 @@ x     a
 x    c
 b
 2.   c
-3#dxbxd
+3#d
+xb
+xd
 b
 2#a
 x    d
 x  Qd
 b
 3#b  a
-xa2# a
+xa
+2# a
 x     d
 b
 
-b2a
-3#    dx dx bx a
+b
+2a
+3#    d
+x d
+x b
+x a
 b
 2#  Qd  b
-x      a3# ax  d
+x      a
+3# a
+x  d
 b
 2#  c  a
-x      /axa
+x      /a
+xa
 b
 3# d    a
-x b2. a   a
+x b
+2. a   a
 4#  d
 x a
 b
@@ -1719,44 +3105,63 @@ b
 2#acd a
 x      //a
 xa
-b2cdd   a
+b
+2cdd   a
 3#   a
-xdxcxa
+xd
+xc
+xa
 b
 2# d
 x     d
 x     c
 b
 
-b2#d    a
-x   cxb     ab
+b
+2#d    a
+x   c
+xb     a
+b
 2a     /a
 3#    d
-x dx bx a
+x d
+x b
+x a
 b
 2#  d  b
 x a   d
 3#  d
 x a
 b
-2# bx      /ax  d
-b2 d
-3#      ax bx ax  d
+2# b
+x      /a
+x  d
+b
+2 d
+3#      a
+x b
+x a
+x  d
 b
 2#  c  a
 x      /a
 xa
 b
 3# d    a
-x b2. a   a
-4#  dx a
+x b
+2. a   a
+4#  d
+x a
 b
 2#  d
-x    ax      //ab
+x    a
+x      //a
+b
 Y  dc
 b
 B
-{7e. Bontade Ballardj - 7F8Ef10C/CH-SO DA 111, ff. 15v-16r}
+
+{7e. Bontade Ballardj - 7F8Ef10C/CH-SO DA 111, ff. 15v-16r}
 BX
 bX
 S3
@@ -1764,38 +3169,57 @@ S3
 b
 1 bdc
 2      Qa
-b2 dda
-3#      a
-x bx ax  d
 b
-2#  cx     ax    c
+2 dda
+3#      a
+x b
+x a
+x  d
+b
+2#  c
+x     a
+x    c
 b
 1aacc
 2d
 b
-2#dfgfdx      /a3#f
+2#dfgfd
+x      /a
+3#f
 xd
-b2#f   a
-xcf  cx e
+b
+2#f   a
+xcf  c
+x e
 b
 2#af
 x     a
 x    c
 b
 2.aacc
-3#dxbxd
+3#d
+xb
+xd
 b
-2#ax    dx  b
+2#a
+x    d
+x  b
 b
-2.bbd  b3a
+2.bbd  b
+3a
 2 d   d
 b
 
-b2a   d
-3#      /a
-x dx bx a
 b
-2  dd b3#      ax b
+2a   d
+3#      /a
+x d
+x b
+x a
+b
+2  dd b
+3#      a
+x b
 x a
 x  d
 b
@@ -1809,7 +3233,9 @@ x b
 4#  d
 x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bXQ
@@ -1818,26 +3244,107 @@ bXQ
 b
 2. bdc
 3#  b
-x   dx   c
-b3#      ax dx  dx bx ax  d
+x   d
+x   c
+b
+3#      a
+x d
+x  d
+x b
+x a
+x  d
 b
 
-b3#  cx     ax   cx  dx ax  c
-b3#  dx ax bx dxaxc
-b3#dx   cxcxdx    dxa
-b3#f dxdxcefx cx ex  f
-b3#ax     ax bdx ax bx  d
-b3# ax     ax   cxdxbxd
-b3#ax    dx   cx  ax  bx   c
+b
+3#  c
+x     a
+x   c
+x  d
+x a
+x  c
+b
+3#  d
+x a
+x b
+x d
+xa
+xc
+b
+3#d
+x   c
+xc
+xd
+x    d
+xa
+b
+3#f d
+xd
+xcef
+x c
+x e
+x  f
+b
+3#a
+x     a
+x bd
+x a
+x b
+x  d
+b
+3# a
+x     a
+x   c
+xd
+xb
+xd
+b
+3#a
+x    d
+x   c
+x  a
+x  b
+x   c
 b
 
-b3#bbd  bxax dx     dx bx d
-b3#ax    dx  bx dx bx a
-b3#  dx     bx      ax bx a ax  d
-b3#  cc ax axax      ax      /ax  d
-b3#bddx bxaaccx  dx  c  ax d
 b
-2# cx    ax      ///a
+3#bbd  b
+xa
+x d
+x     d
+x b
+x d
+b
+3#a
+x    d
+x  b
+x d
+x b
+x a
+b
+3#  d
+x     b
+x      a
+x b
+x a a
+x  d
+b
+3#  cc a
+x a
+xa
+x      a
+x      /a
+x  d
+b
+3#bdd
+x b
+xaacc
+x  d
+x  c  a
+x d
+b
+2# c
+x    a
+x      ///a
 b
 1 cdc
 bXQ
@@ -1849,30 +3356,46 @@ b
 2#acd a
 x      ///a
 xacd
-b2cdda
-3#      axdxcxa
+b
+2cdda
+3#      a
+xd
+xc
+xa
 b
 2#     d
 x dba
 x     c
-b2#da   ax b3#b  a
+b
+2#da   a
+x b
+3#b  a
 x a
 b
 2a   d
 3#      /a
-x dx b   bx a
+x d
+x b   b
+x a
 b
 3# b  a
 x d
 2. a   d
-4#  dx a
+4#  d
+x a
 b
-2 b3#      /ax d
+2 b
+3#      /a
+x d
 xa
 x b
-b3#      a
-x dx  d
-x bx ax  d
+b
+3#      a
+x d
+x  d
+x b
+x a
+x  d
 b
 
 b
@@ -1880,11 +3403,15 @@ b
 x   c
 xa     /a
 b
-3# d    ax b
+3# d    a
+x b
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bXQ
@@ -1892,64 +3419,142 @@ bXQ
 2a
 b
 3#      ///a
-xax cx  ax  cx  d
-b3#      axcx  dxdxcxa
-b3#     dxax dx    ax     dx     c
-b3#     axdx     ax bxdx a
+xa
+x c
+x  a
+x  c
+x  d
+b
+3#      a
+xc
+x  d
+xd
+xc
+xa
+b
+3#     d
+xa
+x d
+x    a
+x     d
+x     c
+b
+3#     a
+xd
+x     a
+x b
+xd
+x a
 b
 
-b3#ax    dx  bx dx b   bx a
-b3# b  ax dx     dx ax  dx a
-b3# bx    dx      /ax ax  dx  b
-b3#  dx     bx      ax bx ax  d
-b3#  cx     ax   cx   ax    dx    c
-b3#    ax b2. a   a
-4  dx a
 b
-2#  dx    ax      ///a
+3#a
+x    d
+x  b
+x d
+x b   b
+x a
+b
+3# b  a
+x d
+x     d
+x a
+x  d
+x a
+b
+3# b
+x    d
+x      /a
+x a
+x  d
+x  b
+b
+3#  d
+x     b
+x      a
+x b
+x a
+x  d
+b
+3#  c
+x     a
+x   c
+x   a
+x    d
+x    c
+b
+3#    a
+x b
+2. a   a
+4  d
+x a
+b
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b
 B
 
-{7f. La Boutade de Ballard - 7F8Ef10C/GB-Eu Coll.2073, ff. 189v-190r}BX
+{7f. La Boutade de Ballard - 7F8Ef10C/GB-Eu Coll.2073, ff. 189v-190r}
+BX
 bX
 S3
 2      ///a
 b
 1 bdca
 2      a
-b2. dda
-3# bx ax  d
 b
-2#  cx     ax   Qc
+2. dda
+3# b
+x a
+x  d
+b
+2#  c
+x     a
+x   Qc
 b
 1aac
 2d
 b
-2#dfgf  /ax    dxdfg
-b2#f   a
-xcf  cx e
+2#dfgf  /a
+x    d
+xdfg
+b
+2#f   a
+xcf  c
+x e
 b
 2#af
 x     a
 x   c
 b
 2.aac
-3#dxbxd
+3#d
+xb
+xd
 b
-2#ax    dx  d
+2#a
+x    d
+x  d
 b
-3#b    bxa
+3#b    b
+xa
 2# d
 x     d
 b
 
-b2a
-3#    d
-x dx bx a
 b
-2#  d  bx      a3# a
+2a
+3#    d
+x d
+x b
+x a
+b
+2#  d  b
+x      a
+3# a
 x  d
 b
 2#  c  a
@@ -1962,8 +3567,10 @@ x b
 4#  d
 x a
 b
-2#  dx      ///a
-x    ab
+2#  d
+x      ///a
+x    a
+b
 1  dc
 bXQ
 bXQ
@@ -1971,28 +3578,106 @@ bXQ
 b
 1 bdca
 2      a
-b3# dx  dx   a
-x bx ax  d
+b
+3# d
+x  d
+x   a
+x b
+x a
+x  d
 b
 
-b3#  cx     ax   cx  dx ax  c
-b3#  dx ax bx dxaxc
-b3#ax      /ax fx    dxfxd
-b3#fx    axcx    cx fx e
-b3# fx     ax  dx ax bx  d
-b3#ax  c
-x axdxbxd
-b3#ax    dx  dx    cx    ax     d
+b
+3#  c
+x     a
+x   c
+x  d
+x a
+x  c
+b
+3#  d
+x a
+x b
+x d
+xa
+xc
+b
+3#a
+x      /a
+x f
+x    d
+xf
+xd
+b
+3#f
+x    a
+xc
+x    c
+x f
+x e
+b
+3# f
+x     a
+x  d
+x a
+x b
+x  d
+b
+3#a
+x  c
+x a
+xd
+xb
+xd
+b
+3#a
+x    d
+x  d
+x    c
+x    a
+x     d
 b
 
-b3#b    bxax dx     dx   ax     b
-b3#     axax    dx dx bx a
-b3#  dx     bx     ax   dx a    ax  d
-b3#  cx     ax   cx      ax      /axa
-b3# d    ax bx a   axfxcxe
 b
-2#fx      ///a
-x    ab
+3#b    b
+xa
+x d
+x     d
+x   a
+x     b
+b
+3#     a
+xa
+x    d
+x d
+x b
+x a
+b
+3#  d
+x     b
+x     a
+x   d
+x a    a
+x  d
+b
+3#  c
+x     a
+x   c
+x      a
+x      /a
+xa
+b
+3# d    a
+x b
+x a   a
+xf
+xc
+xe
+b
+2#f
+x      ///a
+x    a
+b
 1  dc
 bXQ
 bXQ
@@ -2003,40 +3688,58 @@ b
 2#acd   ///a
 x    a
 xacd
-b2cdd   a
-3#   axdxcxa
+b
+2cdd   a
+3#   a
+xd
+xc
+xa
 b
 2# db
 x     d
 x     c
-b2#d    ax bxb     a
+b
+2#d    a
+x b
+xb     a
 b
 2a     /a
 3#    d
-x dx bx a
+x d
+x b
+x a
 b
 3#  d
 x     b
 2. a a d
-4#  dx a
+4#  d
+x a
 b
 2# bbcd
 x      /a
 x a
 b
-2#  d  bx      a3# a
+2#  d  b
+x      a
+3# a
 x  d
 b
 
-b2#  c  a
-x      /axa
 b
-3# d    ax b
+2#  c  a
+x      /a
+xa
+b
+3# d    a
+x b
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx      ///a
-x    ab
+2#  d
+x      ///a
+x    a
+b
 2  dc
 bXQ
 bXQ
@@ -2047,30 +3750,85 @@ x  d
 b
 3#a
 x      ///a
-x    ex   ax   cx    e
+x    e
+x   a
+x   c
+x    e
 b
-3#cx      ax   axdxcxa
+3#c
+x      a
+x   a
+xd
+xc
+xa
 b
-3# dx     dx   ax  ax  bx     c
-b3#     axdx ax bx      ax a
+3# d
+x     d
+x   a
+x  a
+x  b
+x     c
+b
+3#     a
+xd
+x a
+x b
+x      a
+x a
 b
 
-b3#      /axax    dx dx bx a
-b3#  dx     bx     dxax   cx   a
-b3# bx      /ax   cx   dx  bx   c
-b3# dx  dx   ax bx ax  d
-b3#  cx     ax   cx      ax      /axa
-b3# d    a
-x b2. a   a
-4#  dx a
 b
-2#  dx      ///a
-x    ab
+3#      /a
+xa
+x    d
+x d
+x b
+x a
+b
+3#  d
+x     b
+x     d
+xa
+x   c
+x   a
+b
+3# b
+x      /a
+x   c
+x   d
+x  b
+x   c
+b
+3# d
+x  d
+x   a
+x b
+x a
+x  d
+b
+3#  c
+x     a
+x   c
+x      a
+x      /a
+xa
+b
+3# d    a
+x b
+2. a   a
+4#  d
+x a
+b
+2#  d
+x      ///a
+x    a
+b
 Y  dc
 b
 B
 
-{7g. Courante - 7F8Ef10C/GB-Eu Coll.2073, ff. 60v-61r}BX
+{7g. Courante - 7F8Ef10C/GB-Eu Coll.2073, ff. 60v-61r}
+BX
 bX
 S3
 3#  d
@@ -2079,17 +3837,26 @@ b
 2# bdca
 x      ///a
 x bdc
-b2. dda
-3# bx ax  d
 b
-2#  c  ax    cx   c
+2. dda
+3# b
+x a
+x  d
+b
+2#  c  a
+x    c
+x   c
 b
 1aac
 2d
 b
-2.dfgfd3f2d
-b2f   a
-2.c   c4# f
+2.dfgfd
+3f
+2d
+b
+2f   a
+2.c   c
+4# f
 xc
 b
 2# f
@@ -2097,18 +3864,26 @@ x     a
 x    c
 b
 1aacc
-3#dxb
+3#d
+xb
 b
-2#ax    dx  d
+2#a
+x    d
+x  d
 b
-2.bbd  b3a
+2.bbd  b
+3a
 2 d   d
 b
 
-b2#a   d
-x dx b
 b
-2#  d  bx      a3# a
+2#a   d
+x d
+x b
+b
+2#  d  b
+x      a
+3# a
 x  d
 b
 2#  c  a
@@ -2121,7 +3896,9 @@ x b
 4#  d
 x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bbX
@@ -2130,37 +3907,54 @@ b
 2#acd a
 x      ///a
 xacd
-b2.c     a
-3#dxcxa
+b
+2.c     a
+3#d
+xc
+xa
 b
 2. db  d
 3     c
 2aab  a
 b
 
-b3# b    /ax d.xa
+b
+3# b    /a
+x d.
+xa
 xb.
 xd
 xb.
 b
 2ab  d
 3#      /a
-x dx bx a
+x d
+x b
+x a
 b
 2  d  b
 2. a   d
-4#  dx a
+4#  d
+x a
 b
-2# bx    dx      /a
-b2. bbc
+2# b
+x    d
+x      /a
+b
+2. bbc
 3# d
-x bx a
+x b
+x a
 b
-2#  d  bx      a3# a
+2#  d  b
+x      a
+3# a
 x  d
 b
-2#  c  ax   c
-xa     /ab
+2#  c  a
+x   c
+xa     /a
+b
 
 b
 3# d    a
@@ -2181,71 +3975,134 @@ b
 2acd a
 3#      a
 xc
-2ab
-3#c  axaxcxdxcxa
+2a
 b
-3# d   dx    ax     dx     cx     ax      a
-b3# b    /ax d.xaxb.xdxb.
-b2a     /a3#    dx dx bx a
+3#c  a
+xa
+xc
+xd
+xc
+xa
+b
+3# d   d
+x    a
+x     d
+x     c
+x     a
+x      a
+b
+3# b    /a
+x d.
+xa
+xb.
+xd
+xb.
+b
+2a     /a
+3#    d
+x d
+x b
+x a
 b
 
-b2  d  b2. a   d4#  dx a
-b2# bdc
-x    dx      /a
-b2. b
-3# dx bx a
-b2#  d  bx      a3# ax  d
-b2#  c  ax   cxa     /a
-b3# d    a
-x b2. a   a
-4#  dx a
 b
-2#  dx    ax      ///a
+2  d  b
+2. a   d
+4#  d
+x a
+b
+2# bdc
+x    d
+x      /a
+b
+2. b
+3# d
+x b
+x a
+b
+2#  d  b
+x      a
+3# a
+x  d
+b
+2#  c  a
+x   c
+xa     /a
+b
+3# d    a
+x b
+2. a   a
+4#  d
+x a
+b
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b
 B
 
 p
-{7h. Courante - 7F8Ef10C/GB-Lbl Add.38539, f. 25v}BX
+{7h. Courante - 7F8Ef10C/GB-Lbl Add.38539, f. 25v}
+BX
 bX
 S3
 2      ///a
 b
 1 #bdca
 2      a
-b2. ddd
-3# b&,.x a:x  d.
 b
-2#  #c:x     ax    c
+2. ddd
+3# b&,.
+x a:
+x  d.
+b
+2#  #c:
+x     a
+x    c
 b
 1   c
 2d.
 b
-2#dfgfdx      /axdfg
-b3#f   a
+2#dfgfd
+x      /a
+xdfg
+b
+3#f   a
 xd.
-2##c:x ea c
+2##c:
+x ea c
 b
 2#axf
 x     a
 x   c{
 b
 2.aac
-3#d.xb:xd. }
+3#d.
+xb:
+xd. }
 b
-2##a:x    d{x  d.}
+2##a:
+x    d{
+x  d.}
 b
-3#b -  b{xa.
+3#b -  b{
+xa.
 2# d: }
 x     d
 b
 
-b2-#a:
-3#      /a
-x d.x #b:x a.
 b
-2#  d  bx      a3# a a
+2-#a:
+3#      /a
+x d.
+x #b:
+x a.
+b
+2#  d  b
+x      a
+3# a a
 x  d.
 b
 2#  c  a
@@ -2257,8 +4114,10 @@ b
 4#  d.
 x a:
 b
-2#  d.x      ///a
-x    ab
+2#  d.
+x      ///a
+x    a
+b
 1  dc
 bXQ
 bXQ
@@ -2272,29 +4131,99 @@ x  b.
 x   d
 x   c.
 b
-3#      ax d.x   d  {x b&,. }
-x a ax  d.
+3#      a
+x d.
+x   d  {
+x b&,. }
+x a a
+x  d.
 b
 
-b3#  #c:x     ax   cx  a.x  c:x  d.
-b3# a:x     ax b:x d.xa:xc.
-b3#d:x    d{x  b.xc:xa. }x    c
-b3#  d ax  b&,.x  a:x    c {x   c:x   b.}
-b2#   xc:x     ax    c
-b2.   c{3#d.xb:xd. }
-b3#a:x    d{x  d:x a.x b:x  d.}
 b
-
-b3#b:x     bx d.x     d{x a:xd.   }
-b3#a:x    d{x   cx d&,.x b:x a.}
-b3#  d- b{x  b.x   dx   c&,.}x   ax    d.
-b3#     ax  c.x   cx   a.x    d{
+3#  #c:
+x     a
+x   c
+x  a.
+x  c:
+x  d.
+b
+3# a:
+x     a
+x b:
+x d.
+xa:
+xc.
+b
+3#d:
+x    d{
+x  b.
+xc:
+xa. }
+x    c
+b
+3#  d a
+x  b&,.
+x  a:
+x    c {
+x   c:
+x   b.}
+b
+2#   xc:
+x     a
+x    c
+b
+2.   c{
+3#d.
+xb:
+xd. }
+b
+3#a:
+x    d{
+x  d:
+x a.
+x b:
 x  d.}
-b3#    ax    d.2.    #ca4#    a
+b
+
+b
+3#b:
+x     b
+x d.
+x     d{
+x a:
+xd.   }
+b
+3#a:
+x    d{
+x   c
+x d&,.
+x b:
+x a.}
+b
+3#  d- b{
+x  b.
+x   d
+x   c&,.}
+x   a
+x    d.
+b
+3#     a
+x  c.
+x   c
+x   a.
+x    d{
+x  d.}
+b
+3#    a
+x    d.
+2.    #ca
+4#    a
 x    c.
 b
-2#    ax      ///a
-x    ab
+2#    a
+x      ///a
+x    a
+b
 1  xdc
 bXQ
 bXQ
@@ -2305,37 +4234,52 @@ b
 2#a#cd a
 x      ///a
 xacd
-b2-#cdd   a
-3#   axd.x-#c:xa.
+b
+2-#cdd   a
+3#   a
+xd.
+x-#c:
+xa.
 b
 2#     d{
 x dba }
 x     ,c
-b2#xda c ax      a
+b
+2#xda c a
+x      a
 x-,b.
 b
 2abb   /a
 3#     a
-x dx b - b{x a.  }
+x d
+x b - b{
+x a.  }
 b
 3# b da
 x   c.
 2. #b a d{
 3 a.  }
 b
-2# b:x      /ax ,a.
-b2#  dd b
-x      a3# a a
+2# b:
+x      /a
+x ,a.
+b
+2#  dd b
+x      a
+3# a a
 x  d.
 b
-2#  #c  ax      /a
+2#  #c  a
+x      /a
 xa d
 b
 
 b
-2 b -- a2. #a   a
+2 b -- a
+2. #a   a
 4#  d.
-x a:b
+x a:
+b
 2#  d.
 x      ///a
 x    a
@@ -2347,72 +4291,142 @@ bXQ
 b
 3#    a
 xa.
-x #c:x  a.x  b:x  d.
+x #c:
+x  a.
+x  b:
+x  d.
 b
 3#      a
-xc.x   axd.x-#c:xa.
+xc.
+x   a
+xd.
+x-#c:
+xa.
 b
-3#     d{x d.x a:x  d.x  ,b:x   d.}
-b3#     axd&(.x-)a:x b.xb --  ax a.
+3#     d{
+x d.
+x a:
+x  d.
+x  ,b:
+x   d.}
+b
+3#     a
+xd&(.
+x-)a:
+x b.
+xb --  a
+x a.
 b
 
-b3#a:x      /ax   c.{x d: }x b - b{x a.  }
-b3# b  ax d.x     d{x a a x  d:x a. }
-b3# b:x      /ax   c.x a:x  d.x  b:
 b
-3#     b {x  d.x   dx   c.x   ,ax    d.}
-b3#     ax  c.x a:x      ax      /axa.
-b3# d -- a
-x b.x     a
-x acx  d:
+3#a:
+x      /a
+x   c.{
+x d: }
+x b - b{
+x a.  }
+b
+3# b  a
+x d.
+x     d{
+x a a 
+x  d:
+x a. }
+b
+3# b:
+x      /a
+x   c.
+x a:
+x  d.
+x  b:
+b
+3#     b {
+x  d.
+x   d
+x   c.
+x   ,a
+x    d.}
+b
+3#     a
+x  c.
+x a:
+x      a
+x      /a
+xa.
+b
+3# d -- a
+x b.
+x     a
+x ac
+x  d:
 x  c.
 b
-2#  xd ax      ///a
-x    ab
+2#  xd a
+x      ///a
+x    a
+b
 Y  dc
 b
 B
 
-{7i. Couranta 69 - 7F8Ef10C/D-Mbs 21646, f. 74r}BX
+{7i. Couranta 69 - 7F8Ef10C/D-Mbs 21646, f. 74r}
+BX
 bX
 S3
 2      ///a
 b
 1 bdca
 2      a
-b2. ddd
-3# b.x ax  d.
 b
-2#  cx     axaadc
+2. ddd
+3# b.
+x a
+x  d.
+b
+2#  c
+x     a
+xaadc
 b
 1  c
 2d.
 b
-2#dfg   /ax    dxdfg
-b2#f   a
-xcf  cx e    //a
+2#dfg   /a
+x    d
+xdfg
+b
+2#f   a
+xcf  c
+x e    //a
 b
 2#af
 x     a
 x   c
 b
 2.aac
-3#d.xb
+3#d.
+xb
 xd.
 b
-2#ax    dx  d.
+2#a
+x    d
+x  d.
 b
-3#b    bxa
+3#b    b
+xa
 2# d.
 x     d
 b
 
-b2a
+b
+2a
 3#    d
-x d.x b
+x d.
+x b
 x a.
 b
-2#  d  bx      a3# a
+2#  d  b
+x      a
+3# a
 x  d
 b
 2#  c  a
@@ -2424,8 +4438,10 @@ x b
 2# a
 x     a
 b
-2#  d ax      ///a
-x    ab
+2#  d a
+x      ///a
+x    a
+b
 1  dc
 bXQ
 bXQ
@@ -2433,9 +4449,12 @@ bXQ
 b
 1 bdca
 2      a
-b3# d
+b
+3# d
 x  d.
-x   ax bx a
+x   a
+x b
+x a
 x  d
 b
 
@@ -2446,44 +4465,58 @@ x   c
 x  d.
 x a
 x  c.
-b3#  dx a.x b
+b
+3#  d
+x a.
+x b
 x d.
 xa
 xc
 b
 3#d
 x      /a
-x f.x    dxf.
+x f.
+x    d
+xf.
 xd
 b
 3#f
 x    a
 xc.
 x    c
-x fx e.
+x f
+x e.
 b
 3# f
 x     a
-x  dx a.x b
+x  d
+x a.
+x b
 x  d.
-b3# a
+b
+3# a
 x   c.
 x  c
 xd.
-xbxd.
+xb
+xd.
 b
 3#a
-x    dx  d.x    c
+x    d
+x  d.
+x    c
 x    a
 x     d
 b
 
 b
-3#b    bxa
+3#b    b
+xa
 x d.
 x     d
 x   a
-x     bb
+x     b
+b
 3#     a
 xa
 x    d
@@ -2523,25 +4556,58 @@ b
 b
 2#acd a
 x      ///a
-xacdb
-2cdd   a3#   axdxcxa
+xacd
 b
-2. db3     d2     cb2.d    a3 b.2b     a
-b2a     /a3#    dx d.x bx a.
-b2  d  b2. a a d4#  dx a
-b2# b
-x    dx a
-b2#  d  b
-x      a3# ax  d.
+2cdd   a
+3#   a
+xd
+xc
+xa
+b
+2. db
+3     d
+2     c
+b
+2.d    a
+3 b.
+2b     a
+b
+2a     /a
+3#    d
+x d.
+x b
+x a.
+b
+2  d  b
+2. a a d
+4#  d
+x a
+b
+2# b
+x    d
+x a
+b
+2#  d  b
+x      a
+3# a
+x  d.
 b
 
-b2#  c  ax      /axab3# d    a
-x b.2. a   a
+b
+2#  c  a
+x      /a
+xa
+b
+3# d    a
+x b.
+2. a   a
 4#  d
 x a.
 b
-2#  dx      ///a
-x    ab
+2#  d
+x      ///a
+x    a
+b
 2  dc
 bXQ
 bXQ
@@ -2552,69 +4618,143 @@ x  d
 b
 3#a
 x      ///a
-x    ex   a.x   cx    e.
+x    e
+x   a.
+x   c
+x    e.
 b
-3#cx      ax   axd.xcxa.
+3#c
+x      a
+x   a
+xd.
+xc
+xa.
 b
-3# dx     dx   a.x  ax  b.x     c
-b3#     axd.x ax b.xb     ax a.
+3# d
+x     d
+x   a.
+x  a
+x  b.
+x     c
+b
+3#     a
+xd.
+x a
+x b.
+xb     a
+x a.
 b
 
-b3#ax      /ax    dx d.x bx a.
-b3#  d.x     bx     dx ax   cx   a
-b3# bx      /a.x   cx   d.x  bx   c.
-b3# dx  d.x      ax b.x ax  d.
-b3#  cx     ax   c.x      ax      /axa.
-b3# d    a
-x b.2. a   a
-4  dx a
 b
-2#  dx      ///a
-x    ab
+3#a
+x      /a
+x    d
+x d.
+x b
+x a.
+b
+3#  d.
+x     b
+x     d
+x a
+x   c
+x   a
+b
+3# b
+x      /a.
+x   c
+x   d.
+x  b
+x   c.
+b
+3# d
+x  d.
+x      a
+x b.
+x a
+x  d.
+b
+3#  c
+x     a
+x   c.
+x      a
+x      /a
+xa.
+b
+3# d    a
+x b.
+2. a   a
+4  d
+x a
+b
+2#  d
+x      ///a
+x    a
+b
 Y  dc
 b
 B
 
-{7j. Courante de la Reyne. Cinquiesme - 7F8Ef10C/Ballard 1611, pp. 44-45}BX
+{7j. Courante de la Reyne. Cinquiesme - 7F8Ef10C/Ballard 1611, pp. 44-45}
+BX
 bX
 S3
 2      ///a
 b
 1 bdc
 2      a
-b2. ddd {
-3# b.x ax  d.}
 b
-2#  cx     ax    c
+2. ddd {
+3# b.
+x a
+x  d.}
+b
+2#  c
+x     a
+x    c
 b
 1  cc{
 2d. }
 b
-2#dfg dx      /axdfg
-b3#f   a
+2#dfg d
+x      /a
+xdfg
+b
+3#f   a
 xd.
-2#cx ea c
+2#c
+x ea c
 b
 2#af
 x     a
 x    c
 b
 2.aacc{
-3#d.xbxd. }
+3#d.
+xb
+xd. }
 b
-2a3#   cd{
-x  a.2  b }
+2a
+3#   cd{
+x  a.
+2  b }
 b
 
 b
-3#b d  b&{xa.
+3#b d  b&{
+xa.
 2# d  }
 x  f  d
-b2a g
-3#      /a
-x d.x bx a.
 b
-2#  d  bx      a3# a a
+2a g
+3#      /a
+x d.
+x b
+x a.
+b
+2#  d  b
+x      a
+3# a a
 x  d.
 b
 2#  c  a
@@ -2627,8 +4767,10 @@ b
 4#  d
 x a.
 b
-2#  d ax      ///a
-x    ab
+2#  d a
+x      ///a
+x    a
+b
 1  dc
 bXQ
 bXQ
@@ -2641,34 +4783,111 @@ x  d
 x  b.
 x   d
 x   c.
-b3# d d  ax b cx a a
-x b cx  d dx a a
+b
+3# d d  a
+x b c
+x a a
+x b c
+x  d d
+x a a
 b
 
-b3#  c  ax a.x bx a.x  cx  d.
-b3# ax     ax   c
-4#  dx a.
+b
+3#  c  a
+x a.
 x b
-x d.xaxc.
-b3#dx    d{xcxd.xax  d.}
-b3#    ax  b.x  a c{x   c.x   a
-4#   cx  a.}
-b3#   cx     ax   cx  a.x  cx  d.
-b3# ax     a
-x   c{xd. }x   axb.
-b3#ax    d{x  bx  a.x  b }x   c.
+x a.
+x  c
+x  d.
+b
+3# a
+x     a
+x   c
+4#  d
+x a.
+x b
+x d.
+xa
+xc.
+b
+3#d
+x    d{
+xc
+xd.
+xa
+x  d.}
+b
+3#    a
+x  b.
+x  a c{
+x   c.
+x   a
+4#   c
+x  a.}
+b
+3#   c
+x     a
+x   c
+x  a.
+x  c
+x  d.
+b
+3# a
+x     a
+x   c{
+xd. }
+x   a
+xb.
+b
+3#a
+x    d{
+x  b
+x  a.
+x  b }
+x   c.
 b
 
-b3#b    b&{xa.x d  }x     d&{x bbx d. }
-b3#ax      /ax   cx d.x bx a.
-b3#  dx     bx      ax b.x a ax  d.
-b3#  c  ax  d.x ax  c   ax  d   /a
-x a    //ab3# bdc  ///ax  a.x ac  ax  d d3.  c ca
+b
+3#b    b&{
+xa.
+x d  }
+x     d&{
+x bb
+x d. }
+b
+3#a
+x      /a
+x   c
+x d.
+x b
+x a.
+b
+3#  d
+x     b
+x      a
+x b.
+x a a
+x  d.
+b
+3#  c  a
+x  d.
+x a
+x  c   a
+x  d   /a
+x a    //a
+b
+3# bdc  ///a
+x  a.
+x ac  a
+x  d d
+3.  c ca
 5#  a
 x  c.
 b
-2#  d ax      ///a
-x    ab
+2#  d a
+x      ///a
+x    a
+b
 1  dc&{
 bXQ
 bXQ
@@ -2677,38 +4896,55 @@ b
 
 b
 1.acdca
-b2cdd   a
-3#   axd.xcxa.
+b
+2cdd   a
+3#   a
+xd.
+xc
+xa.
 b
 2#     d{
 x dff }
 x  d  c
-b2#da   ax  b.3#b d   a
+b
+2#da   a
+x  b.
+3#b d   a
 x a.
 b
 2abb   /a
 3#     a
-x d.x bd  b{x a.  }
+x d.
+x bd  b{
+x a.  }
 b
 3# bdca
 x  a.
 x  ba d{
 x b.
-x ax   d.}
+x a
+x   d.}
 b
-2# bbcdx      /ax a.
-b2#  dd b
-x      a3# a a
+2# bbcd
+x      /a
+x a.
+b
+2#  dd b
+x      a
+3# a a
 x  d.
 b
 
 b
-2#  cccax      /a
+2#  ccca
+x      /a
 xa d
 b
 2 b    a
-2. ac  a4#  d
-x a.b
+2. ac  a
+4#  d
+x a.
+b
 2#  d a
 x      ///a
 x    a
@@ -2720,32 +4956,87 @@ bXQ
 b
 3#    a
 xa  c
-x cx  a.x  bx  d.
+x c
+x  a.
+x  b
+x  d.
 b
-3#      axc.x  daxd.xcxa.
+3#      a
+xc.
+x  da
+xd.
+xc
+xa.
 b
-3#     d{x d.x ab  }x    a.x     dx     c.
-b3#     axd.x a cx b.xb     ax a.
+3#     d{
+x d.
+x ab  }
+x    a.
+x     d
+x     c.
+b
+3#     a
+xd.
+x a c
+x b.
+xb     a
+x a.
 b
 
-b3#a     /axb.xdx  bcx  ddx a c
-b3# b ax    dx     d&{x b c
-3. a a5#  dx a. }
-b3# bx      /ax    d{x d. }x b c{x a.}
-b3#  dx     bx      ax b.x a ax  d.
-b3#  c  ax a.xax      ax      /ax  d.
-b3#bd    a
-x b.xaa   a
-x  d dx  c c{
+b
+3#a     /a
+xb.
+xd
+x  bc
+x  dd
+x a c
+b
+3# b a
+x    d
+x     d&{
+x b c
+3. a a
+5#  d
+x a. }
+b
+3# b
+x      /a
+x    d{
+x d. }
+x b c{
+x a.}
+b
+3#  d
+x     b
+x      a
+x b.
+x a a
+x  d.
+b
+3#  c  a
+x a.
+xa
+x      a
+x      /a
+x  d.
+b
+3#bd    a
+x b.
+xaa   a
+x  d d
+x  c c{
 x d. }
 b
-2# cdcax      ///a
-x    ab
+2# cdca
+x      ///a
+x    a
+b
 Y cdc
 b
 B
 
-{7k. Untitled - 7F8Ef10C/A-SPL KK 35, p. 66}BX
+{7k. Untitled - 7F8Ef10C/A-SPL KK 35, p. 66}
+BX
 bX
 S3
 2      N10
@@ -2754,39 +5045,70 @@ b
 2      a
 b
 2. ddd
-3# bx ax  d
+3# b
+x a
+x  d
 b
-2#  c&,x     ax    c
+2#  c&,
+x     a
+x    c
 b
 1 acc
 2d
 bQ
-2#      8x    dxdfg
-b2#f - axcf  cx e
-b2#afx     ax   c
+2#      8
+x    d
+xdfg
+b
+2#f - a
+xcf  c
+x e
+b
+2#af
+x     a
+x   c
 b
 
-b2@aac
-3#dxbxd
+b
+2@aac
+3#d
+xb
+xd
 bQ
-2#a&,x    dx  d
-b3#b -- Qb
-xa2# d
+2#a&,
+x    d
+x  d
+b
+3#b -- Qb
+xa
+2# d
 x     d
-b2a
-3#    dx dx bx a
 b
-2#  Qd  bx      a
-3# a ax  d
+2a
+3#    d
+x d
+x b
+x a
+b
+2#  Qd  b
+x      a
+3# a a
+x  d
 bQ
-2#  c  ax      8x bd
-b2      a
+2#  c  a
+x      8
+x bd
+b
+2      a
 2. a - a
-4#  dx a
+4#  d
+x a
 b
 
 b
-2#  dx      N10!@x    a
+2#  d
+x      N10!@
+x    a
 b
 1  dc
 bbX
@@ -2794,57 +5116,145 @@ bbX
 b
 1acd a
 2      N10
-b2cdda
-3#      axdxcxa
 b
-2#     dx dbax     Qc
+2cdda
+3#      a
+xd
+xc
+xa
 b
-3#     ax axdx bxb --  ax a
+2#     d
+x dba
+x     Qc
+b
+3#     a
+x a
+xd
+x b
+xb --  a
+x a
 b
 2a --  8
-3#    dx dx bx a
+3#    d
+x d
+x b
+x a
 b
 
 b
-2# b dx bbcx a&, a
+2# b d
+x bbc
+x a&, a
 b
-2# bbcdx      8x bbc
-b2#  dd bx      a
-3# a ax  d
+2# bbcd
+x      8
+x bbc
 b
-2#  c  axax      8
+2#  dd b
+x      a
+3# a a
+x  d
 b
-3# d -- ax b
+2#  c  a
+xa
+x      8
+b
+3# d -- a
+x b
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx      N10x    a
+2#  d
+x      N10
+x    a
 b
 Y  dc
 b
-B{ }{7l. Untitled - 7F8Ef10C/LT-Va 285-MF-LXXIX, f. 75r}
+B
+
+{ }
+{7l. Untitled - 7F8Ef10C/LT-Va 285-MF-LXXIX, f. 75r}
 B
 b
 S3
 1acd.
 2a.
 b
-3#a:  ax d.xa:xc.xd:xa.
-b3#cdd   axa.xc:xd.xc:xa.
-b3# d:  dx b.x a:x b.x d:x a.
-b3#da   axb.xa:xb.xd:xb.
-b3#a:  dx d.x b:x d.xa:x b.
+3#a:  a
+x d.
+xa:
+xc.
+xd:
+xa.
+b
+3#cdd   a
+xa.
+xc:
+xd.
+xc:
+xa.
+b
+3# d:  d
+x b.
+x a:
+x b.
+x d:
+x a.
+b
+3#da   a
+xb.
+xa:
+xb.
+xd:
+xb.
+b
+3#a:  d
+x d.
+x b:
+x d.
+xa:
+x b.
 b
 
-b3# a:  dx  d.x a:x b.x d:x a.
-b3# b:   /ax a.x b:x d.x b:x a.
-b3#  da  ax a.x b:x d.x a:x  d.
-b3#  c: ax   c.x  a:x  c.x  d:ax a.
-b3# b:x d.
-2. a   a
-4#  d.x a:
 b
-2#  d.x      ///ax    a
+3# a:  d
+x  d.
+x a:
+x b.
+x d:
+x a.
+b
+3# b:   /a
+x a.
+x b:
+x d.
+x b:
+x a.
+b
+3#  da  a
+x a.
+x b:
+x d.
+x a:
+x  d.
+b
+3#  c: a
+x   c.
+x  a:
+x  c.
+x  d:a
+x a.
+b
+3# b:
+x d.
+2. a   a
+4#  d.
+x a:
+b
+2#  d.
+x      ///a
+x    a
 b
 Yacd.
 b
@@ -2855,213 +5265,580 @@ BX
 bX
 S3
 2a
-b2#abd ax      ///axf
-b2#e
-x     a
-3#ax d
 b
-2# bx      ///ax    a
+2#abd a
+x      ///a
+xf
+b
+2#e
+x     a
+3#a
+x d
+b
+2# b
+x      ///a
+x    a
 b
 1abd
 2f
-b2#dx      /ax f
-b2. d
-3 b2 d
 b
-2# ax     axc
-b2#ex   cx a a
+2#d
+x      /a
+x f
 b
-
-b2  d d
-3#    cx  dx  c- Qax   c
+2. d
+3 b
+2 d
 b
-3#  d ax bx a   ax   cxax d
+2# a
+x     a
+xc
 b
-2# bd ax a   ax      a
-b2#  d   /ax  d   a
-3#  cc ax a
-b
-2#  dcax      ///ax    a
-b
-1acd
-bbX
-2a
-b
-3#    axax bx  dx      ///axf
-b3#ex ax     axbxax d
-b
-
-b3# bx  dx      ///ax ax bx  d
-b
-2#abd ax      ///axf
-b
-3#dx fx      /axaxfxd
-b3#bx dx      ax  dx dx b
-b3# ax     ax   cx axaxc
-b3#ex     ax   cx  cx ax   a
-b3#    dx  dx    cx  dx  c  ax   c
-b3#  d ax bx a - ax  cxax d
-b
-
-b3# bd ax d
-x bx ax     ax b    a
-b3#  d   /ax      ax     ax  dx  cx a
-b
-2#  dcax      ///ax    a
-b
-1acd
-bbX
-2a
-b2#ab- ax ax  d
-b2#  b- a
+2#e
 x   c
-3#  d - ax a
-b
-2# bx    dx  bc
-b2#   dax   c Qdx   c Qb
+x a a
 b
 
 b
-3#   a dx   cx   dx   a
-2   c
-b2#     ax  a
+2  d d
+3#    c
+x  d
+x  c- Qa
+x   c
+b
+3#  d a
+x b
+x a   a
+x   c
+xa
+x d
+b
+2# bd a
+x a   a
+x      a
+b
+2#  d   /a
+x  d   a
+3#  cc a
+x a
+b
+2#  dca
+x      ///a
+x    a
+b
+1acd
+bbX
+2a
+b
+3#    a
+xa
+x b
+x  d
+x      ///a
+xf
+b
+3#e
+x a
+x     a
+xb
+xa
+x d
+b
+
+b
+3# b
+x  d
+x      ///a
+x a
+x b
+x  d
+b
+2#abd a
+x      ///a
+xf
+b
+3#d
+x f
+x      /a
+xa
+xf
+xd
+b
+3#b
+x d
+x      a
+x  d
+x d
+x b
+b
+3# a
+x     a
+x   c
+x a
+xa
+xc
+b
+3#e
+x     a
+x   c
 x  c
-b2#   cx   ax  d d
+x a
+x   a
+b
+3#    d
+x  d
+x    c
+x  d
+x  c  a
+x   c
+b
+3#  d a
+x b
+x a - a
+x  c
+xa
+x d
+b
+
+b
+3# bd a
+x d
+x b
+x a
+x     a
+x b    a
+b
+3#  d   /a
+x      a
+x     a
+x  d
+x  c
+x a
+b
+2#  dca
+x      ///a
+x    a
+b
+1acd
+bbX
+2a
+b
+2#ab- a
+x a
+x  d
+b
+2#  b- a
+x   c
+3#  d - a
+x a
+b
+2# b
+x    d
+x  bc
+b
+2#   da
+x   c Qd
+x   c Qb
+b
+
+b
+3#   a d
+x   c
+x   d
+x   a
+2   c
+b
+2#     a
+x  a
+x  c
+b
+2#   c
+x   a
+x  d d
 b
 2.    c
-3#  cx  d ax a
-b3# bx dxaxcxexf
+3#  c
+x  d a
+x a
+b
+3# b
+x d
+xa
+xc
+xe
+xf
 b
 2#h
-x     ax      a
-b2#i     /axhxf     a
-b2#ea   axa     /ax dda- a
-b2 bd a
+x     a
+x      a
+b
+2#i     /a
+xh
+xf     a
+b
+2#ea   a
+xa     /a
+x dda- a
+b
+2 bd a
 2. a.  a
-4#  dx a
+4#  d
+x a
 b
 
 b
-2#  dx      ///ax    a
+2#  d
+x      ///a
+x    a
 b
 1acd
 bbX
 2a
 b
-3#    ax dx bx dx a - ax  d
-b3#  bx   c
-x     ax   a- ax  dx a
+3#    a
+x d
+x b
+x d
+x a - a
+x  d
+b
+3#  b
+x   c
+x     a
+x   a- a
+x  d
+x a
 b
 2 b
-3#    dx  dx  bx    c
-b3#    ax   dx   cx     dx     bx   c
-b3#   a dx   ax   cx   dx   ax   c
-b3#     ax   ax   cx  ax  cx   c
+3#    d
+x  d
+x  b
+x    c
+b
+3#    a
+x   d
+x   c
+x     d
+x     b
+x   c
+b
+3#   a d
+x   a
+x   c
+x   d
+x   a
+x   c
+b
+3#     a
+x   a
+x   c
+x  a
+x  c
+x   c
 b
 
-b3# ax   dx   cx   ax    dx  d
-b3#    cx  dx  c- ax   cx  d ax a
-b3# bx dxaxcxexfb
-2h
-3#     ax axax      a
-b3#      /axaxfxixhxf
-b3#ex     a2Qa     /a3# dda  axa
-b3# bd ax d
-2. a - a
-4#  dx a
 b
-2#  dx      ///ax    a
+3# a
+x   d
+x   c
+x   a
+x    d
+x  d
+b
+3#    c
+x  d
+x  c- a
+x   c
+x  d a
+x a
+b
+3# b
+x d
+xa
+xc
+xe
+xf
+b
+2h
+3#     a
+x a
+xa
+x      a
+b
+3#      /a
+xa
+xf
+xi
+xh
+xf
+b
+3#e
+x     a
+2Qa     /a
+3# dda  a
+xa
+b
+3# bd a
+x d
+2. a - a
+4#  d
+x a
+b
+2#  d
+x      ///a
+x    a
 b
 Yacdca
 b
 B
 
-{9. Courante de Gautier sans chanterelle - 7F8Ef9D10C/CH-SO DA 111, ff. 3v-4r}BX
+{9. Courante de Gautier sans chanterelle - 7F8Ef9D10C/CH-SO DA 111, ff. 3v-4r}
+BX
 bX
 S3
-3#  dx a
-b2# b  ax  bx   d
-b2#   cx bx a a
-b2# bbcdx      /ax    d
-b2# bbcx    dx    c
-b2#    ax  dx   c d
+3#  d
+x a
 b
-3#     bx   c.
+2# b  a
+x  b
+x   d
+b
+2#   c
+x b
+x a a
+b
+2# bbcd
+x      /a
+x    d
+b
+2# bbc
+x    d
+x    c
+b
+2#    a
+x  d
+x   c d
+b
+3#     b
+x   c.
 2.   a
-4#    dx   a.
+4#    d
+x   a.
 b
-2#   cx     ax      a
-b2#      /ax b
-3# a    ax  d
+2#   c
+x     a
+x      a
+b
+2#      /a
+x b
+3# a    a
+x  d
 b
 
 b
-2#  cc ax      /ax  d
-b2 b    a2. a   a
+2#  cc a
+x      /a
+x  d
+b
+2 b    a
+2. a   a
 3   c.
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bbX
-3#  dx a
-b3#    ax b.x ax  d.x  bx   d.
-b3#   c {x  b.}x   ax b.x ax  d.
-b3#      /ax b.x  bx   d.x   cx   a.
+3#  d
+x a
+b
+3#    a
+x b.
+x a
+x  d.
+x  b
+x   d.
+b
+3#   c {
+x  b.}
+x   a
+x b.
+x a
+x  d.
+b
+3#      /a
+x b.
+x  b
+x   d.
+x   c
+x   a.
 b
 
-b3#    d{x b.x  b }x   d.x   cx    c
-b3#    ax  d.x  bx   d.x     dx   c.
 b
-3#     bx   c.x   ax    d.x   a
-4#    dx   a.
+3#    d{
+x b.
+x  b }
+x   d.
+x   c
+x    c
 b
-3#     ax  cx   cx     b.x     ax      a.
-b3#      /ax b.x  dx b.x a    ax  d.
-b3#     ax  c.x   cx      ax      /ax  d.
+3#    a
+x  d.
+x  b
+x   d.
+x     d
+x   c.
+b
+3#     b
+x   c.
+x   a
+x    d.
+x   a
+4#    d
+x   a.
+b
+3#     a
+x  c
+x   c
+x     b.
+x     a
+x      a.
+b
+3#      /a
+x b.
+x  d
+x b.
+x a    a
+x  d.
+b
+3#     a
+x  c.
+x   c
+x      a
+x      /a
+x  d.
 b
 
-b3# d    ax b.x     ax b.x ax   c.
 b
-2#  dx    ax      ///a
+3# d    a
+x b.
+x     a
+x b.
+x a
+x   c.
+b
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bbX
 2 b
-b2# b  ax  bx   c
+b
+2# b  a
+x  b
+x   c
 b
 2#   Qd
 x Qa
 x  Qd
 b
-2#  c  ax   cx   a
-b2#    dx  dx  c c
-b2#    ax  ddx   c d
-b2#     bx   cx   a
+2#  c  a
+x   c
+x   a
+b
+2#    d
+x  d
+x  c c
+b
+2#    a
+x  dd
+x   c d
+b
+2#     b
+x   c
+x   a
 b
 
-b2#     ax   cx    d
 b
-3#      ax    cx      /ax    ax      //ax     e
+2#     a
+x   c
+x    d
 b
-2#    afx      ///ax    a
+3#      a
+x    c
+x      /a
+x    a
+x      //a
+x     e
+b
+2#    af
+x      ///a
+x    a
 b
 1  dc
 bbX
 2 b
 b
-3#    ax bx ax  dx  bx   c
-b3#   d{x  dx a.x bx a }x  d
+3#    a
+x b
+x a
+x  d
+x  b
+x   c
 b
-3#     ax  cx   cx     bx     ax      a
+3#   d{
+x  d
+x a.
+x b
+x a }
+x  d
+b
+3#     a
+x  c
+x   c
+x     b
+x     a
+x      a
 b
 
-b3#    d&{x  dx ax  dx  c}x    c
-b3#    ax  cx  dx   dx   cx     d
-b3#     bx     ax      ax   dx   cx   a
-b3#     ax  cx   cx   ax  dx    d
-b3#    c&{x  cx  dx b }x a   a
-4#  dx a
+b
+3#    d&{
+x  d
+x a
+x  d
+x  c}
+x    c
+b
+3#    a
+x  c
+x  d
+x   d
+x   c
+x     d
+b
+3#     b
+x     a
+x      a
+x   d
+x   c
+x   a
+b
+3#     a
+x  c
+x   c
+x   a
+x  d
+x    d
+b
+3#    c&{
+x  c
+x  d
+x b }
+x a   a
+4#  d
+x a
 b
 1  dca
 2      ///a
@@ -3076,360 +5853,920 @@ BX
 bX
 S3
 2  d
-b2#ax  dx ac
-b2# bdx  bx d d
+b
+2#a
+x  d
+x ac
+b
+2# bd
+x  b
+x d d
 b
 2.a  c
 3 d
 2 bd
-b2# a   ax   cx  d d
-b2 a a
-3#  ccx dx bx a
 b
-2# bd ax db cx  a
-b2a   d
-3#   axd
+2# a   a
+x   c
+x  d d
+b
+2 a a
+3#  cc
+x d
+x b
+x a
+b
+2# bd a
+x db c
+x  a
+b
+2a   d
+3#   a
+xd
 2c d
-b2d  c
-3#  bxb
+b
+2d  c
+3#  b
+xb
 2a   d
 b
 
-b2# dff dx   dx bbc a
-b2#  d  bx dx    cd
-b2#ax    dx  d
-b2b
-3#      axax dx b
 b
-2# a   axa cx  d d
-b2 b a
+2# dff d
+x   d
+x bbc a
+b
+2#  d  b
+x d
+x    cd
+b
+2#a
+x    d
+x  d
+b
+2b
+3#      a
+xa
+x d
+x b
+b
+2# a   a
+xa c
+x  d d
+b
+2 b a
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx      ///ax    a
+2#  d
+x      ///a
+x    a
 b
 1  dc
 bbX
-3# d  ax b
+3# d  a
+x b
 b
-2# a   dx   c
-3# b   ax a
+2# a   d
+x   c
+3# b   a
+x a
 b
 
 b
-2#  d  bx   ax a
+2#  d  b
+x   a
+x a
 b
 2.  bc a
-4#    ax    c
+4#    a
+x    c
 2    d
-b2#  d  bx   d  ax    c
-b2  bcd /a
-3#axb
-2d
-b2# b dx   cx d a
-b2a   d
-3#      /ax dxaxc
 b
-2#dd  cx b  axb
-b2#a b dx dx  d  b
-b2# bbc ax ddd  ax  f
+2#  d  b
+x   d  a
+x    c
+b
+2  bcd /a
+3#a
+xb
+2d
+b
+2# b d
+x   c
+x d a
+b
+2a   d
+3#      /a
+x d
+xa
+xc
+b
+2#dd  c
+x b  a
+xb
+b
+2#a b d
+x d
+x  d  b
+b
+2# bbc a
+x ddd  a
+x  f
 b
 
-b2#ab    /axd
-3# bxc
-b3#ax axc     axe
+b
+2#ab    /a
+xd
+3# b
+xc
+b
+3#a
+x a
+xc     a
+xe
 2f
-b2#e    ax fxab    /a
 b
-3#  dxdxba    ax bx ax  d
-b3#     axax  dx ax b ax d
-b3#  c  ax  d
+2#e    a
+x f
+xab    /a
+b
+3#  d
+xd
+xba    a
+x b
+x a
+x  d
+b
+3#     a
+xa
+x  d
+x a
+x b a
+x d
+b
+3#  c  a
+x  d
 2. a c
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b
 B
 
-p{10b. Courante de la Reine Seconde - 7F8Ef10C/Ballard 1611, pp. 38-39}
+p
+{10b. Courante de la Reine Seconde - 7F8Ef10C/Ballard 1611, pp. 38-39}
 BX
 bX
 S3
 2  d
-b2#ax   c{x ac}
-b2# bdx  b.x d d
+b
+2#a
+x   c{
+x ac}
+b
+2# bd
+x  b.
+x d d
 b
 2.a  c{
 3 d }
 2 b  a
-b2# a  h {x   f.}x  dcd
-b2 a a
-3#   c{x b.x d }x a.
 b
-2# bd ax  b c{x da }
-b2a  cd
-3# a axd.
+2# a  h {
+x   f.}
+x  dcd
+b
+2 a a
+3#   c{
+x b.
+x d }
+x a.
+b
+2# bd a
+x  b c{
+x da }
+b
+2a  cd
+3# a a
+xd.
 2c d
-b2da c{
-3#  bxb. }
+b
+2da c{
+3#  b
+xb. }
 2ab  d
 b
 
-b2# dba dx     bx bbc a
-b2#  d ab{x d.  }x    cd
-b2#a   dx      /ax  d.
-b2#ba    a
-x  dx b.
 b
-2#aac  ax   c.x  d d
-b2 b a
+2# dba d
+x     b
+x bbc a
+b
+2#  d ab{
+x d.  }
+x    cd
+b
+2#a   d
+x      /a
+x  d.
+b
+2#ba    a
+x  d
+x b.
+b
+2#aac  a
+x   c.
+x  d d
+b
+2 b a
 2. ac  a
-4#  dx a.
+4#  d
+x a.
 b
-2#  d ax      ///ax    a
+2#  d a
+x      ///a
+x    a
 b
 1  dc
 bXQ
 bXQ
-2  db
+2  d
+b
 
 b
 2a
-3#   c{x d.x bx a.}
-b3# bd {x a.x b }x  b.x   d{x d.}
-b3#   c{xa.x dxa. }x b  ax d.
-b3#     ax a.x  bx   a.x   cd{x  d.}
-b3#  aax a.x  cc{x b.x dx a.}
-b3#    ax bdx  ax d.x    c{x  b.}
+3#   c{
+x d.
+x b
+x a.}
+b
+3# bd {
+x a.
+x b }
+x  b.
+x   d{
+x d.}
+b
+3#   c{
+xa.
+x d
+xa. }
+x b  a
+x d.
+b
+3#     a
+x a.
+x  b
+x   a.
+x   cd{
+x  d.}
+b
+3#  aa
+x a.
+x  cc{
+x b.
+x d
+x a.}
+b
+3#    a
+x bd
+x  a
+x d.
+x    c{
+x  b.}
 b
 
-b3#ax    d{x  d }xcdx   ax b.
-b3#dax   c{x  bxb. }
-xa   dxb.
-b3# dx     d{x a   }x     bx     ax b.
-b3#     b&{x  d.x d  }x      ax     d{x a.  }
-b3#    d{xa.x bx  b.}x   c {x  d.}
-b3#      axbax  dx b.x ax  d.
+b
+3#a
+x    d{
+x  d }
+xcd
+x   a
+x b.
+b
+3#da
+x   c{
+x  b
+xb. }
+xa   d
+xb.
+b
+3# d
+x     d{
+x a   }
+x     b
+x     a
+x b.
+b
+3#     b&{
+x  d.
+x d  }
+x      a
+x     d{
+x a.  }
+b
+3#    d{
+xa.
+x b
+x  b.}
+x   c {
+x  d.}
+b
+3#      a
+xba
+x  d
+x b.
+x a
+x  d.
 b
 
-b3#  c  ax a.xax  a.x  cx d.
+b
+3#  c  a
+x a.
+xa
+x  a.
+x  c
+x d.
 b
 2 bd
 2. ac  a
-4#  dx a.
+4#  d
+x a.
 b
-2#  dx      ///ax    a
+2#  d
+x      ///a
+x    a
 b
 1  dc
 bXQ
 bXQ
 2f d
-b2da
-3#   c&{xc.xaxc.}
 b
-2#dxc d {x a.}
-b2.ab
-3# a.x  dx  b.
+2da
+3#   c&{
+xc.
+xa
+xc.}
+b
+2#d
+xc d {
+x a.}
+b
+2.ab
+3# a.
+x  d
+x  b.
 b
 
 b
-2#  d{xa.}
-3#  bx  a.
+2#  d{
+xa.}
+3#  b
+x  a.
 b
-2#   c{xa. }x  a
+2#   c{
+xa. }
+x  a
 b
 2 db {
-3#ax d.}x bd {x d.}
+3#a
+x d.}
+x bd {
+x d.}
 b
-2# a cx     ax     d
-b2# b c ax  dc b{x   a.}
-b2  bc a
-3#    dx    c.
+2# a c
+x     a
+x     d
+b
+2# b c a
+x  dc b{
+x   a.}
+b
+2  bc a
+3#    d
+x    c.
 2    d
-b2#  d  bx   da ax    c.
-b2#   c  /ax    d{xab  }
+b
+2#  d  b
+x   da a
+x    c.
+b
+2#   c  /a
+x    d{
+xab  }
 b
 
-b2# d  cx b  a
-3# dax b.
+b
+2# d  c
+x b  a
+3# da
+x b.
 b
 2 ab  d&{
-3#   ax b.
+3#   a
+x b.
 2 d  }
-b2#     bx  b  ax c.
-b2#      ax d dx f f
-b2# gdx  f.{
-3#dx g.}
 b
-2#      /ax fgx  f.
-b2#      ax ddx  f.
-b2#     ax dcc{xa. }
+2#     b
+x  b  a
+x c.
+b
+2#      a
+x d d
+x f f
+b
+2# gd
+x  f.{
+3#d
+x g.}
+b
+2#      /a
+x fg
+x  f.
+b
+2#      a
+x dd
+x  f.
+b
+2#     a
+x dcc{
+xa. }
 b
 
-b2# bdx bd  ax ac
-b2#  dcax      ///ax    a
+b
+2# bd
+x bd  a
+x ac
+b
+2#  dca
+x      ///a
+x    a
 b
 2.  dc {
 bXQ
 bXQ
-3#a.xfx  d.}
-b3# axd.x   c&{xc.xaxc.}
-b3#dx  b.x  dxc.x axd.
-b3# bxc.xax a.x  dx  b.
-b3#  dxa.x bx  d.x  bx  a.
+3#a.
+xf
+x  d.}
+b
+3# a
+xd.
+x   c&{
+xc.
+xa
+xc.}
+b
+3#d
+x  b.
+x  d
+xc.
+x a
+xd.
+b
+3# b
+xc.
+xa
+x a.
+x  d
+x  b.
+b
+3#  d
+xa.
+x b
+x  d.
+x  b
+x  a.
 b
 
-b3#   c{xa.x dx b.}x ax  a.
-b3#  bx a.x dxa.x bdx d.
-b3# ax     ax  bx  d.x ax     d
-b3# b   ax a.x     b{x  dcx   ax    a}
-b3#     ax  b.x   cx    d.x    cx    d.
-b3#     b{x  d. }x      ax   d.x    ax    c.
+b
+3#   c{
+xa.
+x d
+x b.}
+x a
+x  a.
+b
+3#  b
+x a.
+x d
+xa.
+x bd
+x d.
+b
+3# a
+x     a
+x  b
+x  d.
+x a
+x     d
+b
+3# b   a
+x a.
+x     b{
+x  dc
+x   a
+x    a}
+b
+3#     a
+x  b.
+x   c
+x    d.
+x    c
+x    d.
+b
+3#     b{
+x  d. }
+x      a
+x   d.
+x    a
+x    c.
 b
 
-b3#      /ax   c.x    d{xa.x bx  b.}
-b3#    c{x d. }x    ax b.x dax b.
-b3#     d&{x abx   ax b.x d  }x     d
-b3#     b{x  d. }x  b  ax d.x cx  b.
-b3#      ax d.x   dx  d.x   fx f.
-b3#  dx g.x  fx d.xdx g.
+b
+3#      /a
+x   c.
+x    d{
+xa.
+x b
+x  b.}
+b
+3#    c{
+x d. }
+x    a
+x b.
+x da
+x b.
+b
+3#     d&{
+x ab
+x   a
+x b.
+x d  }
+x     d
+b
+3#     b{
+x  d. }
+x  b  a
+x d.
+x c
+x  b.
+b
+3#      a
+x d.
+x   d
+x  d.
+x   f
+x f.
+b
+3#  d
+x g.
+x  f
+x d.
+xd
+x g.
 b
 
 -l "6 in"
-b3#      /ax f.x  gx  f.x  dx   f.
-b3#      ax d.x  dx   d.x   ax  f.
-b3#     ax d.x  cxa.x   c{x d.}
-b3# bx  d.x bx     ax ax   c.
 b
-2#  dcax      ///ax    a
+3#      /a
+x f.
+x  g
+x  f.
+x  d
+x   f.
 b
-Y  dcb
+3#      a
+x d.
+x  d
+x   d.
+x   a
+x  f.
+b
+3#     a
+x d.
+x  c
+xa.
+x   c{
+x d.}
+b
+3# b
+x  d.
+x b
+x     a
+x a
+x   c.
+b
+2#  dca
+x      ///a
+x    a
+b
+Y  dc
+b
 B
 
-p{11. Gaultier ?lendzon - 7F8Ef9D10C/D-B 4022, f. 15v}BX
+p
+{11. Gaultier ?lendzon - 7F8Ef9D10C/D-B 4022, f. 15v}
+BX
 bX
 S3
 2  d
-b2 b
-3#    ax d
+b
+2 b
+3#    a
+x d
 2a   d
 b
-3#  dx   a
-2# ax     a
-b2#  dcax      ///ax    a
+3#  d
+x   a
+2# a
+x     a
+b
+2#  dca
+x      ///a
+x    a
 b
 1  dc
 2 a
-b2 aba d
-3#    cx b
+b
+2 aba d
+3#    c
+x b
 2 d
-b2  b d
+b
+2  b d
 2.  ba  a
 3  a
 b
-2#  bx     dx  ba
-b2#  dx     bx    a
-b2#     ax  b cx    d
+2#  b
+x     d
+x  ba
+b
+2#  d
+x     b
+x    a
+b
+2#     a
+x  b c
+x    d
 b
 
-b2#      ax   dax    c
-b2#      //a
+b
+2#      a
+x   da
+x    c
+b
+2#      //a
 x   cd
-3#   a  ax   c
-b2#    dx   a
-2.    ca
-4#    ax    c
+3#   a  a
+x   c
 b
-2#    ax      ///ax    a
-b2  dc
+2#    d
+x   a
+2.    ca
+4#    a
+x    c
+b
+2#    a
+x      ///a
+x    a
+b
+2  dc
 bXQ
 bXQ
-3#  ax  bx  dx a
-b3# bx    ax   cx dxax    d
-b3#  dx   ax ax     ax  dx  c
+3#  a
+x  b
+x  d
+x a
 b
-2#  d ax      ///ax    a
-b2  dc
-3#   cx  ax  bx  d
+3# b
+x    a
+x   c
+x d
+xa
+x    d
+b
+3#  d
+x   a
+x a
+x     a
+x  d
+x  c
+b
+2#  d a
+x      ///a
+x    a
+b
+2  dc
+3#   c
+x  a
+x  b
+x  d
 b
 
-b3# ax     dx   ax bx dx    c
-b3# bx    dx      ax  bx  ax  d
-b3#  bx     dx    cx    dx   ax   c
-b3#     bx  dx    ax    cx    dx   a
-b3#     ax  bx    cx    dx   ax   c
-b3#      ax   dx    ax    cx    dx    c
-b3#      //ax   cx    dx    ax   d  ax   c
-b3#   ax    d
+b
+3# a
+x     d
+x   a
+x b
+x d
+x    c
+b
+3# b
+x    d
+x      a
+x  b
+x  a
+x  d
+b
+3#  b
+x     d
+x    c
+x    d
+x   a
+x   c
+b
+3#     b
+x  d
+x    a
+x    c
+x    d
+x   a
+b
+3#     a
+x  b
+x    c
+x    d
+x   a
+x   c
+b
+3#      a
+x   d
+x    a
+x    c
+x    d
+x    c
+b
+3#      //a
+x   c
+x    d
+x    a
+x   d  a
+x   c
+b
+3#   a
+x    d
 2.    ca
-4#    ax    c
+4#    a
+x    c
 b
 
 b
-2#    ax      ///ax    a
+2#    a
+x      ///a
+x    a
 b
 1  dc
 bXQ
 bXQ
 2a
-b2#acdcax      ///axcdd   a
 b
-3#ax d
+2#acdca
+x      ///a
+xcdd   a
+b
+3#a
+x d
 2add a
-3# cx  b
+3# c
+x  b
 b
-2# daa  ax   ax    a
+2# daa  a
+x   a
+x    a
 b
 1 daa
 2 d
-b2# dff dx   fxabb d
 b
-3# dx b
+2# dff d
+x   f
+xabb d
+b
+3# d
+x b
 2 dba d
-3# bx a
+3# b
+x a
 b
 1      /a
 2 bbc
 b
 
-b2. aba d
-3# bx  d ax a
 b
-2#  c  ax      //ax  d
-b2 a    Qa
+2. aba d
+3# b
+x  d a
+x a
+b
+2#  c  a
+x      //a
+x  d
+b
+2 a    Qa
 2. ac  a
-4#  dx a
+4#  d
+x a
 b
-2#  dx      ///ax    a
-b2  dc
+2#  d
+x      ///a
+x    a
+b
+2  dc
 bQX
 bQX
-3#  dx ax cx d
-b3#ax    ax cx  dxcx      Qa
-b3#  ax  bx    axacx dx c
+3#  d
+x a
+x c
+x d
+b
+3#a
+x    a
+x c
+x  d
+xc
+x      Qa
+b
+3#  a
+x  b
+x    a
+xac
+x d
+x c
 b
 2 d
-3#  a   ax  bx  dx a
+3#  a   a
+x  b
+x  d
+x a
 b
 2  da
-3#  bx  dx ax b
+3#  b
+x  d
+x a
+x b
 b
 
 b
 3# d
-x     dx bx dxax    d
-b3#  bx  dx     dx abx  dx a
-b3# bx      /a
-x   cx  ax  bx  d
-b3# ax     dx   ax bx  d ax a
-b3#  c  ax  dx ax  cx b  Qax a
-b3# bx  d
-2. a   a
-4#  dQx a
+x     d
+x b
+x d
+xa
+x    d
 b
-2#  dQx      ///ax    a
+3#  b
+x  d
+x     d
+x ab
+x  d
+x a
+b
+3# b
+x      /a
+x   c
+x  a
+x  b
+x  d
+b
+3# a
+x     d
+x   a
+x b
+x  d a
+x a
+b
+3#  c  a
+x  d
+x a
+x  c
+x b  Qa
+x a
+b
+3# b
+x  d
+2. a   a
+4#  dQ
+x a
+b
+2#  dQ
+x      ///a
+x    a
 b
 Y  dc
 b
@@ -3447,61 +6784,110 @@ b
 x a.
 2  d:
 b
-1  cc a2      a
-b2  +d - /a
-3# a -- //ax b.x d:x a.
+1  cc a
+2      a
 b
-2# b -- ///ax  d.x b:
-b2# bd - ///ax      //ax      /a
-b2 dba d
-3#   axa.xb:xd.
+2  +d - /a
+3# a -- //a
+x b.
+x d:
+x a.
 b
-2#a:x      /a
-x    db
+2# b -- ///a
+x  d.
+x b:
+b
+2# bd - ///a
+x      //a
+x      /a
+b
+2 dba d
+3#   a
+xa.
+xb:
+xd.
+b
+2#a:
+x      /a
+x    d
+b
 1abb
 bbX
 2a.
 b
 
-b2#f:x      ///ax d -- //a
-b2#dx      /a
+b
+2#f:
+x      ///a
+x d -- //a
+b
+2#d
+x      /a
 xb  -  a
-b2#a -- ax d d
-3#  +bxa.
+b
+2#a -- a
+x d d
+3#  +b
+xa.
 b
 2bbd
-3#    ax d.
+3#    a
+x d.
 2a:
-b2# db cxa.x bd d
-b3#    a
+b
+2# db c
+xa.
+x bd d
+b
+3#    a
 x b
 2# a:
 x     a
 b
-2#  d:x      ///ax    a
+2#  d:
+x      ///a
+x    a
 b
 Y  dc
 b
 B
 
 { }
-{12b. Courrente Gautier - 7F8Ef9D10C/D-Kl 4oMus.108 I, f. 89v}BX
+{12b. Courrente Gautier - 7F8Ef9D10C/D-Kl 4oMus.108 I, f. 89v}
+BX
 bX
 S3
 2  d
 b
 1.  dc  ///a
 b
-2#  ccx     ax      a
-b2  d   /a
-3# a    //ax bx dxa
+2#  cc
+x     a
+x      a
 b
-2# b    ///ax  dx b
-b2# b    ///ax      //ax      /a
-b2 db
-3#     dxaxbxd
+2  d   /a
+3# a    //a
+x b
+x d
+xa
 b
-2#ax    dx      /a
+2# b    ///a
+x  d
+x b
+b
+2# b    ///a
+x      //a
+x      /a
+b
+2 db
+3#     d
+xa
+xb
+xd
+b
+2#a
+x    d
+x      /a
 b
 1abb
 bXQ
@@ -3510,14 +6896,51 @@ bXQ
 b
 
 b
-3#  d   ///ax   cx  ax  cx  dx a
-b3#  cx     ax   cx  dx  cx      a
-b3#      /ax  dx a    //ax bx dxa
-b3#      ///ax bx  dx ax bx  d
-b3# b  ax  dx  bx   dx   cx   a
-b3#    dx dx     dxaxbxd
+3#  d   ///a
+x   c
+x  a
+x  c
+x  d
+x a
 b
-2#ax    dx      /a
+3#  c
+x     a
+x   c
+x  d
+x  c
+x      a
+b
+3#      /a
+x  d
+x a    //a
+x b
+x d
+xa
+b
+3#      ///a
+x b
+x  d
+x a
+x b
+x  d
+b
+3# b  a
+x  d
+x  b
+x   d
+x   c
+x   a
+b
+3#    d
+x d
+x     d
+xa
+xb
+xd
+b
+2#a
+x    d
+x      /a
 b
 1abb
 bXQ
@@ -3525,48 +6948,99 @@ bXQ
 2a
 b
 
-b2#fx    ax da c
-b2d
-3#    dxd
+b
+2#f
+x    a
+x da c
+b
+2d
+3#    d
+xd
 2b  a
-b2#a  cx d d
-3#  bxa
+b
+2#a  c
+x d d
+3#  b
+xa
 b
 2 bd
-3#    ax d
+3#    a
+x d
 2a
-b2# d  cxa cx  Qd Qd
-b2 bd a
-2. a   a
-4#  dx a
 b
-2#  dx      ///ax    a
+2# d  c
+xa c
+x  Qd Qd
+b
+2 bd a
+2. a   a
+4#  d
+x a
+b
+2#  d
+x      ///a
+x    a
 b
 2.acd
 bXQ
 bXQ
-3#axcxd
+3#a
+xc
+xd
 b
 
-b3#fx    ax    cx dxaxc
 b
-3#dx    dxfxdx   axb
-b3#   cxax   dx dx  bxa
-b3#  dx bx    ax dxax b
-b3#    cx dx  bxax    dx  d
+3#f
+x    a
+x    c
+x d
+xa
+xc
+b
+3#d
+x    d
+xf
+xd
+x   a
+xb
+b
+3#   c
+xa
+x   d
+x d
+x  b
+xa
+b
+3#  d
+x b
+x    a
+x d
+xa
+x b
+b
+3#    c
+x d
+x  b
+xa
+x    d
+x  d
 b
 2Q b    a
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx      ///ax    a
+2#  d
+x      ///a
+x    a
 b
 Yacd
 b
 B
 
 { }
-{12c. Curante - 7F8Ef9D10C/GB-Lbl Sloane 1021, f. 51v}BX
+{12c. Curante - 7F8Ef9D10C/GB-Lbl Sloane 1021, f. 51v}
+BX
 bX
 S3
 2  d
@@ -3575,121 +7049,257 @@ b
 x   c
 x  d
 b
-2#  c  ax   cx      a
-b2      /a
+2#  c  a
+x   c
+x      a
+b
+2      /a
 3#      //a
-x ax bx d
+x a
+x b
+x d
 b
-2# b    ///ax  dx a
-b2# b  ax    cx    d
-b2 d   d
+2# b    ///a
+x  d
+x a
+b
+2# b  a
+x    c
+x    d
+b
+2 d   d
 3#   a
-xaxbxd
+xa
+xb
+xd
 b
-2#ax    dx      /a
+2#a
+x    d
+x      /a
 b
 2 bbc
 bbX
 1a
 b
 
-b2#fx    ax d  c
-b2#d
+b
+2#f
+x    a
+x d  c
+b
+2#d
 x    d
 xb  a
-b2a  c3#   d
+b
+2a  c
+3#   d
 x d
-x  bxa
+x  b
+xa
 b
 2# bd
-x    a3# d
+x    a
+3# d
 xa
-b2# d  cxax  d d
-b2   a
-2. a   a
-4#  dx a
 b
-2#  dx    a
-x      ///ab
+2# d  c
+xa
+x  d d
+b
+2   a
+2. a   a
+4#  d
+x a
+b
+2#  d
+x    a
+x      ///a
+b
 2  dc
 Ya
 b
 B
 
-{ }{12d. Co(urante) - 7F8Ef9D10C/RUS-SPan O No 124, ff. 32r-31v}BX
+{ }
+{12d. Co(urante) - 7F8Ef9D10C/RUS-SPan O No 124, ff. 32r-31v}
+BX
 bX
 S3
 2  d
 b
 1.  dc  ///a
 b
-2#  ccx     ax      a
-b2  d   /a
-3# a    //ax bx dxa
+2#  cc
+x     a
+x      a
 b
-2# b    ///ax  dx b
-b2# b  ax    cx    d
-b2 db
-3#     dxaxbxd
+2  d   /a
+3# a    //a
+x b
+x d
+xa
 b
-2#ax      /a
-x    db
+2# b    ///a
+x  d
+x b
+b
+2# b  a
+x    c
+x    d
+b
+2 db
+3#     d
+xa
+xb
+xd
+b
+2#a
+x      /a
+x    d
+b
 1abb
 bbX
 2  d
 b
 
 b
-3#  d ax   cx  ax  cx  dx a
-b3#  cx     ax   cx  dx  cx      a
-b3#      /ax  dx a    //ax bx dxa
-b3#      ///ax bx  dx ax bx  d
-b3# b  ax  dx  bx   dx   cx   a
-b3#    dx dx     dxaxbxd
+3#  d a
+x   c
+x  a
+x  c
+x  d
+x a
 b
-2#ax      /a
-x    db
+3#  c
+x     a
+x   c
+x  d
+x  c
+x      a
+b
+3#      /a
+x  d
+x a    //a
+x b
+x d
+xa
+b
+3#      ///a
+x b
+x  d
+x a
+x b
+x  d
+b
+3# b  a
+x  d
+x  b
+x   d
+x   c
+x   a
+b
+3#    d
+x d
+x     d
+xa
+xb
+xd
+b
+2#a
+x      /a
+x    d
+b
 1abb
 bbX
 2a
 b
 
-b2#fx    ax d  c
-b2d
-3#    dxd
+b
+2#f
+x    a
+x d  c
+b
+2d
+3#    d
+xd
 2b  a
-b2#a  cx d d
-3#  bxa
+b
+2#a  c
+x d d
+3#  b
+xa
 b
 2# bd
-x    a3# d
+x    a
+3# d
 xa
-b2# d  cxa cx  Qd Qd
-b2 b  a
-2. a   a
-4#  dx a
 b
-2#  dx    a
-x      ///ab
+2# d  c
+xa c
+x  Qd Qd
+b
+2 b  a
+2. a   a
+4#  d
+x a
+b
+2#  d
+x    a
+x      ///a
+b
 1Q  dc
 bbX
-3a4#cxe
+3a
+4#c
+xe
 b
 
-b3#fx    ax    cx dxaxc
 b
-3#dx    dxfxdx   axb
-b3#   cxax   dx dx  bxa
-b3#  dx bx    ax dxax b
-b3#    cx dx  cxax    dx  d
+3#f
+x    a
+x    c
+x d
+xa
+xc
+b
+3#d
+x    d
+xf
+xd
+x   a
+xb
+b
+3#   c
+xa
+x   d
+x d
+x  b
+xa
+b
+3#  d
+x b
+x    a
+x d
+xa
+x b
+b
+3#    c
+x d
+x  c
+xa
+x    d
+x  d
 b
 3#   a
 x b
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    a
-x      ///ab
+2#  d
+x    a
+x      ///a
+b
 Y  dc
 b
 B
@@ -3991,7 +7601,8 @@ b
 B
 
 { }
-{13b. Courante Gothier - 7F8Ef9D10C/GB-Eu Coll.2073, ff. 215v-216r}BX
+{13b. Courante Gothier - 7F8Ef9D10C/GB-Eu Coll.2073, ff. 215v-216r}
+BX
 bX
 S3
 3#  d
@@ -4291,7 +7902,8 @@ b
 B
 
 { }
-{13c. Corandt Eiusdem - Ballardt - 7F8Ef9D10C/D-Ngm 33748 I, f. 47r}BX
+{13c. Corandt Eiusdem - Ballardt - 7F8Ef9D10C/D-Ngm 33748 I, f. 47r}
+BX
 bX
 S3
 2  d
@@ -4427,7 +8039,8 @@ b
 B
 
 { }
-{13d. Fauorite de Gauttier - 7F8Ef9D10C/D-B N Mus.479, ff. 15v-16r}BX
+{13d. Fauorite de Gauttier - 7F8Ef9D10C/D-B N Mus.479, ff. 15v-16r}
+BX
 bX
 S3
 3#  d:
@@ -4557,7 +8170,8 @@ Y  dc
 b
 B
 
-{13e. Courante Gauthier BEST - 7F8Ef9D10C/CH-SO DA 111, ff. 14v-15r}BX
+{13e. Courante Gauthier BEST - 7F8Ef9D10C/CH-SO DA 111, ff. 14v-15r}
+BX
 bX
 S3
 3#  d
@@ -4851,83 +8465,144 @@ b
 B
 
 p
-{13f. Untitled - 7F8Ef9D/A-SPL KK 35, p. 67}BX
+{13f. Untitled - 7F8Ef9D/A-SPL KK 35, p. 67}
+BX
 bX
 S3
-3#  \3dx a
+3#  \3d
+x a
 b
 2. bdca
-3 \4d2a
+3 \4d
+2a
 b
 2.a\4f\3f  \1e
 3 d
 2 b- a
 b
 2. a&,   a
-3#   cx  ax  c
+3#   c
+x  a
+x  c
 b
-2#  dcax ax Qb
-b2# d - d&{x  \3f
-3# \4fx d  }
-b3# b  ax \4dxax-\1cx-\3ex-\4f
+2#  dca
+x a
+x Qb
+b
+2# d - d&{
+x  \3f
+3# \4f
+x d  }
+b
+3# b  a
+x \4d
+xa
+x-\1c
+x-\3e
+x-\4f
 b
 
 b
 2-\4h&+
-3#     Qaxfxdxc
+3#     Qa
+xf
+xd
+xc
 b
 2d  c
 2.f&, --  a
 3-\3h
 b
 2.\4i&+ --  8
-3#dxb
+3#d
+xb
 xd
 b
 2a - d
-3#     dx fx d
+3#     d
+x f
+x d
 x  Qf
 bQ
 1  g&+
 2      8
-b1Q bb
+b
+1Q bb
 bbX
-3# bx \4d
+3# b
+x \4d
 b
 
 b
 2a b d
-3#      8x dx bx a
+3#      8
+x d
+x b
+x a
 b
-2#  \4d - ax   \3d
-3# ax  d
-b3#  c  a&{x  dx ax bx d  }xa
+2#  \4d - a
+x   \3d
+3# a
+x  d
 b
-2# b- ax  d
-3# ax b
+3#  c  a&{
+x  d
+x a
+x b
+x d  }
+xa
 b
-2# d  cx  \2cxa
-b2#  \4d \3dx b
-3# a ax  d
+2# b- a
+x  d
+3# a
+x b
+b
+2# d  c
+x  \2c
+xa
+b
+2#  \4d \3d
+x b
+3# a a
+x  d
 b
 
 b
-2#  c&,  ax      ax  d   8
+2#  c&,  a
+x      a
+x  d   8
 b
-3# a    9x bx dx  cx b  ax  d
-b3#     ax bx ax   ax    \3dx  \4d
-b3#    cx    a
+3# a    9
+x b
+x d
+x  c
+x b  a
+x  d
+b
+3#     a
+x b
+x a
+x   a
+x    \3d
+x  \4d
+b
+3#    c
+x    a
 2.  c&,- Qa
-4#  ax  c
+4#  a
+x  c
 b
-2#  dx    ax      N10
+2#  d
+x    a
+x      N10
 b
 Y  dc
 b
 B
 
 p
-{14. Courante Gauthier - 7F8Ef9C/GB-Cfm 689, f. 61v i}BX
+{14. Courante Gauthier - 7F8Ef9C/GB-Cfm 689, f. 61v i}
+BX
 bX
 S3
 2 f
@@ -4937,38 +8612,88 @@ b
 2f
 b
 2.ea - a
-4#cxe
+4#c
+xe
 2a
-b2f
-3#    ax    cx    dx   a
-b3#d- cx   ax   cx   dx   cx   a
 b
-2#    dxax  d
-b2# dx    cx  c
-b2# bx    ax   c
-b2  d
-3# ax bx dx b
+2f
+3#    a
+x    c
+x    d
+x   a
+b
+3#d- c
+x   a
+x   c
+x   d
+x   c
+x   a
+b
+2#    d
+xa
+x  d
+b
+2# d
+x    c
+x  c
+b
+2# b
+x    a
+x   c
+b
+2  d
+3# a
+x b
+x d
+x b
 b
 
 b
-2#     d&{x b-cx a-a}
-b2#  d  bx    dx   a
-b2#  cx     ax    c
+2#     d&{
+x b-c
+x a-a}
+b
+2#  d  b
+x    d
+x   a
+b
+2#  c
+x     a
+x    c
 b
 1   c
 2a
-b2# bx  dxb
-b2#ax  bx d d
-b2# b-cxdx     a
-b2#b  -  ax axd
+b
+2# b
+x  d
+xb
+b
+2#a
+x  b
+x d d
+b
+2# b-c
+xd
+x     a
+b
+2#b  -  a
+x a
+xd
 b
 
-b2#      /ax fx d -- a
-b2  g
-2.  f- a
-4#  dx  f
 b
-2#  dx    ax      //a
+2#      /a
+x f
+x d -- a
+b
+2  g
+2.  f- a
+4#  d
+x  f
+b
+2#  d
+x    a
+x      //a
 b
 1  dc
 bbX
@@ -4977,357 +8702,846 @@ b
 2.ff h
 3h
 2i
-b2# ifx  gx gi
-b2# fx   hx   f
-b2#   dxfx d
+b
+2# if
+x  g
+x gi
+b
+2# f
+x   h
+x   f
+b
+2#   d
+xf
+x d
 b
 
-b2#dx     ax  g
-b2# g -- ax  fxd
-b2# fx      /ax d
-b2#  gx d- cx  b
+b
+2#d
+x     a
+x  g
+b
+2# g -- a
+x  f
+xd
+b
+2# f
+x      /a
+x d
+b
+2#  g
+x d- c
+x  b
 b
 2. b- a
-4# ax b
+4# a
+x b
 2  d
-b2# a - dx  dc bx   a
-b2#ax     ax   c
-b2# acxax d
+b
+2# a - d
+x  dc b
+x   a
+b
+2#a
+x     a
+x   c
+b
+2# ac
+xa
+x d
 b
 
-b2 b
-3#  dx  bx   dx   c
 b
-2# d-ax    dxd - c
+2 b
+3#  d
+x  b
+x   d
+x   c
 b
-3#a  -  /ax dxaxbxdxa
-b3# g -- ax fx dx fx  gx d
+2# d-a
+x    d
+xd - c
 b
-2#  f  ax f
-3#f   axh
-b3#ixf
+3#a  -  /a
+x d
+xa
+xb
+xd
+xa
+b
+3# g -- a
+x f
+x d
+x f
+x  g
+x d
+b
+2#  f  a
+x f
+3#f   a
+xh
+b
+3#i
+xf
 2.h -- a
-4#fxh
+4#f
+xh
 b
-2#fx    ax      //a
+2#f
+x    a
+x      //a
 b
 Y  dc
 b
 B
 
 p
-{15. Courante Gauthier - 7F8Ef9C/GB-Cfm 689, f. 62r i}BX
+{15. Courante Gauthier - 7F8Ef9C/GB-Cfm 689, f. 62r i}
+BX
 bX
 S3
 2  d
-b2 b
-3#    ax d
+b
+2 b
+3#    a
+x d
 2a - d
-b2  d
-3#   ax a
+b
+2  d
+3#   a
+x a
 2  cc
-b2  d
-3#    ax  cx  dx a
-b3# bx dxaxcxexf
 b
-2#efxfxab
-b2  d
-3# ax bx d-ax b
+2  d
+3#    a
+x  c
+x  d
+x a
 b
-2# a cx     ax  d
+3# b
+x d
+xa
+xc
+xe
+xf
 b
-3#a-cx d
-2# bdx a-c
+2#ef
+xf
+xab
+b
+2  d
+3# a
+x b
+x d-a
+x b
+b
+2# a c
+x     a
+x  d
+b
+3#a-c
+x d
+2# bd
+x a-c
 b
 
 b
-3# bx    ax    cx    dx   ax    d
+3# b
+x    a
+x    c
+x    d
+x   a
+x    d
 b
-2# d- cx  b
-3# bx d
+2# d- c
+x  b
+3# b
+x d
 b
 1ab -- /a
 2ba -- a
-b2#ab - axd- cxa b d
-b2# d d- axa bx   c- /a
-b2b d
-3#      ax bx ax  d
+b
+2#ab - a
+xd- c
+xa b d
+b
+2# d d- a
+xa b
+x   c- /a
+b
+2b d
+3#      a
+x b
+x a
+x  d
 b
 2.aac  a
 3 d
 2 b- a
 b
-3# d -- ax b
+3# d -- a
+x b
 2. a - a
-4#  dx  c
+4#  d
+x  c
 b
-2#  d-ax   cx      //a
+2#  d-a
+x   c
+x      //a
 b
 
 b
 1  dc
 bbX
-3#cxe
+3#c
+xe
 b
-2#fx    axh- g
-b2#i- hxffx gi
-b2#  gxffx  f
+2#f
+x    a
+xh- g
 b
-3#a dx  bx   dx d
+2#i- h
+xff
+x gi
+b
+2#  g
+xff
+x  f
+b
+3#a d
+x  b
+x   d
+x d
 2 b-c
-b2# a a dx  bx   d
+b
+2# a a d
+x  b
+x   d
 b
 1db c a
 2ba -- a
-b2#ab -- /a
+b
+2#ab -- /a
 x  dQ
 xaQ bQ - /aQ
 bQ
-2# dQ dQ  aQxax b ca
+2# dQ dQ  aQ
+xa
+x b ca
 b
 
-b2# ax     a
-3#  dx a
-b3# b- ax  bx   dx   cx   ax    d
+b
+2# a
+x     a
+3#  d
+x a
+b
+3# b- a
+x  b
+x   d
+x   c
+x   a
+x    d
 b
 2# d- c
 x  b
-3#dxb
+3#d
+xb
 b
-2#ax      /ax d -- a
-b2# bd- ax a cxa c
-b2# bdx    ax d- c
+2#a
+x      /a
+x d -- a
 b
-1ab c a2 a-a
-b2  d d
+2# bd- a
+x a c
+xa c
+b
+2# bd
+x    a
+x d- c
+b
+1ab c a
+2 a-a
+b
+2  d d
 2.  c ca
-4#  ax  c
+4#  a
+x  c
 b
-2#  dx    ax      //a
+2#  d
+x    a
+x      //a
 b
 Y  dc
 b
 B
 
 { }
-{16. Courante Gauthier - 7F8Ef9D10C/GB-Cfm 689, ff. 71v-72r}BX
+{16. Courante Gauthier - 7F8Ef9D10C/GB-Cfm 689, ff. 71v-72r}
+BX
 bX
 S3
-3#  cx  dx Qa
+3#  c
+x  d
+x Qa
 b
 2. bd-a
 3 d
 2a
 b
 2.aff- e
-3# fx dx f
+3# f
+x d
+x f
 b
-2#  g axf
-3#   hxh
+2#  g a
+xf
+3#   h
+xh
 b
 2.if
-3#   hx   fx    i
+3#   h
+x   f
+x    i
 b
-2#h - hx    fxf -- i
-b2#axa- h h
-3#   gx  i
+2#h - h
+x    f
+xf -- i
+b
+2#a
+xa- h h
+3#   g
+x  i
 b
 2.  gh f
 3 g
 2 if- a
 b
 
-b2#  gxb d - ax a
-b2#ab -- /axcxed -- //a
-b2#      ///axffgxh
-b2# e -- //axfxdf
-b2#ced cxa- fx e e
 b
-2#aac- ax    cx   c
+2#  g
+xb d - a
+x a
+b
+2#ab -- /a
+xc
+xed -- //a
+b
+2#      ///a
+xffg
+xh
+b
+2# e -- //a
+xf
+xdf
+b
+2#ced c
+xa- f
+x e e
+b
+2#aac- a
+x    c
+x   c
 b
 2.aac
 bbX
-3#  cx  dx Qa
+3#  c
+x  d
+x Qa
 b
 
 b
 2. bdca
-3# dxax b
-b3#     exax ax dx fx d
-b3#    ax  gxfx   hxhx g
+3# d
+xa
+x b
+b
+3#     e
+xa
+x a
+x d
+x f
+x d
+b
+3#    a
+x  g
+xf
+x   h
+xh
+x g
 b
 2.if
-3#   hx   fx    i
-b3#    hxhx    fx     ixfx   h
-b3#ax     hx   hx   gx  ix f
-b3#     fx  gx   hx gx     ax i
+3#   h
+x   f
+x    i
+b
+3#    h
+xh
+x    f
+x     i
+xf
+x   h
+b
+3#a
+x     h
+x   h
+x   g
+x  i
+x f
+b
+3#     f
+x  g
+x   h
+x g
+x     a
+x i
 b
 
-b3#  fx  gx      ax  dxbx a
-b3#      /ax bxaxcxe  -  //ax d
-b3#      ///ax fx  gxfxhxf
-b3#      //ax fx exfx fxd
-b3#c - cx ex  dx   fxax e-e
 b
-2#aac- ax    cx   c
-b2aac
-bbX2#cxe
+3#  f
+x  g
+x      a
+x  d
+xb
+x a
+b
+3#      /a
+x b
+xa
+xc
+xe  -  //a
+x d
+b
+3#      ///a
+x f
+x  g
+xf
+xh
+xf
+b
+3#      //a
+x f
+x e
+xf
+x f
+xd
+b
+3#c - c
+x e
+x  d
+x   f
+xa
+x e-e
+b
+2#aac- a
+x    c
+x   c
+b
+2aac
+bbX
+2#c
+xe
 b
 
-b2#ffg axhxf
-b2#da - axce- cx  d
 b
-2#a b dx   cx  d
-b2#aad dax  c cx d
-b2#    ax bdcx     d
-b2# dd- bxadb- ax c
-b2#b d - ax axab -- /a
-b2#     dx dbax   d
+2#ffg a
+xh
+xf
+b
+2#da - a
+xce- c
+x  d
+b
+2#a b d
+x   c
+x  d
+b
+2#aad da
+x  c c
+x d
+b
+2#    a
+x bdc
+x     d
+b
+2# dd- b
+xadb- a
+x c
+b
+2#b d - a
+x a
+xab -- /a
+b
+2#     d
+x dba
+x   d
 b
 
-b2# bdcax  f  ex d
-b2#    axabdx-Qadb-c
-b2#      /axa b-dxc-d
-b2#    cxa- fx ede
-b2#ab - axda cx   a
-b2#a b dxc dxed- c
-b2#    axffgx  i
-b2#ffi  ax  gxedf
+b
+2# bdca
+x  f  e
+x d
+b
+2#    a
+xabd
+x-Qadb-c
+b
+2#      /a
+xa b-d
+xc-d
+b
+2#    c
+xa- f
+x ede
+b
+2#ab - a
+xda c
+x   a
+b
+2#a b d
+xc d
+xed- c
+b
+2#    a
+xffg
+x  i
+b
+2#ffi  a
+x  g
+xedf
 b
 
-b2#fx    ax      ///a
+b
+2#f
+x    a
+x      ///a
 b
 2.fcd
 bbX
-3#axcxe
-b3#    axfx fx  gxhxf
-b3#     axdx ax cxce- cx  d
-b3#ax    dx  bx   cx  dx a
-b3#     axabx ax  dx  cx d
-b3#  dx bx    ax dxax     d
+3#a
+xc
+xe
+b
+3#    a
+xf
+x f
+x  g
+xh
+xf
+b
+3#     a
+xd
+x a
+x c
+xce- c
+x  d
+b
+3#a
+x    d
+x  b
+x   c
+x  d
+x a
+b
+3#     a
+xab
+x a
+x  d
+x  c
+x d
+b
+3#  d
+x b
+x    a
+x d
+xa
+x     d
 b
 
-b3#  d- bx ax bx dxad - ax c
-b3#      ax  dxbx ax      /axab
 b
-3#     dx dx  bx bx ax   d
-b3#    ax bx   cx  dx  f- ex d
+3#  d- b
+x a
+x b
+x d
+xad - a
+x c
 b
-3#    ax bxax  dx    cxbdb
-b3#    dx      /ax  bxax  dxc
+3#      a
+x  d
+xb
+x a
+x      /a
+xab
+b
+3#     d
+x d
+x  b
+x b
+x a
+x   d
+b
+3#    a
+x b
+x   c
+x  d
+x  f- e
+x d
+b
+3#    a
+x b
+xa
+x  d
+x    c
+xbdb
+b
+3#    d
+x      /a
+x  b
+xa
+x  d
+xc
 b
 
-b3#    cx   fxax   ex ex  d
-b3#     axabx axdx   cx   a
-b3#    dxax  dxcxe - cx d
-b3#f - axax bxbxax  d
-b3#b  -  ax bx     ax b
-x ax  d
+b
+3#    c
+x   f
+xa
+x   e
+x e
+x  d
+b
+3#     a
+xab
+x a
+xd
+x   c
+x   a
+b
+3#    d
+xa
+x  d
+xc
+xe - c
+x d
+b
+3#f - a
+xa
+x b
+xb
+xa
+x  d
+b
+3#b  -  a
+x b
+x     a
+x b
+x a
+x  d
 b
 3# Qa
-x Qb2. a   Qa
-4#  dx a
+x Qb
+2. a   Qa
+4#  d
+x a
 bQ
-1  d aY      ///a
+1  d a
+Y      ///a
 b
 B
-{17. Untitled - 7F8Ef10C AA12BB16/RUS-SPan O No 124, ff. 24v-25r}BX
+
+{17. Untitled - 7F8Ef10C AA12BB16/RUS-SPan O No 124, ff. 24v-25r}
+BX
 bX
 S3
 2a
 b
 2.abd   ///a
-3# dx bx a
+3# d
+x b
+x a
 b
-2#  dcaxa    e
-3#   cx d
+2#  dca
+xa    e
+3#   c
+x d
 b
 2. b  a
-4# ax b
+4# a
+x b
 2  d
-b2#ffg   ///axhxf
+b
+2#ffg   ///a
+xh
+xf
 b
 2.d    a
-4#cxd
+4#c
+xd
 2 f
 b
-3#  gx f
-2# dfx bd
-b2 a c
-3#     ax  d
+3#  g
+x f
+2# df
+x bd
+b
+2 a c
+3#     a
+x  d
 2  b
-b2 b
-3#   d  ax d
+b
+2 b
+3#   d  a
+x d
 2 Qb
 b
 
 b
-3#      /ax d
+3#      /a
+x d
 2a
-3#b   ax    c
+3#b   a
+x    c
 b
 2a   d
 2. d   d
-4#ax d
+4#a
+x d
 b
-2# bx    dx      /a
+2# b
+x    d
+x      /a
 b
 1 bbc
 bbX
 2a
 b
 2.abd   ///a
-3# dx bx a
-b3#  d ax    cx    dx    axa    ex d
+3# d
+x b
+x a
+b
+3#  d a
+x    c
+x    d
+x    a
+xa    e
+x d
 b
 2. b  a
-4# ax b4#  dx ax bx d
+4# a
+x b
+4#  d
+x a
+x b
+x d
 b
-4#axcxexa
-3#fx      ///axhxf
+4#a
+xc
+xe
+xa
+3#f
+x      ///a
+xh
+xf
 b
 
-b3#     axfxdxcxdx f
 b
-3#    dxax d  cxax b  ax d
-b3# a   ax  dx  bx  ax  bx   c
-b3# bx ax  Qbx   dx dx b
-b3#      /axaxbx    dx   ax   c
-b3#    dx    cx    ax     dx fx d
+3#     a
+xf
+xd
+xc
+xd
+x f
 b
-2#  gx    dx      /a
+3#    d
+xa
+x d  c
+xa
+x b  a
+x d
+b
+3# a   a
+x  d
+x  b
+x  a
+x  b
+x   c
+b
+3# b
+x a
+x  Qb
+x   d
+x d
+x b
+b
+3#      /a
+xa
+xb
+x    d
+x   a
+x   c
+b
+3#    d
+x    c
+x    a
+x     d
+x f
+x d
+b
+2#  g
+x    d
+x      /a
 b
 1  gf
 bbX
 2 b
 b
 2. bbc  /a
-3# dxaxb
+3# d
+xa
+xb
 b
 
 b
-3#dx    d
-2#dd  cxb
+3#d
+x    d
+2#dd  c
+xb
 b
-2#ax    dx      /a
+2#a
+x    d
+x      /a
 b
 2.ab
-3#  dx ax b
+3#  d
+x a
+x b
 b
-2# dx     dxa
+2# d
+x     d
+xa
 b
 2. bdca
-3# dxax b
+3# d
+xa
+x b
 b
-2# ax     ax   c
+2# a
+x     a
+x   c
 b
 1aacc
-3#  dx a
+3#  d
+x a
 b
-2# cdcax      ///ax  b
+2# cdca
+x      ///a
+x  b
 b
 2. daa  a
-3#    dx    cx    a
+3#    d
+x    c
+x    a
 b
 
 b
@@ -5335,64 +9549,149 @@ b
 2   d
 b
 1 bbc  /a
-3# bx d
+3# b
+x d
 b
-3#ax    dx   cxax d  cxa
-b3# b  ax dx     ax bx ax  c
+3#a
+x    d
+x   c
+xa
+x d  c
+xa
 b
-2#  dx    ax      ///a
+3# b  a
+x d
+x     a
+x b
+x a
+x  c
+b
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bbX
 2 b
 b
 2. bbc  /a
-3# dxaxb
-b3#d   dx   ax   cx    dxd   cxb
+3# d
+xa
+xb
+b
+3#d   d
+x   a
+x   c
+x    d
+xd   c
+xb
 b
 
-b3#a   dx   ax   c
-x  a4  bx  ax  bx  a
-b3#  bx  ax   cx  a3  bx  d
-x ax b
 b
-3# d   dx    ax    cx    dx   ax   c
+3#a   d
+x   a
+x   c
+x  a
+4  b
+x  a
+x  b
+x  a
+b
+3#  b
+x  a
+x   c
+x  a
+3  b
+x  d
+x a
+x b
+b
+3# d   d
+x    a
+x    c
+x    d
+x   a
+x   c
 b
 2 b  a
 4#
-x    cx    dx   a4#   cx  ax  cx  d
+x    c
+x    d
+x   a
+4#   c
+x  a
+x  c
+x  d
 b
 2 a
-3#     ax  dx  cx  a
+3#     a
+x  d
+x  c
+x  a
 b
-4#   cx   ax   cx   a4#   cx   ax   cx   a
-3#    ex    c
+4#   c
+x   a
+x   c
+x   a
+4#   c
+x   a
+x   c
+x   a
+3#    e
+x    c
 b
 
 b
 2. cdca
-3#     dx     cx     a
+3#     d
+x     c
+x     a
 b
 3. dda  a
-4#    dx    c4#    ax    cx    ax    c4#    a
-x    cx    a
+4#    d
+x    c
+4#    a
+x    c
+x    a
+x    c
+4#    a
+x    c
+x    a
 b
 2 aba d
-3#     bx     ax      ax      /a
+3#     b
+x     a
+x      a
+x      /a
 b
 1 bbcd
-3# bx d
+3# b
+x d
 b
-3#a   dx    cx b  ax     dx d   bx     a
-b3# d    ax bx     ax bx ax   c
+3#a   d
+x    c
+x b  a
+x     d
+x d   b
+x     a
 b
-2#  dx    ax      ///a
+3# d    a
+x b
+x     a
+x b
+x a
+x   c
+b
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b
 B
 
-{18a. Corandt - 7F8Ef10C AA16BB14/D-Ngm 33748 I, ff. 27v-28r}BX
+{18a. Corandt - 7F8Ef10C AA16BB14/D-Ngm 33748 I, ff. 27v-28r}
+BX
 bX
 S3
 2a
@@ -5400,27 +9699,53 @@ b
 2.abd
 3c
 2a
-b2d  c2.c  b
-4#axc
+b
+2d  c
+2.c  b
+4#a
+xc
 b
 2a
-3#     ax dx bx a
+3#     a
+x d
+x b
+x a
 b
 2 b  a
-3# ax b2 d  c
+3# a
+x b
+2 d  c
 b
-2#    dxa
+2#    d
+xa
 xc  a
 b
 2.d  c
-4#cxd2a
-b2#c  ax    dxe - c
-b2#f - ax     dx     c
+4#c
+xd
+2a
+b
+2#c  a
+x    d
+xe - c
+b
+2#f - a
+x     d
+x     c
 b
 
-b2#e -- ax fx d
-b2#ffghxhx   g
-b2.if h3h2f
+b
+2#e -- a
+x f
+x d
+b
+2#ffgh
+xh
+x   g
+b
+2.if h
+3h
+2f
 b
 2h
 3#     a
@@ -5430,9 +9755,12 @@ b
 2.c   c
 3Qd
 2a
-b2#    ax e  c
+b
+2#    a
+x e  c
 x  d
-b2aac
+b
+2aac
 3#     a
 x  d
 x  c
@@ -5441,69 +9769,152 @@ bX
 2Q   c
 bQ
 bQ
-3#  dx ax bx d
+3#  d
+x a
+x b
+x d
 b
-2a3#    a
+2a
+3#    a
 x    c
 x    d
 x   a
 b
 
 b
-2#d  cxc
+2#d  c
+xc
 x   b
 b
 2#a  c
 x  d
 x  c
-b2# b  ax  dx d  c
-b3#a   dx dx bx a2c  a
-b2d  c3#     a
-xc2a
-b3#c  axax d  cxaxcxe
-b2#fx    ax      ///a
-b3#  c  ax  ax  cx  dx ax  c
-b2#  dx    ax a - e
+b
+2# b  a
+x  d
+x d  c
+b
+3#a   d
+x d
+x b
+x a
+2c  a
+b
+2d  c
+3#     a
+xc
+2a
+b
+3#c  a
+xa
+x d  c
+xa
+xc
+xe
+b
+2#f
+x    a
+x      ///a
+b
+3#  c  a
+x  a
+x  c
+x  d
+x a
+x  c
+b
+2#  d
+x    a
+x a - e
 bQ
 
-bQ2 b  a
+bQ
+2 b  a
 3# a
-x bx  dx b
-b2 a3#     ax  d
+x b
+x  d
+x b
+b
+2 a
+3#     a
+x  d
 x  b
 x  d
-b2.  a c
+b
+2.  a c
 3  b
 2   c d
-b2  d a
+b
+2  d a
 2.  a c
 4#   c
 x   b
 b
-2#   cx     ax    c
+2#   c
+x     a
+x    c
 b
-2aacbQ
+2aac
 bQ
-2#cxd
-bX2#fx    axd
-b2#c   cx ax  d
-b2#d bx     axc
+bQ
+2#c
+xd
+bX
+2#f
+x    a
+xd
+b
+2#c   c
+x a
+x  d
+b
+2#d b
+x     a
+xc
 b
 
-b2#ax  dx  b
-b2#b  dx      axa
-b2# d - dx b cx a a
-b2#a   dx      /ax d
-b2# bx   dx   c
-b1Q d a2 b
-b2# a   ax  dx a
-b2 b  a3# ax bx  dx a
 b
-3# bx d
+2#a
+x  d
+x  b
+b
+2#b  d
+x      a
+xa
+b
+2# d - d
+x b c
+x a a
+b
+2#a   d
+x      /a
+x d
+b
+2# b
+x   d
+x   c
+b
+1Q d a
+2 b
+b
+2# a   a
+x  d
+x a
+b
+2 b  a
+3# a
+x b
+x  d
+x a
+b
+3# b
+x d
 2. a - a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    a
+2#  d
+x    a
 x      ///a
 b
 
@@ -5511,36 +9922,106 @@ b
 2  dc
 bQ
 bQ
-3# dxaxcxd
+3# d
+xa
+xc
+xd
 bX
-3#f   axdxcxdxfxd
-b3#c   cx fx ex fxcx e
+3#f   a
+xd
+xc
+xd
+xf
+xd
 b
-3#d  cxbxaxbxdxb
-b3#a dx dxa
-xbxdxa
-b3#b  axaxbxdxbxa
-b3# d   dx bx dxaxbx d
+3#c   c
+x f
+x e
+x f
+xc
+x e
+b
+3#d  c
+xb
+xa
+xb
+xd
+xb
+b
+3#a d
+x d
+xa
+xb
+xd
+xa
+b
+3#b  a
+xa
+xb
+xd
+xb
+xa
+b
+3# d   d
+x b
+x d
+xa
+xb
+x d
 b
 
-b3#a   dx dxaxbxax d
-b3# b dx ax bx dxax b
-b3# d ax b
-x dxax bx d
-b3# a c
-x  dx ax bx dxa
-b3# bd ax ax bx dxaxc
-b3#exf2.e -- a
+b
+3#a   d
+x d
+xa
+xb
+xa
+x d
+b
+3# b d
+x a
+x b
+x d
+xa
+x b
+b
+3# d a
+x b
+x d
+xa
+x b
+x d
+b
+3# a c
+x  d
+x a
+x b
+x d
+xa
+b
+3# bd a
+x a
+x b
+x d
+xa
+xc
+b
+3#e
+xf
+2.e -- a
 4#c
 xe
 b
-2#fx    ax      ///a
+2#f
+x    a
+x      ///a
 b
 Yfcd
 b
 B
 
-{18b. Courante Heart - 7F8Ef9C AA16BB14A16B14/GB-Cfm 689, ff. 62v-63r}BX
+{18b. Courante Heart - 7F8Ef9C AA16BB14A16B14/GB-Cfm 689, ff. 62v-63r}
+BX
 bX
 S3
 2a
@@ -5548,37 +10029,71 @@ b
 2.abd a
 3c
 2a
-b2#da - axce- cx  d
+b
+2#da - a
+xce- c
+x  d
 b
 2.aac- a
-3# d.x bx a.
+3# d.
+x b
+x a.
 b
-2# b- ax  dx db c
-b2#a b dx  dxc- a
-b2#da cx    dxa d
-b2#c daxeax   c
-b2#ffddx dx  f
+2# b- a
+x  d
+x db c
+b
+2#a b d
+x  d
+xc- a
+b
+2#da c
+x    d
+xa d
+b
+2#c da
+xea
+x   c
+b
+2#ffdd
+x d
+x  f
 b
 
-b2# fg hxfxe-f
 b
-2#fg hx fxh i
+2# fg h
+xf
+xe-f
 b
-2#i- hx gxh- f
-b2#f  d&{x fxfd}
+2#fg h
+x f
+xh i
+b
+2#i- h
+x g
+xh- f
+b
+2#f  d&{
+x f
+xfd}
 b
 2.da c
 3c
 2a - a
-b2#abdx    c
-3# ex  d
 b
-2#ax     a
+2#abd
+x    c
+3# e
+x  d
+b
+2#a
+x     a
 x   c
 bX
 1aac
 bQ
-bQ2a
+bQ
+2a
 b
 2.abd
 3c
@@ -5586,95 +10101,210 @@ b
 b
 
 b
-2#da cxcefx  d
-b2#a-cx ax d
-b2# bdx  bx d d
+2#da c
+xcef
+x  d
 b
-2#a -cx  dxc -a
-b2#da cx    dxa b
-b2#c dax d- cxe
-b2#f g ax     dx  d- b
-b2#aa - axc  -  axe -- a
-b2#ff  ax      //axh
+2#a-c
+x a
+x d
+b
+2# bd
+x  b
+x d d
+b
+2#a -c
+x  d
+xc -a
+b
+2#da c
+x    d
+xa b
+b
+2#c da
+x d- c
+xe
+b
+2#f g a
+x     d
+x  d- b
+b
+2#aa - a
+xc  -  a
+xe -- a
+b
+2#ff  a
+x      //a
+xh
 b
 
-b2#if - fx hxh-i- h
-b2#ff  dxhxfg- f
-b2#da cxc-axa b
-b2  d
-2. e-ec
-4# cx e
 b
-2# fx     ax   c
+2#if - f
+x h
+xh-i- h
+b
+2#ff  d
+xh
+xfg- f
+b
+2#da c
+xc-a
+xa b
+b
+2  d
+2. e-ec
+4# c
+x e
+b
+2# f
+x     a
+x   c
 bX
 2.aac
 bQ
 bQ
-3#   ax    dx    c
+3#   a
+x    d
+x    c
 b
-2#ffg  fx   hx i
-b2 ef c
-3#cx    ax     dx     c
+2#ffg  f
+x   h
+x i
+b
+2 ef c
+3#c
+x    a
+x     d
+x     c
 b
 
 b
 2da - a
-3#   cxcxax d
+3#   c
+xc
+xa
+x d
 b
 2ab- d
-3#  dx  bx   dx   c
+3#  d
+x  b
+x   d
+x   c
 b
 2bdd - a
-3#   axax dx b
+3#   a
+xa
+x d
+x b
 b
 2 d - d
-3#  bx   dx   cx   a
+3#  b
+x   d
+x   c
+x   a
 b
 2abb - /a
-3#    dx dx bx a
+3#    d
+x d
+x b
+x a
 b
 2 bd- b
-3#   dx  bx   dx   c
+3#   d
+x  b
+x   d
+x   c
 b
 2 da - a
-3#   ax bx ax  d
+3#   a
+x b
+x a
+x  d
 b
 
 b
 2 ac- a
-3#   cx   ax    dx    c
+3#   c
+x   a
+x    d
+x    c
 b
 2 bd - //a
-3#    ax ax  dx  b
+3#    a
+x a
+x  d
+x  b
 b
-3#  d - ax    d2.  c ca
-4#  ax  c
+3#  d - a
+x    d
+2.  c ca
+4#  a
+x  c
 b
-2#  d ax   cx      //a
-bX2  dc
+2#  d a
+x   c
+x      //a
+bX
+2  dc
 bQ
 bQ
-2#cxe
+2#c
+xe
 b
-2#fb  ax  dx   c
+2#fb  a
+x  d
+x   c
 b
-2#cax    cx   b
-b2#da cx     ax   a
-b2#a dx     fx    e
+2#ca
+x    c
+x   b
+b
+2#da c
+x     a
+x   a
+b
+2#a d
+x     f
+x    e
 b
 
-b2#b dax      ax    d
-b2# dbx     dx    c
 b
-2#a b dx      /ax    c
-b2# bddx     bx    a
-b2# ddd- ax    fx    a
-b2#  fcx      cx     e
-b2# bdcx    ax  dd
-b2      a2.  c ca
-4#  ax  c
+2#b da
+x      a
+x    d
 b
-2#  d ax   cx      //a
+2# db
+x     d
+x    c
+b
+2#a b d
+x      /a
+x    c
+b
+2# bdd
+x     b
+x    a
+b
+2# ddd- a
+x    f
+x    a
+b
+2#  fc
+x      c
+x     e
+b
+2# bdc
+x    a
+x  dd
+b
+2      a
+2.  c ca
+4#  a
+x  c
+b
+2#  d a
+x   c
+x      //a
 b
 
 b
@@ -5683,64 +10313,210 @@ bbX
 2a
 b
 2.abd a
-3#cxaxc
-b3#da - ax cxcex    cx  fx  d
-b3#ax  cx     ax dx bx a
-b3# b
-x    ax  dx    cx dx  b
-b3#ax    dx  bx  dxcx   a
-b3#dx   cx   ax    dxax d
-b3#cx   axex   cx   ax   c
+3#c
+xa
+xc
+b
+3#da - a
+x c
+xce
+x    c
+x  f
+x  d
+b
+3#a
+x  c
+x     a
+x d
+x b
+x a
+b
+3# b
+x    a
+x  d
+x    c
+x d
+x  b
+b
+3#a
+x    d
+x  b
+x  d
+xc
+x   a
+b
+3#d
+x   c
+x   a
+x    d
+xa
+x d
+b
+3#c
+x   a
+xe
+x   c
+x   a
+x   c
 b
 
 b
-3#f  dx fx dxfx  dx  f
-b3# f  hx  gxfx  ixe fx f
-bQ3#fx   hx gx fxh ix g
-b3#ifx   hx gx   fxhx    h
-b3#f  dx    fxhx     axaxf
-b3#d- cx  ax  bxcxax  d
+3#f  d
+x f
+x d
+xf
+x  d
+x  f
 b
-3#cxa2. e- c
-4# cx e
+3# f  h
+x  g
+xf
+x  i
+xe f
+x f
+bQ
+3#f
+x   h
+x g
+x f
+xh i
+x g
+b
+3#if
+x   h
+x g
+x   f
+xh
+x    h
+b
+3#f  d
+x    f
+xh
+x     a
+xa
+xf
+b
+3#d- c
+x  a
+x  b
+xc
+xa
+x  d
+b
+3#c
+xa
+2. e- c
+4# c
+x e
 b
 
 b
-2# fx     ax   c
-bX2aac
+2# f
+x     a
+x   c
+bX
+2aac
 bQ
 bQ
-2#cxe
-b3#fx    ax bx  dx   cx  b
-bQ3#cx    cx ax    ex   bx  a
-b3#dx   cx     ax   ax   cx   a
-b3#ax    ex  dx   ax   cx    e
+2#c
+xe
+b
+3#f
+x    a
+x b
+x  d
+x   c
+x  b
+bQ
+3#c
+x    c
+x a
+x    e
+x   b
+x  a
+b
+3#d
+x   c
+x     a
+x   a
+x   c
+x   a
+b
+3#a
+x    e
+x  d
+x   a
+x   c
+x    e
 b
 3#b
-x   ax     ax   cx   ax    d
-b3# dx    cx     dx     bx     ax      a
+x   a
+x     a
+x   c
+x   a
+x    d
+b
+3# d
+x    c
+x     d
+x     b
+x     a
+x      a
 b
 
-b3#ax      /ax    dx    cx    ax     d
 b
-3#bx     bx  dx     dx     bx     a
+3#a
+x      /a
+x    d
+x    c
+x    a
+x     d
+b
+3#b
+x     b
+x  d
+x     d
+x     b
+x     a
 bQ
-3#      ax dx  dx bx ax  d
-b3#  cx     ax   cx   ax    dx    c
+3#      a
+x d
+x  d
+x b
+x a
+x  d
 b
-3# bx    ax  dx   dx dx      a
-b3#  dx b
+3#  c
+x     a
+x   c
+x   a
+x    d
+x    c
+b
+3# b
+x    a
+x  d
+x   d
+x d
+x      a
+b
+3#  d
+x b
 2. a - a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      //a
+2#  d
+x    a
+x      //a
 b
 Y  dc
 b
 B
 
 p
-{18c. Courante - 7F10C A15A16BB14/D-Hs ND VI 3238, pp. 84-85}BX
+{18c. Courante - 7F10C A15A16BB14/D-Hs ND VI 3238, pp. 84-85}
+BX
 bX
 S3
 2a
@@ -5748,26 +10524,53 @@ b
 2.abd-a
 3c
 2a
-b2#da - axcaa c
-3#axc
+b
+2#da - a
+xcaa c
+3#a
+xc
 b
 2a --
-3#     ax d.x bx a.
+3#     a
+x d.
+x b
+x a.
 b
 2. b  a
-4# ax b2Q d- c
+4# a
+x b
+2Q d- c
 b
-2#a   dxc- a
-3#axc
+2#a   d
+xc- a
+3#a
+xc
 b
-2#d- cxcxa - d
-b2#cddax a- cxe
-b2#ffgxh - axf
+2#d- c
+xc
+xa - d
+b
+2#cdda
+x a- c
+xe
+b
+2#ffg
+xh - a
+xf
 b
 
-b2#eff  axcxe
-b2#ffg ax   hxff
-b2#ix   hx  i
+b
+2#eff  a
+xc
+xe
+b
+2#ffg a
+x   h
+xff
+b
+2#i
+x   h
+x  i
 b
 2.ffgh
 3h
@@ -5776,9 +10579,13 @@ b
 2.d  c
 3c
 2a -- d
-b2#    ax e- c
-3# cx e
-b2# f --
+b
+2#    a
+x e- c
+3# c
+x e
+b
+2# f --
 x     a
 x   c
 bX
@@ -5787,99 +10594,281 @@ bQ
 bQ
 2a
 b
-3#  dx a.x bx d.xaxc.
+3#  d
+x a.
+x b
+x d.
+xa
+xc.
 b
 
 b
-2#d- cxcaa c
-3#axc
+2#d- c
+xcaa c
+3#a
+xc
 b
 2a
-3#     ax d.x bx a.
-b3#    ax bx ax bx d --x    c
-b3#    dxa --x   axc --xaxc
-b3#   cxdxcxdxa - dx  d
-b3#c- axax d- cxaxcxe
-b3#f - ax  cx  dx ax bx d
+3#     a
+x d.
+x b
+x a.
+b
+3#    a
+x b
+x a
+x b
+x d --
+x    c
+b
+3#    d
+xa --
+x   a
+xc --
+xa
+xc
+b
+3#   c
+xd
+xc
+xd
+xa - d
+x  d
+b
+3#c- a
+xa
+x d- c
+xa
+xc
+xe
+b
+3#f - a
+x  c
+x  d
+x a
+x b
+x d
 b
 
-b3#a -- axcxexfxhxe
-b3#f   ax   cx  ax  cx  dx a
-b3#   cax b --x     ex a --x   cx   a
-b3#    ax    cx    dx   ax   cx  a
-b3#  b- ax  dx  bx  ax   cx  a
-b3#  bx  d
+b
+3#a -- a
+xc
+xe
+xf
+xh
+xe
+b
+3#f   a
+x   c
+x  a
+x  c
+x  d
+x a
+b
+3#   ca
+x b --
+x     e
+x a --
+x   c
+x   a
+b
+3#    a
+x    c
+x    d
+x   a
+x   c
+x  a
+b
+3#  b- a
+x  d
+x  b
+x  a
+x   c
+x  a
+b
+3#  b
+x  d
 2  a c
-3#   cx  a
+3#   c
+x  a
 b
-2#   cx     ax    c
+2#   c
+x     a
+x    c
 b
 
-b2   c
+b
+2   c
 bQ
 bQ
 2#c
 xe
-bX2#f - ax  dx   c
-b2#c --x    cx   b
-b2#d- cx a - axc
-b2#ab- ax  d
-3# dxa
+bX
+2#f - a
+x  d
+x   c
 b
-2#bx  daxa
-b2# d- cx  b
-3# bx d
+2#c --
+x    c
+x   b
 b
-2#ax   cdx d
-b2# b dx  d
-3# a cx b
+2#d- c
+x a - a
+xc
+b
+2#ab- a
+x  d
+3# d
+xa
+b
+2#b
+x  da
+xa
+b
+2# d- c
+x  b
+3# b
+x d
+b
+2#a
+x   cd
+x d
+b
+2# b d
+x  d
+3# a c
+x b
 b
 
 b
-2# d-ax  dx b
-b2# accx  dx acc-a
-b2 bdca
-3#    cx a
+2# d-a
+x  d
+x b
+b
+2# acc
+x  d
+x acc-a
+b
+2 bdca
+3#    c
+x a
 2  d d
 b
-3# a ax  d
+3# a a
+x  d
 2  c ca
-3#  ax  c
+3#  a
+x  c
 b
-2#  dcax      ///a
-x    abX2  dc
+2#  dca
+x      ///a
+x    a
+bX
+2  dc
 bQ
-bQ2#cxe
+bQ
+2#c
+xe
 b
-3#f - ax   cx  dx ax  dx  b
-b
-
-b3#    cxcx ax  dx  bx  a
-b3#     axdx axcxax d
-b3#    a
-xax bx ax  dx  b
-b3#   axbx  dxax dx b
-b3#     dx dx ax bx dx a
-b3#    dxa --x    cx dx bx a
+3#f - a
+x   c
+x  d
+x a
+x  d
+x  b
 b
 
-b3#  ddx ax bx  dx a cx b
-b3#   ax dx  dx bx ax  d
-b3#  c  ax  dx ax   ax    dx    c
-b3# b  ax dxax  dxc  -  axe
 b
-3#fxh
+3#    c
+xc
+x a
+x  d
+x  b
+x  a
+b
+3#     a
+xd
+x a
+xc
+xa
+x d
+b
+3#    a
+xa
+x b
+x a
+x  d
+x  b
+b
+3#   a
+xb
+x  d
+xa
+x d
+x b
+b
+3#     d
+x d
+x a
+x b
+x d
+x a
+b
+3#    d
+xa --
+x    c
+x d
+x b
+x a
+b
+
+b
+3#  dd
+x a
+x b
+x  d
+x a c
+x b
+b
+3#   a
+x d
+x  d
+x b
+x a
+x  d
+b
+3#  c  a
+x  d
+x a
+x   a
+x    d
+x    c
+b
+3# b  a
+x d
+xa
+x  d
+xc  -  a
+xe
+b
+3#f
+xh
 2ea - a
-3#cxe
+3#c
+xe
 b
-2#fcd ax      ///ax    a
+2#fcd a
+x      ///a
+x    a
 b
-2  dcY    a
+2  dc
+Y    a
 b
 B
 
 { }
-{18d. Courente - 7F8Ef10C A16B14/CH-SO DA 111, f. 18v}BX
+{18d. Courente - 7F8Ef10C A16B14/CH-SO DA 111, f. 18v}
+BX
 bX
 S3
 2aac
@@ -5887,39 +10876,71 @@ b
 2#abd
 xc
 xa
-b2d  c1ca b
+b
+2d  c
+1ca b
 b
 2aabc
 3#     a
-x dx bx a
+x d
+x b
+x a
 b
 2 b  a
-3# ax b2 d  c
-b2#a   dx  dxc  a
-b2#d  cxabb dx  d
-b2.cdf c3f2e
-b2.f   a3     d2     c
+3# a
+x b
+2 d  c
+b
+2#a   d
+x  d
+xc  a
+b
+2#d  c
+xabb d
+x  d
+b
+2.cdf c
+3f
+2e
+b
+2.f   a
+3     d
+2     c
 b
 
-b2.ha g a3f2e  c
 b
-2#f   ax      ///a3#f  h
+2.ha g a
+3f
+2e  c
+b
+2#f   a
+x      ///a
+3#f  h
 xh
 b
-2i1hf g
-b2.ffgh3Qh2d  c
+2i
+1hf g
+b
+2.ffgh
+3Qh
+2d  c
 b
 2#c   c
 xd
 xa   d
-b2    a2. e  c
-4# cx e
 b
-2#afx     a
+2    a
+2. e  c
+4# c
+x e
+b
+2#af
+x     a
 x   cc
 b
 1aac
-bbX2a
+bbX
+2a
 b
 2#f
 x    a
@@ -5927,40 +10948,71 @@ xd
 b
 
 b
-2.ca  c3a2c
+2.ca  c
+3a
+2c
 b
 2#d  c
 x     a
 xc
-b2.a d3 d2a
-b2#bdd   ax   axa
 b
-2. dba d3 b2 d
-b2#abb dx      /ax d
-b2. b-d
+2.a d
+3 d
+2a
+b
+2#bdd   a
+x   a
+xa
+b
+2. dba d
+3 b
+2 d
+b
+2#abb d
+x      /a
+x d
+b
+2. b-d
 3 a
 2 b
-b2# dx    ax b
 b
-3# a cx  dx ax bx dxa
+2# d
+x    a
+x b
+b
+3# a c
+x  d
+x a
+x b
+x d
+xa
 b
 
 b
 -l "4 in"
 2 b  a
-3# ax bx  dx b
-b3# a ax  d
-2.  cc a
-4#  ax  c
+3# a
+x b
+x  d
+x b
 b
-2#  dx    ax      ///a
+3# a a
+x  d
+2.  cc a
+4#  a
+x  c
+b
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b
 B
 
 p
-{18e. Courante - 10C AA16BB14/GB-Eu Coll.2073, ff. 58v-59r}BX
+{18e. Courante - 10C AA16BB14/GB-Eu Coll.2073, ff. 58v-59r}
+BX
 bX
 S3
 2a
@@ -5968,33 +11020,56 @@ b
 2.a   a
 3c
 2a
-b2#d  cxf&+
+b
+2#d  c
+xf&+
 xc   c
 b
 2.aa   a
-3# d.x bx a.
+3# d.
+x b
+x a.
 b
 2# bd
-x    ax d  c
+x    a
+x d  c
 b
-2#abx    d
+2#ab
+x    d
 xc  a
 b
 2#d  c
-x    dxd
-b2.c  a3    d2    c
-b2.ffg a3h2f
+x    d
+xd
+b
+2.c  a
+3    d
+2    c
+b
+2.ffg a
+3h
+2f
 b
 
-b2   a2.e  c
-4#cxe
-b2#f&+x    ax      ///a
-b2#i  hx f.xh  f
+b
+2   a
+2.e  c
+4#c
+xe
+b
+2#f&+
+x    a
+x      ///a
+b
+2#i  h
+x f.
+xh  f
 b
 2#Qf  Qd
 x Qd
 x-Qh  Qf
-bQ2.d  c
+bQ
+2.d  c
 3c
 2a    d
 b
@@ -6002,19 +11077,25 @@ b
 2. e  c
 4# c
 x e
-b2# f&+x     a
+b
+2# f&+
+x     a
 x    c
-bX1aac
+bX
+1aac
 bb
 2a
 b
 3#a d
-x a.x bx d.
+x a.
+x b
+x d.
 xa
 xc.
 bQ
 
-bQ2d  c
+bQ
+2d  c
 3#f
 xd.
 2c   c
@@ -6024,90 +11105,176 @@ b
 x d.
 x b
 x a.
-b1 b  a2 d  c
-b1a   d2c  a
-b2.d  c3   a
+b
+1 b  a
+2 d  c
+b
+1a   d
+2c  a
+b
+2.d  c
+3   a
 2    d
-b2#c  ax    dxe   c
-b2.f&+   a3     d
+b
+2#c  a
+x    d
+xe   c
+b
+2.f&+   a
+3     d
 2     b
-b3#     ax  a.x  cx  d.x ax  c
+b
+3#     a
+x  a.
+x  c
+x  d.
+x a
+x  c
 b
 
-b2#  dx    ax      ///a
-b2#i  h
+b
+2#  d
+x    a
+x      ///a
+b
+2#i  h
 x f
 xh  f
-b2#f  d
+b
+2#f  d
 x d
 xh  f
-b2d  c
+b
+2d  c
 3#c
 xd.
 xa
 xd.
-b3#c   a
+b
+3#c   a
 xa
 x e
 xa
 xc
 x e
 b
-1aac  a2   c
+1aac  a
+2   c
 bX
-1aacbQbQ2-Qa
-b2.ffg a3h
+1aac
+bQ
+bQ
+2-Qa
+b
+2.ffg a
+3h
 2f
-b2.c   c3a2c
 b
-
-b2.d  c3c2d
-b2.a d3 d2a
-b2#bx   axa
-b2. db3 b2 a
-b2#abx    dx d
-b2. b d3 a2 b
-b2# dx   ax b
-b2. a c3  d2 a
-b2# b  ax    cx  d d
+2.c   c
+3a
+2c
 b
 
 b
-2   a2.  cc
-4#  ax  c
+2.d  c
+3c
+2d
 b
-2#  dx    a
+2.a d
+3 d
+2a
+b
+2#b
+x   a
+xa
+b
+2. db
+3 b
+2 a
+b
+2#ab
+x    d
+x d
+b
+2. b d
+3 a
+2 b
+b
+2# d
+x   a
+x b
+b
+2. a c
+3  d
+2 a
+b
+2# b  a
+x    c
+x  d d
+b
+
+b
+2   a
+2.  cc
+4#  a
+x  c
+b
+2#  d
+x    a
 x      ///a
 b
 1  dc
 bQ
 bQ
-2abX
+2a
+bX
 2.f  h
-3h  g2f  h
-b2.c   c3a
+3h  g
+2f  h
+b
+2.c   c
+3a
 2c
 b
-2.d  c3   a
+2.d  c
+3   a
 2   c
-b2.a   a3     d2    ab2.b  a3    d
+b
+2.a   a
+3     d
+2    a
+b
+2.b  a
+3    d
 2   a
 b
 
-b2. d f3   e
+b
+2. d f
+3   e
 2   f
-b2.a   d3    c
+b
+2.a   d
+3    c
 2    d
-b2. b d3   c
+b
+2. b d
+3   c
 2   d
-b2. d a3    d
+b
+2. d a
+3    d
 2   a
-b2. a c
+b
+2. a c
 3   a
 2   c
-b2. b  a3 a
+b
+2. b  a
+3 a
 2  d d
-b3# a a
+b
+3# a a
 x  d
 x  cc
 x  d
@@ -6124,7 +11291,8 @@ Y  d a
 b
 B
 
-{18f. Courante Dixiesme - 7F8Ef9DC10 AA16BB14/Ballard 1614, pp. 30-31}BX
+{18f. Courante Dixiesme - 7F8Ef9DC10 AA16BB14/Ballard 1614, pp. 30-31}
+BX
 bX
 S3
 2a.
@@ -6132,36 +11300,71 @@ b
 2.abd a
 3c.
 2a
-b2#da c axcaa cx    a
-b2af   e
-3#   c{x d.x bx a.}
+b
+2#da c a
+xcaa c
+x    a
+b
+2af   e
+3#   c{
+x d.
+x b
+x a.}
 b
 2. bdca
-4# ax b.
+4# a
+x b.
 2 d  c
-b2#a   dx bd axc.
-b2#da c {
-x  b.}xab  d
-b2#c dax d  c{xe.  }
-b2ffg a
-3#   h&{xh.
+b
+2#a   d
+x bd a
+xc.
+b
+2#da c {
+x  b.}
+xab  d
+b
+2#c da
+x d  c{
+xe.  }
+b
+2ffg a
+3#   h&{
+xh.
 2f }
 b
 
-b2#eff  axf gxe f
-b2#ffg ax   h{xh. }
 b
-2#ifxh  g {x  i.}
-b2ffgh
-3#     f&{xh.
+2#eff  a
+xf g
+xe f
+b
+2#ffg a
+x   h{
+xh. }
+b
+2#if
+xh  g {
+x  i.}
+b
+2ffgh
+3#     f&{
+xh.
 2f   }
-b2da   a
-3#     c{xc.   }
+b
+2da   a
+3#     c{
+xc.   }
 2a    d
 b
-3#c   axa.
-2# ea c{xa.  }
-b2#aacccax   cx    c
+3#c   a
+xa.
+2# ea c{
+xa.  }
+b
+2#aaccca
+x   c
+x    c
 bX
 1aac
 bQ
@@ -6170,88 +11373,280 @@ bQ
 b
 
 b
-3#    axa.x bx  d.xaxc.
-b3#     axd.x ax c.xc   c{x e. }
-b3#afx     ax   c{x d.x bx a.}
+3#    a
+xa.
+x b
+x  d.
+xa
+xc.
 b
-3#    ax bdx ax b.x    c{x d. }
-b3#    d{xa.  }x b  ax d.xaxc.
-b3#dx   c{
-x  bxb.  }x    d{xa.  }
-b3#   axc.x  dx    dx d  c{xe.  }
+3#     a
+xd.
+x a
+x c.
+xc   c{
+x e. }
+b
+3#af
+x     a
+x   c{
+x d.
+x b
+x a.}
+b
+3#    a
+x bd
+x a
+x b.
+x    c{
+x d. }
+b
+3#    d{
+xa.  }
+x b  a
+x d.
+xa
+xc.
+b
+3#d
+x   c{
+x  b
+xb.  }
+x    d{
+xa.  }
+b
+3#   a
+xc.
+x  d
+x    d
+x d  c{
+xe.  }
 b
 
-b3#    axf.x fx  g.x  fx   h.
-b3#     ax a.xe
-x    d.x   ax   c.
-b3#    axf.x   h{
-x i.xfxh. }
 b
-3#ix f.x   g{xh.x  ix f.}
-b3#   h{xf.x f }x  gx  fx   h.
-b3#   c&{x a.xd }xc dx ab{xa.}
-b3#  dx  b.
-2#a de{x e.}
-b2#af cx     ax   c
+3#    a
+xf.
+x f
+x  g.
+x  f
+x   h.
+b
+3#     a
+x a.
+xe
+x    d.
+x   a
+x   c.
+b
+3#    a
+xf.
+x   h{
+x i.
+xf
+xh. }
+b
+3#i
+x f.
+x   g{
+xh.
+x  i
+x f.}
+b
+3#   h{
+xf.
+x f }
+x  g
+x  f
+x   h.
+b
+3#   c&{
+x a.
+xd }
+xc d
+x ab{
+xa.}
+b
+3#  d
+x  b.
+2#a de{
+x e.}
+b
+2#af c
+x     a
+x   c
 b
 
-b2.aac{
+b
+2.aac{
 bQ
 bQ
-3#a.xcxe.}
+3#a.
+xc
+xe.}
 bX
-2#f   ax  d.x   c
-b2#cx    c{x   b}
-b2#da c ax   cx   a
-b2#af  e&{x  d.
-3# dxa. }
+2#f   a
+x  d.
+x   c
 b
-2#   axbddx    d
-b2#    c{x dba
-3# bx d. }
-b2#    d&{xabbx d.}
+2#c
+x    c{
+x   b}
+b
+2#da c a
+x   c
+x   a
+b
+2#af  e&{
+x  d.
+3# d
+xa. }
+b
+2#   a
+xbdd
+x    d
+b
+2#    c{
+x dba
+3# b
+x d. }
+b
+2#    d&{
+xabb
+x d.}
 b
 
-b2#     b&{x bdd}
-3# a   ax b.
-b2#      ax dfax bd
-b2# acc ax bdx ac
-b2 bdc  ///a
-3#      //ax a.
+b
+2#     b&{
+x bdd}
+3# a   a
+x b.
+b
+2#      a
+x dfa
+x bd
+b
+2# acc a
+x bd
+x ac
+b
+2 bdc  ///a
+3#      //a
+x a.
 2  d   /a
 b
-3# a    ax  d.
+3# a    a
+x  d.
 2.  ccca
-4#  ax  c.
+4#  a
+x  c.
 b
-2#  d ax      ///ax    a
+2#  d a
+x      ///a
+x    a
 bX
 2.  dc
 bQ
 bQ
-3#a.xcxe.
+3#a.
+xc
+xe.
 b
 
-b3#fx    ax  dx  b.x  ax   c.
-b3#    c{xc.x ax  d.}x  bx  a.
-b3#     axd.x ax   a.x    dx    c.
-b3#    axa.x bx  d.x dxa.
-b3#   axb.x  dx   c.x   ax    d.
-b3#    c&{x d.x  bx a.x bx d.}
-b3#ax    d&{x   cx d.x bx a.}
+b
+3#f
+x    a
+x  d
+x  b.
+x  a
+x   c.
+b
+3#    c{
+xc.
+x a
+x  d.}
+x  b
+x  a.
+b
+3#     a
+xd.
+x a
+x   a.
+x    d
+x    c.
+b
+3#    a
+xa.
+x b
+x  d.
+x d
+xa.
+b
+3#   a
+xb.
+x  d
+x   c.
+x   a
+x    d.
+b
+3#    c&{
+x d.
+x  b
+x a.
+x b
+x d.}
+b
+3#a
+x    d&{
+x   c
+x d.
+x b
+x a.}
 b
 
-b3# bx     b&{x   dx  d.}x a   ax b.
-b3#      ax dx   ax  f.x  d {x b.}
-b3#     ax a.x  cx   c.x  dx a.
-b3 b  a
-4#    cx    d.4#   ax   c.x  ax  b.4#  dx a.x bx d.
-b4#axc.
-xexf.
+b
+3# b
+x     b&{
+x   d
+x  d.}
+x a   a
+x b.
+b
+3#      a
+x d
+x   a
+x  f.
+x  d {
+x b.}
+b
+3#     a
+x a.
+x  c
+x   c.
+x  d
+x a.
+b
+3 b  a
+4#    c
+x    d.
+4#   a
+x   c.
+x  a
+x  b.
+4#  d
+x a.
+x b
+x d.
+b
+4#a
+xc.
+xe
+xf.
 2.ha   a
-4#fxh.
+4#f
+xh.
 b
-2#f   ax      ///a
+2#f   a
+x      ///a
 x    a
 b
 Yffhh
@@ -6268,7 +11663,8 @@ b
 2. a  c
 3 c
 2 a
-b2 d
+b
+2 d
 1 ca b
 b
 1. aa c
@@ -6278,7 +11674,10 @@ b
 b
 1 a   d
 2 c  a
-b2# da cx  cx d
+b
+2# da c
+x  c
+x d
 b
 1 c  a
 2 da c
@@ -6294,25 +11693,44 @@ b
 b
 
 b
-1da c2c  a
+1da c
+2c  a
 b
 2.a   d
-3c2a
+3c
+2a
 b
 2. da c
 3 c
 2 a   d
-b2     a1  e  c
-b1. aabc
-bb
-2#aaccx     ax d
-b2# cx    ax  d
-b2# dda
-x      ax c
-bQ2# ax     dx  b
-b2# bx    dx a
 b
-2.  d   a3 a
+2     a
+1  e  c
+b
+1. aabc
+bb
+2#aacc
+x     a
+x d
+b
+2# c
+x    a
+x  d
+b
+2# dda
+x      a
+x c
+bQ
+2# a
+x     d
+x  b
+b
+2# b
+x    d
+x a
+b
+2.  d   a
+3 a
 2  d
 b
 
@@ -6327,20 +11745,57 @@ b
 b
 1caa c
 2a    e
-b2    a
+b
+2    a
 1 ea c
-b1aac  a
+b
+1aac  a
 2   c
 b
 bQ
-3#a  cx dxaxcxax d
-b3# c  ax ax cx dxax c
-b3# d ax cx dxax dx c
+3#a  c
+x d
+xa
+xc
+xa
+x d
+b
+3# c  a
+x a
+x c
+x d
+xa
+x c
+b
+3# d a
+x c
+x d
+xa
+x d
+x c
 b
 
-b3# a   dx  dx ax bx dx a
-b3# b  dx ax bx dx bx a
-b3#  d   ax  bx  dx ax bx  d
+b
+3# a   d
+x  d
+x a
+x b
+x d
+x a
+b
+3# b  d
+x a
+x b
+x d
+x b
+x a
+b
+3#  d   a
+x  b
+x  d
+x a
+x b
+x  d
 b
 2. a   d
 3 b
@@ -6349,18 +11804,23 @@ b
 2.  d   a
 3 a
 2  b  a
-b1caa c2a    e
-b2    a
+b
+1caa c
+2a    e
+b
+2    a
 1 ea c
 b
-1aac  a2   c
+1aac  a
+2   c
 b
 Yaacc a
 b
 B
 
 p
-{18h. Courant - 7F A15B11B12/D-Dl Ms. 297, p. 83}BX
+{18h. Courant - 7F A15B11B12/D-Dl Ms. 297, p. 83}
+BX
 bX
 S3
 2 a
@@ -6368,7 +11828,8 @@ b
 2. a- c
 3 c
 2 a
-b2 d
+b
+2 d
 1 ca b
 b
 1. aa c
@@ -6378,7 +11839,10 @@ b
 b
 1 a - d
 2 c- a
-b2# da-cx  cx d
+b
+2# da-c
+x  c
+x d
 b
 1 c- a
 2 da c
@@ -6394,25 +11858,44 @@ b
 b
 
 b
-1da c2c- a
+1da c
+2c- a
 bQ
 2.a - d
-3c2a
+3c
+2a
 b
 2. da c
 3 c
 2 a - d
-bQ2     a1  e- c
-b1@ aabc
-bb
-2#aaccx     ax d
-b2# cx    ax  d
-b2# dda
-x      ax c
-bQ2# ax     dx  b
-b2# bx    dx a
+bQ
+2     a
+1  e- c
 b
-2.  d   a3 a
+1@ aabc
+bb
+2#aacc
+x     a
+x d
+b
+2# c
+x    a
+x  d
+b
+2# dda
+x      a
+x c
+bQ
+2# a
+x     d
+x  b
+b
+2# b
+x    d
+x a
+b
+2.  d   a
+3 a
 2  d
 b
 
@@ -6427,20 +11910,57 @@ b
 b
 1caa-c
 2a -- e
-bQ2    a
+bQ
+2    a
 1 ea-c
-b1aac  a
+b
+1aac  a
 2   c
 bQ
 bQ
-3#aaccx dxaxcxax d
-b3# c  ax ax cx dxax c
-b3# d ax cx dxax dx c
+3#aacc
+x d
+xa
+xc
+xa
+x d
+b
+3# c  a
+x a
+x c
+x d
+xa
+x c
+b
+3# d a
+x c
+x d
+xa
+x d
+x c
 b
 
-b3# a - dx  dx ax bx dx a
-b3# b- dx ax bx dx bx a
-b3#  d - ax  bx  dx ax bx  d
+b
+3# a - d
+x  d
+x a
+x b
+x d
+x a
+b
+3# b- d
+x a
+x b
+x d
+x b
+x a
+b
+3#  d - a
+x  b
+x  d
+x a
+x b
+x  d
 b
 2. a - d
 3 b
@@ -6449,18 +11969,23 @@ b
 2.  d - a
 3 a
 2  b- a
-b1caa c2a -- e
-b2    a
+b
+1caa c
+2a -- e
+b
+2    a
 1 ea-c
 b
-1aac  a2   c
+1aac  a
+2   c
 b
 Yaac
 b
 B
 
 { }
-{18i. Curant - 7F A15B11B12/D-Lr 2000, p. 47}BX
+{18i. Curant - 7F A15B11B12/D-Lr 2000, p. 47}
+BX
 bX
 S3
 2 a
@@ -6468,7 +11993,8 @@ b
 2. a  c
 3 c
 2 a
-b2 d
+b
+2 d
 1 ca b
 b
 1. aa c
@@ -6478,7 +12004,10 @@ b
 b
 1 a   d
 2 c  a
-b2# da cx  cx d
+b
+2# da c
+x  c
+x d
 b
 1 c  a
 2 da c
@@ -6494,25 +12023,44 @@ b
 b
 
 b
-1da c2c  a
+1da c
+2c  a
 b
 2.a   d
-3c2a
+3c
+2a
 b
 2. d  c
 3 c
 2 a   d
-b2     a1 ce  c
-b1. aabc
-bb
-2#aaccx     ax d
-b2# cx    ax  d
-b2# ddQa
-x      ax c
-b2# ax     dx  b
-b2# bx    dx a
 b
-2.  d   a3 a
+2     a
+1 ce  c
+b
+1. aabc
+bb
+2#aacc
+x     a
+x d
+b
+2# c
+x    a
+x  d
+b
+2# ddQa
+x      a
+x c
+b
+2# a
+x     d
+x  b
+b
+2# b
+x    d
+x a
+b
+2.  d   a
+3 a
 2  d
 b
 
@@ -6527,20 +12075,57 @@ b
 b
 1ca  c
 2a    e
-b2    a
+b
+2    a
 1 ea c
-b1aacc a
+b
+1aacc a
 2   c
 b
 bQ
-3#a  cx dxaxcxax d
-b3# c  ax ax cx dxax c
-b3# d ax cx dxax dx c
+3#a  c
+x d
+xa
+xc
+xa
+x d
+b
+3# c  a
+x a
+x c
+x d
+xa
+x c
+b
+3# d a
+x c
+x d
+xa
+x d
+x c
 b
 
-b3# a   dx  dx ax bx dx a
-b3# b  dx ax bx dx bx a
-b3#  d   ax  bx  dx ax bx  d
+b
+3# a   d
+x  d
+x a
+x b
+x d
+x a
+b
+3# b  d
+x a
+x b
+x d
+x b
+x a
+b
+3#  d   a
+x  b
+x  d
+x a
+x b
+x  d
 b
 2. a   d
 3 b
@@ -6549,11 +12134,15 @@ b
 2#  d   a
 x a
 x  b  a
-b1caa c2a    e
-b2    a
+b
+1caa c
+2a    e
+b
+2    a
 1 ea c
 b
-1aac  a2   c
+1aac  a
+2   c
 b
 Yaacc a
 b
@@ -6569,9 +12158,11 @@ bQ
 2.ddef
 3f.
 2d
-bQ2bdda
+bQ
+2bdda
 1 e  d
-bQ1 dedb
+bQ
+1 dedb
 2 bdd
 b
 1  ef d
@@ -6601,8 +12192,10 @@ bQ
 bQ
 1 e  d
 2 d a
-bQ2#   b
-xdx b.
+bQ
+2#   b
+xd
+x b.
 bQ
 2.cdda
 3d.
@@ -6619,8 +12212,12 @@ bQ
 2.a   a
 3 d.
 2 c c
-bX2 d a
-3#  dx  b.x  ax   c.
+bX
+2 d a
+3#  d
+x  b.
+x  a
+x   c.
 bQ
 
 bQ
@@ -6649,7 +12246,8 @@ bQ
 2@  eb
 3Q   a
 2Q    d
-bQ2 b.
+bQ
+2 b.
 1 d  c
 bQ
 2. dff
@@ -6677,17 +12275,26 @@ bQ
 2@   a
 3Q    d
 2Q  da
-bQ2    d
+bQ
+2    d
 1 d  b
 b
 2.a   a
 3c.
 2d    d
 bQ
-3#f  axd.xcxd.xfxc.
+3#f  a
+xd.
+xc
+xd.
+xf
+xc.
 bQ
 2dab  d
-3# dx b.x ax  d.
+3# d
+x b.
+x a
+x  d.
 b
 Y  b
 b
@@ -6707,21 +12314,39 @@ b
 2acd a
 b
 2. dda  a
-3# bx  ex  d
-2#  ex     dx b  a
+3# b
+x  e
+x  d
+2#  e
+x     d
+x b  a
 b
 1 d  b
-2a   d2#b  ax    bxbd a
-b2#a   dx    bxc   a
+2a   d
+2#b  a
+x    b
+xbd a
+b
+2#a   d
+x    b
+xc   a
 2.dde  d
 3f
 2d
-b2d da
-3#cxa
-2c2#dx     dxd
+b
+2d da
+3#c
+xa
+2c
+2#d
+x     d
+xd
 b
 
-b2#g  fx dxf  d
+b
+2#g  f
+x d
+xf  d
 2.d  b
 3 d
 2 b
@@ -6730,10 +12355,16 @@ b
 3a
 2 d   b
 2     d
-3# c  ax dxax c
+3# c  a
+x d
+xa
+x c
 b
 2 dda  a
-3#  dx  bx  ax   c
+3#  d
+x  b
+x  a
+x   c
 1Q   a
 bbX
 2 d
@@ -6753,26 +12384,42 @@ b
 2 df
 b
 
-b2# egx    dx d
+b
+2# eg
+x    d
+x d
 2. bdd
 3  e
 2  d
-b2# edx    bx b
+b
+2# ed
+x    b
+x b
 2.  eb
 3  d
 2  e
-b2# bx    dx  e
+b
+2# b
+x    d
+x  e
 2.  da
 3  b
 2  d
 b
 2.  e  d
 3  d a
-2  b b2    d
-3#  aax  bx  dx  a
+2  b b
+2    d
+3#  aa
+x  b
+x  d
+x  a
 b
 2 aba d
-3# dx bx ax  d
+3# d
+x b
+x a
+x  d
 Y  b
 b
 B
@@ -7140,33 +12787,52 @@ Y bbc
 b
 B
 
-{21a. Courante Gothier - 7F8Ef10Bf/CZ-Pnm G.IV.18, f. 27r}BX
+{21a. Courante Gothier - 7F8Ef10Bf/CZ-Pnm G.IV.18, f. 27r}
+BX
 bX
 S3
 2  b
-b2  bcd
-3#      /ax  d
+b
+2  bcd
+3#      /a
+x  d
 2  b
-b2#   cx    dxa
-b2a   d
-3#      /axb
+b
+2#   c
+x    d
+xa
+b
+2a   d
+3#      /a
+xb
 2a
-b2#  bx dx    d
+b
+2#  b
+x d
+x    d
 b
 1.bbd  b
 b
 2.a   d
-3#dxbxa
+3#d
+xb
+xa
 b
 2. db  d
-3# ax bx d
+3# a
+x b
+x d
 b
-2ab  d2. d   d
-4#ax d
+2ab  d
+2. d   d
+4#a
+x d
 b
 
 b
-2# bx    dx      /a
+2# b
+x    d
+x      /a
 b
 1 bbc
 bbX
@@ -7176,66 +12842,111 @@ b
 2 d  c
 b
 2. b  a
-3# dx a   dx b
+3# d
+x a   d
+x b
 b
-2#  dx     bx   d
+2#  d
+x     b
+x   d
 b
 1 bd
 2 d
 b
 2. dd   a
-3# bx ax  d
+3# b
+x a
+x  d
 b
 2 ab  d
 2.  da  a
-4# ax  d
+4# a
+x  d
 b
 
 b
-2#  bx     dx      ///a
-b2#  dx     bx   a
-b2#     ax  b cx    d
-b2#      ax   dax    c
-b2#      /ax   cd
-3#   a bx   c
-b3#   dx   c
-2.   a d
-4#    dx   a
+2#  b
+x     d
+x      ///a
 b
-2#    dx      /ax    d
+2#  d
+x     b
+x   a
+b
+2#     a
+x  b c
+x    d
+b
+2#      a
+x   da
+x    c
+b
+2#      /a
+x   cd
+3#   a b
+x   c
+b
+3#   d
+x   c
+2.   a d
+4#    d
+x   a
+b
+2#    d
+x      /a
+x    d
 b
 Y bbc
 b
 B
 
 { }
-{21b. Courante Gothier - 7F8Ef10Bf/GB-Eu Coll.2073, f. 273r}BX
+{21b. Courante Gothier - 7F8Ef10Bf/GB-Eu Coll.2073, f. 273r}
+BX
 bX
 S3
 2  b
-b2  bcd
-3#      /ax  d
+b
+2  bcd
+3#      /a
+x  d
 2  b
-b2#   cx    dxa
-b2ab  d
-3#      /axb
+b
+2#   c
+x    d
+xa
+b
+2ab  d
+3#      /a
+xb
 2a
-b2#  bxdx    d
+b
+2#  b
+xd
+x    d
 b
 1.bbd  b
 b
 2.a   d
-3#dxbxa
+3#d
+xb
+xa
 b
 2. db  d
-3# ax bx d
+3# a
+x b
+x d
 b
-2a   d2. d   d
-4#ax d
+2a   d
+2. d   d
+4#a
+x d
 b
 
 b
-2# bx    dx      /a
+2# b
+x    d
+x      /a
 b
 1 bbc
 bbX
@@ -7245,98 +12956,186 @@ b
 2 d  c
 b
 2. b  a
-3# dx a   dx b
+3# d
+x a   d
+x b
 b
-2#  dx     bx   d
+2#  d
+x     b
+x   d
 b
 1 bd
 2 d
 b
 2. dd   a
-3# bx ax  d
+3# b
+x a
+x  d
 b
 2 ab  d
 2.  d   a
-4# ax  d
+4# a
+x  d
 b
 
 b
-2#  bx     dx      ///a
-b2#  dx     bx   a
-b2#     ax  b cx    d
-b2#      ax   dax    c
-b2#      /ax   cd
-3#   a bx   c
-b3#   dx   c
-2.   a d
-4#    dx   a
+2#  b
+x     d
+x      ///a
 b
-2#    dx      /ax    d
+2#  d
+x     b
+x   a
+b
+2#     a
+x  b c
+x    d
+b
+2#      a
+x   da
+x    c
+b
+2#      /a
+x   cd
+3#   a b
+x   c
+b
+3#   d
+x   c
+2.   a d
+4#    d
+x   a
+b
+2#    d
+x      /a
+x    d
 b
 Y bbc
 b
 B
-{21c. Cor: - 7F8Ef/D-Ngm 33748 I, f. 44v}BX
+
+{21c. Cor: - 7F8Ef/D-Ngm 33748 I, f. 44v}
+BX
 bX
 S3
 2  b
-b2  bcd
-3#      /ax  d
+b
+2  bcd
+3#      /a
+x  d
 2  b
-b2#   cx    dxa
-b2abb d
-3#      /axd
+b
+2#   c
+x    d
+xa
+b
+2abb d
+3#      /a
+xd
 2a
-b2# b cxdx    d
+b
+2# b c
+xd
+x    d
 b
 1.bbdd b
 b
 2#abb d
-xd3#bxa
+xd
+3#b
+xa
 b
 2. dba d
-3# ax b  ax d
+3# a
+x b  a
+x d
 b
-2#a   dx db
+2#a   d
+x db
 x     d
 b
 
 b
-2# bx      /a
-x    db
+2# b
+x      /a
+x    d
+b
 1 bbc
 bQ
 bQ
 2  b
 bX
 2  bcd
-3#      /ax  dx  bx   d
+3#      /a
+x  d
+x  b
+x   d
 b
-2#   cx    dxa
-b2abb d
-3#      /axbxax d
-b3# b  dx dxaxbxdxa
-b3#b    bx  bx  dx ax bx d
-b3#a   dx   ax   cx   dx  bx  d
+2#   c
+x    d
+xa
+b
+2abb d
+3#      /a
+xb
+xa
+x d
+b
+3# b  d
+x d
+xa
+xb
+xd
+xa
+b
+3#b    b
+x  b
+x  d
+x a
+x b
+x d
+b
+3#a   d
+x   a
+x   c
+x   d
+x  b
+x  d
 b
 
-b3# a   dx bx dx ax b  ax d
 b
-2#a   dx dbx     d
-b2# bx      /ax    d
+3# a   d
+x b
+x d
+x a
+x b  a
+x d
+b
+2#a   d
+x db
+x     d
+b
+2# b
+x      /a
+x    d
 b
 1 bbc
 bXQ
-bXQ2a
+bXQ
+2a
 b
 2#abb d
 x    c
 x d
 b
 2. bdca
-3# dx a   dx b
+3# d
+x a   d
+x b
 b
-2#  dx     bx    d
+2#  d
+x     b
+x    d
 b
 2#  dd
 x abc a
@@ -7345,124 +13144,264 @@ b
 
 b
 2. dda  a
-3# bx a - dx  d
+3# b
+x a - d
+x  d
 b
 2# a
-x    c3#  d d
+x    c
+3#  d d
 x   a
 b
-2#  bx     dx  ba
-b2#  dx     bx   Qa
-b2#     ax  b cx    d
-b2#      ax   dax    c
-b2#      /ax   cd
-3#   a bx   c
-b3#   dx   c
+2#  b
+x     d
+x  ba
+b
+2#  d
+x     b
+x   Qa
+b
+2#     a
+x  b c
+x    d
+b
+2#      a
+x   da
+x    c
+b
+2#      /a
+x   cd
+3#   a b
+x   c
+b
+3#   d
+x   c
 2#   a
 x     d
 b
 
 b
-2#      /ax    dx   c
+2#      /a
+x    d
+x   c
 b
 1 bbc
 bXQ
 bXQ
 2a
-b2abb d
-3#    cx dxax d
-b3# b  ax ax bx dx a - dx b
 b
-2#  dx     bx    d
-b2  dd
-3#  b  ax  dx ax b
-b3# dx      ax   ax bx a   dx b
-b3# dx    cx    dx  dx   Qax a
+2abb d
+3#    c
+x d
+xa
+x d
+b
+3# b  a
+x a
+x b
+x d
+x a - d
+x b
+b
+2#  d
+x     b
+x    d
+b
+2  dd
+3#  b  a
+x  d
+x a
+x b
+b
+3# d
+x      a
+x   a
+x b
+x a   d
+x b
+b
+3# d
+x    c
+x    d
+x  d
+x   Qa
+x a
 b
 
 b
-2#  bx     dx  ba
+2#  b
+x     d
+x  ba
 b
-3#  dx     bx   dx ax bx d
-b3#     axax  bxbxdxa
-b3#      axbx axdxbxd
+3#  d
+x     b
+x   d
+x a
+x b
+x d
 b
-3#ax    dx   cx dx b - bx a
-b3# b  ax d
+3#     a
+xa
+x  b
+xb
+xd
+xa
+b
+3#      a
+xb
+x a
+xd
+xb
+xd
+b
+3#a
+x    d
+x   c
+x d
+x b - b
+x a
+b
+3# b  a
+x d
 2. a a d
-4#  dx a
+4#  d
+x a
 b
-2# bx      /ax    d
+2# b
+x      /a
+x    d
 b
 Y bbc
 b
 B
 
-p{21d. Courante de la Reyne. Huitiesme - 7F8Ef/Ballard 1611, pp. 50-51}BX
+p
+{21d. Courante de la Reyne. Huitiesme - 7F8Ef/Ballard 1611, pp. 50-51}
+BX
 bX
 S3
 2  b.
-b2  bcd
-3#      /ax  d.
+b
+2  bcd
+3#      /a
+x  d.
 2  b
-b2#   cx    d{xa.  }
-b2abb d
-3#      /axb.
+b
+2#   c
+x    d{
+xa.  }
+b
+2abb d
+3#      /a
+xb.
 2a
-b2# bbxd  cx    d
+b
+2# bb
+xd  c
+x    d
 b
 1.bbdd b
 b
 2abb d
-3#      /axdxb
+3#      /a
+xd
+xb
 xa
 b
 2. dba d{
-3# a.  }x b  ax d.
+3# a.  }
+x b  a
+x d.
 b
-2#a   dx db
+2#a   d
+x db
 x     d
 b
 
 b
-2# b  dx      /a
-x    db
+2# b  d
+x      /a
+x    d
+b
 1 bbc
 bXQ
 bXQ
 2  b
 b
 2  bcd
-3#      /ax  d.x  bx   d.
+3#      /a
+x  d.
+x  b
+x   d.
 b
-2   c3#  dx a.
+2   c
+3#  d
+x a.
 x b
 x d.
-b2a   d
-3#      /axb.xax d.
-b3# b  d&{x d.xaxb.xdxa. }
-b3#b    b&{x  b.x  dx a.x bx d. }
-b3#a   dx   a.x   cx   d.x  bx  d.
+b
+2a   d
+3#      /a
+xb.
+xa
+x d.
+b
+3# b  d&{
+x d.
+xa
+xb.
+xd
+xa. }
+b
+3#b    b&{
+x  b.
+x  d
+x a.
+x b
+x d. }
+b
+3#a   d
+x   a.
+x   c
+x   d.
+x  b
+x  d.
 b
 
-b3# a   d&{x b.x dx a. }x b  ax d.
 b
-2#a   dx db3#     d{
+3# a   d&{
+x b.
+x d
+x a. }
+x b  a
+x d.
+b
+2#a   d
+x db
+3#     d{
 xa.   }
-b2# b  dx      /ax    d{
+b
+2# b  d
+x      /a
+x    d{
 b
 1 bbc}
 bXQ
-bXQ2a
+bXQ
+2a
 b
 3#abb d
 x    c{
 x d. }
 b
 2. bdca
-3# d.x a   d{x b.  }
+3# d.
+x a   d{
+x b.  }
 b
-2#  dx     b&{x   d
+2#  d
+x     b&{
+x   d
 b
 2#  dd}
 x abc a
@@ -7472,54 +13411,132 @@ b
 b
 2 dda  a
 3#   a
-x b.x a   d{x  d. }
+x b.
+x a   d{
+x  d. }
 b
-2 a2.  da  a
+2 a
+2.  da  a
 3 a.
 b
-2#  bx     d{x  bac}
-b2#  dx     b{x    a}
-b2#     ax  b cx    d
-b2#      ax   dax    c.
-b2#      /ax   cd
-3#   a b{x   c.}
-b3#   dx   c.
+2#  b
+x     d{
+x  bac}
+b
+2#  d
+x     b{
+x    a}
+b
+2#     a
+x  b c
+x    d
+b
+2#      a
+x   da
+x    c.
+b
+2#      /a
+x   cd
+3#   a b{
+x   c.}
+b
+3#   d
+x   c.
 2.   a d{
 4#    d
 x   a.}
 b
 
 b
-2#    dx      /ax    d{
+2#    d
+x      /a
+x    d{
 b
 1 bbc}
 bXQ
 bXQ
 2a
-b2abb d
-3#    c&{x d.xax d.}
-b3# b  ax a.x b cx d.x a   d{x b.  }
 b
-2#  dx     b{x    d
-b2  dd }
-3#  b  ax  d.x ax b.
-b3# dx      ax   ax b.x a   dx  d.
-b3# ax    c.x    d{x  d.}x   ax a.
+2abb d
+3#    c&{
+x d.
+xa
+x d.}
+b
+3# b  a
+x a.
+x b c
+x d.
+x a   d{
+x b.  }
+b
+2#  d
+x     b{
+x    d
+b
+2  dd }
+3#  b  a
+x  d.
+x a
+x b.
+b
+3# d
+x      a
+x   a
+x b.
+x a   d
+x  d.
+b
+3# a
+x    c.
+x    d{
+x  d.}
+x   a
+x a.
 b
 
 b
-2#  bx     d{x  ba }
+2#  b
+x     d{
+x  ba }
 b
-3#  dx     bx    ax    c.x    dx    a.
-b3#     ax  b.x    dx    c.x    d{x  d.}
-b3#      ax   d.x    cx    a.x    c{x  b.}
+3#  d
+x     b
+x    a
+x    c.
+x    d
+x    a.
 b
-3#      /ax   d.x   cx  b.x     b{x  d.}
-b3#   dx   c.
+3#     a
+x  b.
+x    d
+x    c.
+x    d{
+x  d.}
+b
+3#      a
+x   d.
+x    c
+x    a.
+x    c{
+x  b.}
+b
+3#      /a
+x   d.
+x   c
+x  b.
+x     b{
+x  d.}
+b
+3#   d
+x   c.
 2. a a d{
-4#  dx a. }
+4#  d
+x a. }
 b
-2# bx      /ax    d
+2# b
+x      /a
+x    d
 b
 Y bbc
 b
@@ -7533,40 +13550,75 @@ S3
 2d
 b
 2#dfQg d
-x      /axdfQg
-b2f- d
-2.h  f
-4#fxh
+x      /a
+xdfQg
 b
-2#i -x      /ax   f
+2f- d
+2.h  f
+4#f
+xh
+b
+2#i -
+x      /a
+x   f
 b
 1ifg
 2h  f
-b2#Qffghx   cxdb
+b
+2#Qffgh
+x   c
+xdb
 b
 2b dd
 3# a
-xd2ab- db
+xd
+2ab- d
+b
 2 d -
-3#     dx b.x ax  d.
+3#     d
+x b.
+x a
+x  d.
 b
 
 b
-2# Qa Qax  Qae- a
-3#   fx   e
+2# Qa Qa
+x  Qae- a
+3#   f
+x   e
 b
-2#   fx     Qdx  ff
-b2#  d- bx abc-ax b
-b2#   -  ax   dx d
-b2#a bxb dx df
-b2d -
-3#      /ax g.x fx d.
-b2 f2. df- d
+2#   f
+x     Qd
+x  ff
+b
+2#  d- b
+x abc-a
+x b
+b
+2#   -  a
+x   d
+x d
+b
+2#a b
+xb d
+x df
+b
+2d -
+3#      /a
+x g.
+x f
+x d.
+b
+2 f
+2. df- d
 4#  g
-x  fb
+x  f
+b
 
 b
-2#  Qgx      /ax    d
+2#  Qg
+x      /a
+x    d
 bQ
 1  gf
 2      /a
@@ -7582,13 +13634,17 @@ b
 3#    d
 x   c
 b
-1dfg -2    d
+1dfg -
+2    d
 b
-2#dfgxbbd- b
+2#dfg
+xbbd- b
 3#bbb - /a
 xa.
 b
-2#b -x     bx   d
+2#b -
+x     b
+x   d
 b
 
 b
@@ -7596,49 +13652,97 @@ b
 2   d
 b
 2.abd
-3# dxaxc.
+3# d
+xa
+xc.
 b
-2#d - cxcb- a3#axcb
-2#d -- dx a
+2#d - c
+xcb- a
+3#a
+xc
+b
+2#d -- d
+x a
 x   a
 b
 1  b
 2d
 b
-2#    dxabb -x    c
-b2#    axffgx  f
-b2#   axcdd -x    d
+2#    d
+xabb -
+x    c
+b
+2#    a
+xffg
+x  f
+b
+2#   a
+xcdd -
+x    d
 b
 
-b2#    cxddbxb
-b2#    dxabb -x    c
 b
-2#    ax bdcx  b
+2#    c
+xddb
+xb
 b
-2# Qd   Qcx  QdQax Qb
-bQ2#     Qdx QaQbQax     Qb
-b2#     Qax  Qbc
+2#    d
+xabb -
+x    c
+b
+2#    a
+x bdc
+x  b
+b
+2# Qd   Qc
+x  QdQa
 x Qb
-b2#      ax daax    db
-2#    cx dbax   d
+bQ
+2#     Qd
+x QaQbQa
+x     Qb
+b
+2#     Qa
+x  Qbc
+x Qb
+b
+2#      a
+x daa
+x    d
+b
+2#    c
+x dba
+x   d
 b
 
-b2#    dx b dx   c
 b
-2#     dx b cx a a
+2#    d
+x b d
+x   c
 b
-2# Qbx      /a
+2#     d
+x b c
+x a a
+b
+2# Qb
+x      /a
 x bbc
-b2# dx  bac
+b
+2# d
+x  bac
 3# b
 x d
 b
-2a -3#    dx d.
+2a -
+3#    d
+x d.
 xa
 xb.
-b2d
+b
+2d
 2. dba d
-4#ax d
+4#a
+x d
 b
 2# b
 x      /a
@@ -7656,41 +13760,76 @@ S3
 2d
 b
 2dfg d
-3#      /axf.
+3#      /a
+xf.
 2d
-b2f  d
-2.hiif
-4#fxh.
 b
-2#ix      /ax   f
+2f  d
+2.hiif
+4#f
+xh.
+b
+2#i
+x      /a
+x   f
 b
 1ifg
 2hiif
-b2#ffghx   c{xdbb}
+b
+2#ffgh
+x   c{
+xdbb}
 b
 2.bbdd{
-3#d. }xa   d{xb.  }
+3#d. }
+xa   d{
+xb.  }
 b
 2 db
-3#     d&{x b.x a ax  d.}
+3#     d&{
+x b.
+x a a
+x  d.}
 b
-3# ax   c.
+3# a
+x   c.
 2  de  a
-3#   ax a.
+3#   a
+x a.
 b
 
 b
-2#  bx     d{x  ba }
-b2#  d  bx abc ax b.
-b2#      ax  ddx d.
-b2#a bxb dx df
-b2d
-3#  g   /ax g.x fx d.
-b3# fx     a
-2. dd  b
-4#     d{xa.   }
+2#  b
+x     d{
+x  ba }
 b
-2# bx      /ax    d
+2#  d  b
+x abc a
+x b.
+b
+2#      a
+x  dd
+x d.
+b
+2#a b
+xb d
+x df
+b
+2d
+3#  g   /a
+x g.
+x f
+x d.
+b
+3# f
+x     a
+2. dd  b
+4#     d{
+xa.   }
+b
+2# b
+x      /a
+x    d
 bX
 1 bbc
 bQ
@@ -7701,34 +13840,107 @@ b
 
 b
 bQ
-3#      /axd.x fx  g.xdx    d
+3#      /a
+xd.
+x f
+x  g.
+xd
+x    d
 b
 2f  d
 2. a a d&{
-4#  dx a. }
+4#  d
+x a. }
 b
-3# bx      /ax  bx   d.x   cx   a.
-b3#   cx   d.x  b.x  dx     d{x a.  }
-b3#    ax  d.x bx   cx     ax ab
-b3#  d  b&{x a.x bx d. }xa   d{xb.  }
-b3# dx     d&{x  bax b.x ax b. }
+3# b
+x      /a
+x  b
+x   d.
+x   c
+x   a.
+b
+3#   c
+x   d.
+x  b.
+x  d
+x     d{
+x a.  }
+b
+3#    a
+x  d.
+x b
+x   c
+x     a
+x ab
+b
+3#  d  b&{
+x a.
+x b
+x d. }
+xa   d{
+xb.  }
+b
+3# d
+x     d&{
+x  ba
+x b.
+x a
+x b. }
 b
 
-b3# dx  b.x  dx      ax   ax a.
-b3#  bx     d&{x   ax  d.x ax  b.}
 b
-3#     b&{x  d.x a  }x     ax  bx b.
-b3#      ax d.x   dx   c.x   d{x d.}
-b3#  b{xa.}x  d{xb.}x  fx d.
-b3#dx      /ax    dx g.x fx d.
+3# d
+x  b.
+x  d
+x      a
+x   a
+x a.
+b
+3#  b
+x     d&{
+x   a
+x  d.
+x a
+x  b.}
+b
+3#     b&{
+x  d.
+x a  }
+x     a
+x  b
+x b.
+b
+3#      a
+x d.
+x   d
+x   c.
+x   d{
+x d.}
+b
+3#  b{
+xa.}
+x  d{
+xb.}
+x  f
+x d.
+b
+3#d
+x      /a
+x    d
+x g.
+x f
+x d.
 b
 2 f
 2. df  d&{
-4#  gx  f.}
+4#  g
+x  f.}
 b
 
 b
-2#  gx      /ax    d
+2#  g
+x      /a
+x    d
 b
 1  gf
 2      /a
@@ -7741,16 +13953,23 @@ b
 2      /a
 b
 2.dbbc
-3#   d.x   cx   a.
+3#   d.
+x   c
+x   a.
 bQ
-2#   cx    d{xf  d}
+2#   c
+x    d{
+xf  d}
 b
-1dfgfd1bbdddb
+1dfgfd
+1bbdddb
 bT
 2.bbb   /a
 3a
 b
-2#bx     b{x    d}
+2#b
+x     b{
+x    d}
 b
 
 b
@@ -7758,99 +13977,309 @@ b
 2      /a
 b
 2.abb d&{
-3# d.xaxc. }
+3# d.
+xa
+xc. }
 b
-3#dx    cx b  axd.xcx b.
+3#d
+x    c
+x b  a
+xd.
+xc
+x b.
 b
-2#dax     d{x   a }
+2#da
+x     d{
+x   a }
 b
 1dab
 2d
-b2#    d{xabb }x    c
-b2#    axffgx  f
-b2#   axcddx    d
-b2#d   c&{x dbxb. }
+b
+2#    d{
+xabb }
+x    c
+b
+2#    a
+xffg
+x  f
+b
+2#   a
+xcdd
+x    d
+b
+2#d   c&{
+x db
+xb. }
 b
 
-b2#    d{xabb }x    c
-b2#    ax cdcx     d
 b
-2# d   c&{x  dax b. }
-b2#     d{x aba }x     b
-b2#     ax  bc{x b.}
-b2#      ax dddx  f.
-b2#      /ax fgf
-3#  dd b{x a.  }
-b3# b  ax   c.
+2#    d{
+xabb }
+x    c
+b
+2#    a
+x cdc
+x     d
+b
+2# d   c&{
+x  da
+x b. }
+b
+2#     d{
+x aba }
+x     b
+b
+2#     a
+x  bc{
+x b.}
+b
+2#      a
+x ddd
+x  f.
+b
+2#      /a
+x fgf
+3#  dd b{
+x a.  }
+b
+3# b  a
+x   c.
 2@ a a d&{
-4#  dx a. }
+4#  d
+x a. }
 b
 
 b
-2# bx      /ax bbc
+2# b
+x      /a
+x bbc
 b
-2#dx db c{xb.  }
-b2#b b   /axa.x d d  ///a
-b2 b c
-2. bba d{3 a.  }
+2#d
+x db c{
+xb.  }
 b
-2# bx      /ax    d
+2#b b   /a
+xa.
+x d d  ///a
+b
+2 b c
+2. bba d{
+3 a.  }
+b
+2# b
+x      /a
+x    d
 bX
 1 bbc
 bQ
 bQ
 2a
 b
-3#      /axa.x b c{x d.}xa bx b.
-b3#     b&{xb.x  dx a. }x b cx d a
+3#      /a
+xa.
+x b c{
+x d.}
+xa b
+x b.
+b
+3#     b&{
+xb.
+x  d
+x a. }
+x b c
+x d a
 b
 
-b3#a   d&{xd.xa bx b.xaxb. }
 b
-3#dx   c{x bx a.}x  dd{xf. }
+3#a   d&{
+xd.
+xa b
+x b.
+xa
+xb. }
 b
-3#d  cx    d{xa bx b.xb d}x     b
-b3# bx d.x  b d&{xa.x dxa. }
-b3#b dx     b&{x   dx  b.x  dx a. }
-b3# b d{x a.}x b c{x d.}xa  axb.
+3#d
+x   c{
+x b
+x a.}
+x  dd{
+xf. }
 b
-3#ax    d&{x bx d.xaxc. }
+3#d  c
+x    d{
+xa b
+x b.
+xb d}
+x     b
+b
+3# b
+x d.
+x  b d&{
+xa.
+x d
+xa. }
+b
+3#b d
+x     b&{
+x   d
+x  b.
+x  d
+x a. }
+b
+3# b d{
+x a.}
+x b c{
+x d.}
+xa  a
+xb.
+b
+3#a
+x    d&{
+x b
+x d.
+xa
+xc. }
 b
 
-b3#dx    cx b  axd.xcx b.
-b3#dax     d&{x dx a.x bx d. }
-b3# ax   a.x  bx   c.x   dx  b.
-b3#    d&{xa.x bbx d.xa }x    c
-b3#    axf.x fx  g.x   hx  f.
-b3#   axc.x dx  d.x  ax    d
 b
-3#    c{xd.x dx  b.}x   ax   d.
+3#d
+x    c
+x b  a
+xd.
+xc
+x b.
+b
+3#da
+x     d&{
+x d
+x a.
+x b
+x d. }
+b
+3# a
+x   a.
+x  b
+x   c.
+x   d
+x  b.
+b
+3#    d&{
+xa.
+x bb
+x d.
+xa }
+x    c
+b
+3#    a
+xf.
+x f
+x  g.
+x   h
+x  f.
+b
+3#   a
+xc.
+x d
+x  d.
+x  a
+x    d
+b
+3#    c{
+xd.
+x d
+x  b.}
+x   a
+x   d.
 b
 
-b3#    d{
-xa.x bx  b.}x   cx    c
-b3#    ax   c.x  dx a.x cx     d
-b3#     c&{x d.x  d }x   a.x dx b.
-b3#     d&{x a.x  bax  d.x a  }x     b
-b3#     ax  b.x   cx  d.x ax b.
 b
-3#      ax d.x  dx   d.x   ax  f.
-b3#      /axa.x bx  b.x  d  b{x a.  }
+3#    d{
+xa.
+x b
+x  b.}
+x   c
+x    c
+b
+3#    a
+x   c.
+x  d
+x a.
+x c
+x     d
+b
+3#     c&{
+x d.
+x  d }
+x   a.
+x d
+x b.
+b
+3#     d&{
+x a.
+x  ba
+x  d.
+x a  }
+x     b
+b
+3#     a
+x  b.
+x   c
+x  d.
+x a
+x b.
+b
+3#      a
+x d.
+x  d
+x   d.
+x   a
+x  f.
+b
+3#      /a
+xa.
+x b
+x  b.
+x  d  b{
+x a.  }
 b
 
-b3# b dx   c.
+b
+3# b d
+x   c.
 2. a a d&{
-4#  dx a. }
+4#  d
+x a. }
 b
 2 b
-3#      /ax d.xaxb.
-b3#dx    dx    c&{x d.x  bxb. }
-b3#      /axb.xax  b.x      ///ax d d
-b3# bx   c.x      ///ax b c
+3#      /a
+x d.
+xa
+xb.
+b
+3#d
+x    d
+x    c&{
+x d.
+x  b
+xb. }
+b
+3#      /a
+xb.
+xa
+x  b.
+x      ///a
+x d d
+b
+3# b
+x   c.
+x      ///a
+x b c
 3.   a
 4 a.
 b
-2# bx      /ax    d
+2# b
+x      /a
+x    d
 b
 Y bbc
 b
@@ -7866,38 +14295,71 @@ b
 2.dfg d
 3f
 2d
-b2f dd
-2.h if
-4#fxh
 b
-2#ix      /ax   f
+2f dd
+2.h if
+4#f
+xh
+b
+2#i
+x      /a
+x   f
 b
 1ifg
 2h  f
-b2#ffghx   cxdb
+b
+2#ffgh
+x   c
+xdb
 b
 2#bbdd
-xdxa   db
-2 db
-3#     dx bx a ax  d
+xd
+xa   d
 b
-3# ax   c
+2 db
+3#     d
+x b
+x a a
+x  d
+b
+3# a
+x   c
 2  de  a
-3#   fx   e
+3#   f
+x   e
 b
 
 b
-2#   fx     dx   f
-b2#  d  bx abc ax b
+2#   f
+x     d
+x   f
 b
-2#      ax   dx dd
-b2#a bxb dx df
-b2d
-3#      /ax gx fx d
-b3# fx     a
+2#  d  b
+x abc a
+x b
+b
+2#      a
+x   d
+x dd
+b
+2#a b
+xb d
+x df
+b
+2d
+3#      /a
+x g
+x f
+x d
+b
+3# f
+x     a
 2# d   b
-x     db
-2# bbcdx      /ax    d
+x     d
+b
+2# bbcd
+x      /a
+x    d
 bX
 1 bbc
 bQ
@@ -7907,36 +14369,100 @@ b
 
 b
 bQ
-3#      /axdx fx  gxdx    Qd
+3#      /a
+xd
+x f
+x  g
+xd
+x    Qd
 b
 2f  d
 2. a a d
-4#  dx a
+4#  d
+x a
 b
-2# bx      /ax    db2# bbcx     dx aba
-b3#   hxfx fx  gx   cxdb
-b3#  ddx ax bx dxa   dxb
-b3# dx     dx  bax bx ax  d
+2# b
+x      /a
+x    d
+b
+2# bbc
+x     d
+x aba
+b
+3#   h
+xf
+x f
+x  g
+x   c
+xdb
+b
+3#  dd
+x a
+x b
+x d
+xa   d
+xb
+b
+3# d
+x     d
+x  ba
+x b
+x a
+x  d
 b
 
-b3# ax  Qbx      ax  dex   f
-x   e
-b2#   fx     dx   f
-b3#     bx  dx     ax ax   cx b
 b
-3#      ax dx   dx   cx   ax d
-b3#  bxax  dxbx  fx d
-b3#dx      /ax    dx gx fx d
+3# a
+x  Qb
+x      a
+x  de
+x   f
+x   e
+b
+2#   f
+x     d
+x   f
+b
+3#     b
+x  d
+x     a
+x a
+x   c
+x b
+b
+3#      a
+x d
+x   d
+x   c
+x   a
+x d
+b
+3#  b
+xa
+x  d
+xb
+x  f
+x d
+b
+3#d
+x      /a
+x    d
+x g
+x f
+x d
 b
 3# f
 x  d
 x     d
-x dfx  g
+x df
+x  g
 x  f
 b
 
 b
-2#  gx      /ax    d
+2#  g
+x      /a
+x    d
 b
 1  gf
 2      /a
@@ -7949,16 +14475,22 @@ b
 2      /a
 b
 2.dbb
-3#   dx   cx   a
+3#   d
+x   c
+x   a
 b
-1    d2fggd
+1    d
+2fggd
 b
-1dfgfd1bbdddb
+1dfgfd
+1bbdddb
 bT
 2.bbb   /a
 3a
 b
-2#bx     bx    d
+2#b
+x     b
+x    d
 b
 
 b
@@ -7966,111 +14498,291 @@ b
 2    d
 b
 2.abb
-3# dxaxc
+3# d
+xa
+xc
 b
-3#dx    cx b  axaxcx b
+3#d
+x    c
+x b  a
+xa
+xc
+x b
 b
-2#dax     dx    a
+2#da
+x     d
+x    a
 b
 1dab
 2Qd
-bQ2#    dxabbx    c
-b2#    axffgx  f
-b2#   axcddx    d
-b2#d   cx dbxb
+bQ
+2#    d
+xabb
+x    c
+b
+2#    a
+xffg
+x  f
+b
+2#   a
+xcdd
+x    d
+b
+2#d   c
+x db
+xb
 b
 
-b2#    dxabbx    c
 b
-2#    ax cdcx     d
+2#    d
+xabb
+x    c
 b
-2# d   cx  dax bb2#     dx abax     b
-b2#     ax   cx bb
-b2#      ax dddx  f
-b2#      /axafg
-3#  d  bx a
-b2 b  a2@ bba d
+2#    a
+x cdc
+x     d
+b
+2# d   c
+x  da
+x b
+b
+2#     d
+x aba
+x     b
+b
+2#     a
+x   c
+x bb
+b
+2#      a
+x ddd
+x  f
+b
+2#      /a
+xafg
+3#  d  b
+x a
+b
+2 b  a
+2@ bba d
 3 a.
 b
 
 b
-2# bx      /ax bbc
-b2 d  c
+2# b
+x      /a
+x bbc
+b
+2 d  c
 3#  b
 xa
-xbx d
+xb
+x d
 b
 2Qd
 3#    d
 xb
 xa
 x d
-b3#a bx  d2 dff d
+b
+3#a b
+x  d
+2 dff d
 3#  g
 x  f
-b2#  gx      /ax    d
+b
+2#  g
+x      /a
+x    d
 b
 1  gf
 2      /a
 b
-bQ1abb
+bQ
+1abb
 2     b
-b1bbd
+b
+1bbd
 2      /a
 b
 
-b2@dbb
-3#bxax d
-b3#a   dxbxdxa2Qf  d
-b3#    dxdx fx  gx     bxb
-b3# bx dx    dxabx dxa
-b2#b
-x     bx   d
-b1bbd
+b
+2@dbb
+3#b
+xa
+x d
+b
+3#a   d
+xb
+xd
+xa
+2Qf  d
+b
+3#    d
+xd
+x f
+x  g
+x     b
+xb
+b
+3# b
+x d
+x    d
+xab
+x d
+xa
+b
+2#b
+x     b
+x   d
+b
+1bbd
 2      /a
-b2abb
+b
+2abb
 3#    d
 x d
 xa
 xc
 b
 
-b3#dx    cx b  axaxcx b
-b3#dax     dx dx ax bx d
-b2# ax     dxd
-b3#    dxax bx dxax    c
-b3#    axfx fx  gx   hx  f
-b3#   axcx dx  dx  ax    d
-b3#d   Qcx dx  bx bx d
+b
+3#d
+x    c
+x b  a
+xa
+xc
+x b
+b
+3#da
+x     d
+x d
+x a
+x b
+x d
+b
+2# a
+x     d
+xd
+b
+3#    d
+xa
+x b
+x d
+xa
+x    c
+b
+3#    a
+xf
+x f
+x  g
+x   h
+x  f
+b
+3#   a
+xc
+x d
+x  d
+x  a
+x    d
+b
+3#d   Qc
+x d
+x  b
+x b
+x d
 xa
 b
 
-b3#    d
-xax bx  bx   cx    c
-b3#    ax cx  dx   cx cx     d
 b
-3#     cx dx  dx   ax  bx  d
-b3#     dx ax  bx  dx ax     b
-b3#     ax  bx  dx ax b
+3#    d
+xa
+x b
+x  b
 x   c
-b3#      ax dx  dx   dx   ax a
-b3#      /axax bx ax  d  bx a
+x    c
+b
+3#    a
+x c
+x  d
+x   c
+x c
+x     d
+b
+3#     c
+x d
+x  d
+x   a
+x  b
+x  d
+b
+3#     d
+x a
+x  b
+x  d
+x a
+x     b
+b
+3#     a
+x  b
+x  d
+x a
+x b
+x   c
+b
+3#      a
+x d
+x  d
+x   d
+x   a
+x a
+b
+3#      /a
+xa
+x b
+x a
+x  d  b
+x a
 b
 
-b3# b  ax d
+b
+3# b  a
+x d
 x   a d
 x a
-x  dx a
+x  d
+x a
 b
 3# b
-x      /ax  bx  dx a
+x      /a
+x  b
+x  d
+x a
 x b
-b3# dx    cx  bxaxbx d
-b3#dx    dx   cxbxaxb
-b3#dx   c2.   a d
-4#    dx   a
 b
-2#    dx      /ax    d
+3# d
+x    c
+x  b
+xa
+xb
+x d
+b
+3#d
+x    d
+x   c
+xb
+xa
+xb
+b
+3#d
+x   c
+2.   a d
+4#    d
+x   a
+b
+2#    d
+x      /a
+x    d
 b
 Y bbc
 b
@@ -8086,39 +14798,72 @@ b
 2.dfg d
 3f
 2d
-b2.f  d
+b
+2.f  d
 3#i
 xh  f
-4#fxh
+4#f
+xh
 b
-2#ix      /ax   f
+2#i
+x      /a
+x   f
 b
 1ifg
 2h  f
-b2#ffghx    hx ig
+b
+2#ffgh
+x    h
+x ig
 b
 2b dd{
 3# a
-xd2ab  db
-2 db
-3#     dx bx ax  d
+xd
+2ab  d
 b
-2 a a2.  de  a
-4#   fx   e
+2 db
+3#     d
+x b
+x a
+x  d
+b
+2 a a
+2.  de  a
+4#   f
+x   e
 b
 
 b
-2#   fx     dx    f
-b2#  d  bx abc ax b
+2#   f
+x     d
+x    f
 b
-2#      ax   dx d
-b2#a bxb dx df
-b2d
-3#      /ax gx fx d
-b2 f2. d   d
-4#  gx  f
+2#  d  b
+x abc a
+x b
 b
-2#  gx      /ax    d
+2#      a
+x   d
+x d
+b
+2#a b
+xb d
+x df
+b
+2d
+3#      /a
+x g
+x f
+x d
+b
+2 f
+2. d   d
+4#  g
+x  f
+b
+2#  g
+x      /a
+x    d
 bX
 1  gf
 bQ
@@ -8128,7 +14873,12 @@ b
 
 b
 bQ
-3#    dxdx fx  gxdx  f
+3#    d
+xd
+x f
+x  g
+xd
+x  f
 b
 3#  dd
 xf
@@ -8138,32 +14888,96 @@ x  d
 x a
 b
 3# b    /a
-x ax bx dxaxb
-b3#dxaxix   hx   fxh
-b3#   hxfx fx  gx    hx i
-b3#   dxbx  dx axa   dx  d
-b3# dx     dx  bax bx ax b
+x a
+x b
+x d
+xa
+xb
+b
+3#d
+xa
+xi
+x   h
+x   f
+xh
+b
+3#   h
+xf
+x f
+x  g
+x    h
+x i
+b
+3#   d
+xb
+x  d
+x a
+xa   d
+x  d
+b
+3# d
+x     d
+x  ba
+x b
+x a
+x b
 b
 
-b3# dx  bx      a
-x  dx  aax a
-b3#  bx     dx   ax  dx ax  b
-b3#  dx     bx     ax  b
-x   cx b
 b
-3#      ax dx   dx   cx   dx d
-b3#  bxax  dxbx  fx d
-b3#dx      /ax  gx gx fx d
+3# d
+x  b
+x      a
+x  d
+x  aa
+x a
+b
+3#  b
+x     d
+x   a
+x  d
+x a
+x  b
+b
+3#  d
+x     b
+x     a
+x  b
+x   c
+x b
+b
+3#      a
+x d
+x   d
+x   c
+x   d
+x d
+b
+3#  b
+xa
+x  d
+xb
+x  f
+x d
+b
+3#d
+x      /a
+x  g
+x g
+x f
+x d
 b
 3# f
 x g
 x     d
 x d
-x  gx  f
+x  g
+x  f
 b
 
 b
-2#  gx      /ax    d
+2#  g
+x      /a
+x    d
 b
 1  gf
 2      /a
@@ -8176,16 +14990,22 @@ b
 2      /a
 b
 2.dbbc
-3#   ax   cx   a
+3#   a
+x   c
+x   a
 b
-2    d1f  d
+2    d
+1f  d
 b
-1dfg d1bbdddb
+1dfg d
+1bbdddb
 bT
 2.bbb   /a
 3-Qa
 b
-2#bx     bx   d
+2#b
+x     b
+x   d
 b
 
 b
@@ -8193,32 +15013,71 @@ b
 2      /a
 b
 2.abb d
-3# dxaxc
-b
-2d   c2.cb  a4#a
+3# d
+xa
 xc
 b
-2#dx a   dx   a
+2d   c
+2.cb  a
+4#a
+xc
+b
+2#d
+x a   d
+x   a
 b
 1  b
 2d
-b2#    dxabbx    c
-b2#    axffgx  f
-b2#   axcddx    d
-b2#d   cx dbxb
+b
+2#    d
+xabb
+x    c
+b
+2#    a
+xffg
+x  f
+b
+2#   a
+xcdd
+x    d
+b
+2#d   c
+x db
+xb
 b
 
-b2#    dxabbx    c
-b2#    ax bdcx  b
-b2#      ax daax    d
-b2# d  cx  bx   d
-b2#      /ax b dx   c
-b2#     dx b cx a a
 b
-2# bx      /ax bbc
+2#    d
+xabb
+x    c
+b
+2#    a
+x bdc
+x  b
+b
+2#      a
+x daa
+x    d
+b
+2# d  c
+x  b
+x   d
+b
+2#      /a
+x b d
+x   c
+b
+2#     d
+x b c
+x a a
+b
+2# b
+x      /a
+x bbc
 b
 2  d
-3#    cxa
+3#    c
+xa
 xb
 x d
 b
@@ -8229,81 +15088,215 @@ b
 xb
 xa
 xb
-b2d2. dba d&{
-4# bx a
 b
-2# b  dx      /ax    d
+2d
+2. dba d&{
+4# b
+x a
+b
+2# b  d
+x      /a
+x    d
 bX
-1 bbcbQ
+1 bbc
+bQ
 bQ
 2a
-b3#      /axax b
+b
+3#      /a
+xa
+x b
 x d
 xa
 x b
-b3#b
+b
+3#b
 x     b
 x  d
 x a
 x b
 x d
 b
-3#      /axd
+3#      /a
+xd
 xa
 x b
 xa
 xb
 b
-3#dxax bx ax  ddxf
-b
-
-b3#    dxdx fx  gx     bxb
-b
-3#  dx ax      /axax bx  d
-b3#     bxbx  dx  bx  dx  e
-b3# bx   dx   cx bx   ax a
-b3# b    /axax bx dxa   dxc
-b3#dx    cx b  axdxcx b
-b3#     dxdax dx ax bx d
+3#d
+xa
+x b
+x a
+x  dd
+xf
 b
 
 b
-3#  bx ax  bx   cx   dx  b
-b3#    dxax bx dxax    c
-b3#    axfx fx  gx   hx  f
-b3#   axcx  dx  bx  dx    d
-b3#    cxdx dx  bx bx d
-b3#ax    dx bx  b
-x   cx    c
+3#    d
+xd
+x f
+x  g
+x     b
+xb
 b
-3#    ax bx  dx   cx    ax  b
+3#  d
+x a
+x      /a
+xa
+x b
+x  d
 b
-
+3#     b
+xb
+x  d
+x  b
+x  d
+x  e
 b
-3#  ax      ax   ax dx  d
-x    d
-b3#    cx dx  bx  dx  bx   d
-b3#      /ax b cx    dx   ax   cx    d
-b3#     dx a ax  bcx bx   ax a
+3# b
+x   d
+x   c
+x b
+x   a
+x a
 b
-3# bx      /ax  bx  dx a
+3# b    /a
+xa
+x b
+x d
+xa   d
+xc
+b
+3#d
+x    c
+x b  a
+xd
+xc
 x b
 b
-3# dx    c
+3#     d
+xda
+x d
+x a
+x b
+x d
+b
+
+b
+3#  b
+x a
 x  b
-xaxb
+x   c
+x   d
+x  b
+b
+3#    d
+xa
+x b
+x d
+xa
+x    c
+b
+3#    a
+xf
+x f
+x  g
+x   h
+x  f
+b
+3#   a
+xc
+x  d
+x  b
+x  d
+x    d
+b
+3#    c
+xd
+x d
+x  b
+x b
+x d
+b
+3#a
+x    d
+x b
+x  b
+x   c
+x    c
+b
+3#    a
+x b
+x  d
+x   c
+x    a
+x  b
+b
+
+b
+3#  a
+x      a
+x   a
+x d
+x  d
+x    d
+b
+3#    c
+x d
+x  b
+x  d
+x  b
+x   d
+b
+3#      /a
+x b c
+x    d
+x   a
+x   c
+x    d
+b
+3#     d
+x a a
+x  bc
+x b
+x   a
+x a
+b
+3# b
+x      /a
+x  b
+x  d
+x a
+x b
+b
+3# d
+x    c
+x  b
+xa
+xb
 x d
 b
 
 -l "4 in"
 b
-3#dx    dx   cxbxaxb
-b2d
+3#d
+x    d
+x   c
+xb
+xa
+xb
+b
+2d
 2. dba d
 4# b
 x a
-b2# bx      /ax    d
-bY bbc
+b
+2# b
+x      /a
+x    d
+b
+Y bbc
 b
 B
 
@@ -8318,38 +15311,71 @@ b
 3#      /a
 xf
 2d
-b2f  d
-2.h- f
-4#fxh
 b
-2#ix      /ax   f
+2f  d
+2.h- f
+4#f
+xh
+b
+2#i
+x      /a
+x   f
 b
 1ifg
 2h- f
-b2#ffghx   cxdb
+b
+2#ffgh
+x   c
+xdb
 b
 2.bbdd
-3#dxa - d
-xbb
-2 d
-3#     dx bx a ax  d
+3#d
+xa - d
+xb
 b
-2 a2.  de- a
-4#   fx   e
+2 d
+3#     d
+x b
+x a a
+x  d
+b
+2 a
+2.  de- a
+4#   f
+x   e
 b
 
 b
-2#   fx     dx   f
-b2#  d- bx ab- ax b
+2#   f
+x     d
+x   f
 b
-2#      ax   dx d
-b2#a bxb dx df
-b2d
-3#      /ax gx fx d
-b2 f2. df- d
-4#  gx  f
+2#  d- b
+x ab- a
+x b
 b
-2#  gx      /ax    d
+2#      a
+x   d
+x d
+b
+2#a b
+xb d
+x df
+b
+2d
+3#      /a
+x g
+x f
+x d
+b
+2 f
+2. df- d
+4#  g
+x  f
+b
+2#  g
+x      /a
+x    d
 b
 1  gf
 bbX
@@ -8357,38 +15383,91 @@ bbX
 b
 
 b
-3#      /axdx fx  g2db
+3#      /a
+xd
+x f
+x  g
+2d
+b
 3#b- d
 xa
 2# d
 x   f
 b
 2# b- d
-x      /ax    db2# bbcx     dx abab2#  dcax     ax  b-d
-b2  dda a3#    c
-x  Qb2   cd
-b2   a d3# dx bx ax  b
+x      /a
+x    d
+b
+2# bbc
+x     d
+x aba
+b
+2#  dca
+x     a
+x  b-d
+b
+2  dda a
+3#    c
+x  Qb
+2   cd
+b
+2   a d
+3# d
+x b
+x a
+x  b
 b
 
-b3# bx a2.  de  a
+b
+3# b
+x a
+2.  de  a
 4#   f
 x   e
-b2#   fx     dx   fb3#     bx  dx  b- ax  d
-x ax b
 b
-3#      ax dx   dx   cx   dx d
-b3#  bxax  dxbx  fx d
-b2d     /a3#    dx gx fx d
+2#   f
+x     d
+x   f
+b
+3#     b
+x  d
+x  b- a
+x  d
+x a
+x b
+b
+3#      a
+x d
+x   d
+x   c
+x   d
+x d
+b
+3#  b
+xa
+x  d
+xb
+x  f
+x d
+b
+2d     /a
+3#    d
+x g
+x f
+x d
 b
 3# g
 x f
 x     d
 x d
-x  gx  f
+x  g
+x  f
 b
 
 b
-2#  gx      /ax    d
+2#  g
+x      /a
+x    d
 b
 1  gf
 2      /a
@@ -8401,17 +15480,21 @@ b
 2      /a
 b
 2#dbb
-x   cx   a
+x   c
+x   a
 b
 1    d
 2f- d
 b
-1dfg d1bbdddb
+1dfg d
+1bbdddb
 bT
 2.bbb d
 3Qa
 b
-2#bx     bx   d
+2#b
+x     b
+x   d
 b
 
 b
@@ -8419,36 +15502,74 @@ b
 2      /a
 b
 2.abb
-3# dxaxc
-b
-3#d
-x    c2.cb  a4#a
+3# d
+xa
 xc
 b
-2#dx     dx   a
+3#d
+x    c
+2.cb  a
+4#a
+xc
+b
+2#d
+x     d
+x   a
 b
 1dab
 2d
-b2#    dxabbx    c
-b2#    axffgx  f
-b2#   axcddx    d
-b2#d - cx dbxb
+b
+2#    d
+xabb
+x    c
+b
+2#    a
+xffg
+x  f
+b
+2#   a
+xcdd
+x    d
+b
+2#d - c
+x db
+xb
 b
 
-b2#    dxabbx    c
-b2#    ax cdcx  b
-b2#      ax ddax    d
-b2# d- cx  bx   d
 b
-2#      /ax  bdx   c
-b2#     dx b cx a a
+2#    d
+xabb
+x    c
 b
-2# bx    dx bbc
+2#    a
+x cdc
+x  b
+b
+2#      a
+x dda
+x    d
+b
+2# d- c
+x  b
+x   d
+b
+2#      /a
+x  bd
+x   c
+b
+2#     d
+x b c
+x a a
+b
+2# b
+x    d
+x bbc
 b
 
 b
 2  d
-3#    cxa
+3#    c
+xa
 xb
 x d
 b
@@ -8457,15 +15578,24 @@ b
 xb
 xa
 x d
-b2#ax dba d&{
-3# bx a
 b
-2# bx      /ax    d
+2#a
+x dba d&{
+3# b
+x a
+b
+2# b
+x      /a
+x    d
 bX
-1 bbcbQ
+1 bbc
+bQ
 bQ
 2a
-b3#      /axax b
+b
+3#      /a
+xa
+x b
 x a
 x  d
 x  b
@@ -8479,100 +15609,239 @@ x b
 b
 
 b
-3#     dx d
+3#     d
+x d
 x b
 x d
 x a
 x  b
 b
-2#dx    dxf- d
-b3#    dxdx fx  gxb
-x     bb3# bx dx      /axax dxa
-b2#bx     bx  db1bbd2      /a
-b2.abb3# dxaxc
-b
-
-b3#dx    cx b  axaxcx b
-b3#da   dx dx ax bxa
-x    c
-b3#    axfx fx  gx   hx  f
-b3#   axcx dx  dx  ax    d
-b3#    cxdx dx  bx   axb
-b
-
-b3#    dxax bx  b
-x   cx    c
-b
-3#    ax cx  dx   cx  dx  b
-b3#      ax dax   ax   cx   a
+2#d
 x    d
-b3#    c
-x dx  bx  dx  bx   d
-b3#      /ax b cx   dx   cx   ax    d
+xf- d
+b
+3#    d
+xd
+x f
+x  g
+xb
+x     b
+b
+3# b
+x d
+x      /a
+xa
+x d
+xa
+b
+2#b
+x     b
+x  d
+b
+1bbd
+2      /a
+b
+2.abb
+3# d
+xa
+xc
 b
 
-b3#     dx ax   cx bx   ax a
 b
-3# bx    dx   cx   dx  bx  d
+3#d
+x    c
+x b  a
+xa
+xc
+x b
+b
+3#da   d
+x d
+x a
+x b
+xa
+x    c
+b
+3#    a
+xf
+x f
+x  g
+x   h
+x  f
+b
+3#   a
+xc
+x d
+x  d
+x  a
+x    d
 b
 3#    c
-x dx  b
-xaxb
+xd
+x d
+x  b
+x   a
+xb
+b
+
+b
+3#    d
+xa
+x b
+x  b
+x   c
+x    c
+b
+3#    a
+x c
+x  d
+x   c
+x  d
+x  b
+b
+3#      a
+x da
+x   a
+x   c
+x   a
+x    d
+b
+3#    c
+x d
+x  b
+x  d
+x  b
+x   d
+b
+3#      /a
+x b c
+x   d
+x   c
+x   a
+x    d
+b
+
+b
+3#     d
+x a
+x   c
+x b
+x   a
+x a
+b
+3# b
+x    d
+x   c
+x   d
+x  b
+x  d
+b
+3#    c
+x d
+x  b
+xa
+xb
 x d
 b
-3#dx     dx   cxbxax d
-b3#a b
+3#d
+x     d
+x   c
+xb
+xa
+x d
+b
+3#a b
 x  d
 2#     d
 x df
-b2# bx      /ax    d
-bY bbc
+b
+2# b
+x      /a
+x    d
+b
+Y bbc
 b
 B
 
 p
-{22f. L'Angelique de Gautier Bass - 7F8Ef9D10Bf/CH-SO DA 111, ff. 9v-10r}BX
+{22f. L'Angelique de Gautier Bass - 7F8Ef9D10Bf/CH-SO DA 111, ff. 9v-10r}
+BX
 bX
 S3
 2 d
-b2# dba dx      ///ax dba
-b2a   d
-2.c  a
-4#axc
 b
-2#dx     dx   a
-b2.dab
+2# dba d
+x      ///a
+x dba
+b
+2a   d
+2.c  a
+4#a
+xc
+b
+2#d
+x     d
+x   a
+b
+2.dab
 3f
 2c     a
 b
-3#aab  ax     cx     dx    a
+3#aab  a
+x     c
+x     d
+x    a
 2 d  c
 b
-3# b  dx   ax   cx   d
+3# b  d
+x   a
+x   c
+x   d
 2 ab  d
-b2  da
-3#      ax  bx  ax   c
+b
+2  da
+3#      a
+x  b
+x  a
+x   c
 b
 2  aa
 2.   ca
-4#   ax   c
+4#   a
+x   c
 b
 
 b
-2#   ax      ax   a
-b2#   cdx  a c
+2#   a
+x      a
+x   a
+b
+2#   cd
+x  a c
 x  b
-b2#  d ax    cx  d d
-b2 a    a
-3# b   ax a
+b
+2#  d a
+x    c
+x  d d
+b
+2 a    a
+3# b   a
+x a
 2  d  c
-b2# dba dx      ///a
-3#axc
 b
-2d   d2.c  a
-4#axc
+2# dba d
+x      ///a
+3#a
+xc
 b
-2#dx     dx   a
+2d   d
+2.c  a
+4#a
+xc
+b
+2#d
+x     d
+x   a
 b
 1dab
 bbX
@@ -8580,239 +15849,583 @@ bbX
 b
 
 b
-3#      ///ax dx ax  bx      //ax d
-b3#      /axax      axaxcx   a
-b3#     d&{x dx ax bx dx  b }
-b3#     d&{xdxaxcxdxc   }
-b3#     axax ax  bx    cx d
-b3#      /ax bx  bx   cx      ///ax a
-b3#      axfx dx  d
+3#      ///a
+x d
+x a
+x  b
+x      //a
+x d
+b
+3#      /a
+xa
+x      a
+xa
+xc
+x   a
+b
+3#     d&{
+x d
+x a
+x b
+x d
+x  b }
+b
+3#     d&{
+xd
+xa
+xc
+xd
+xc   }
+b
+3#     a
+xa
+x a
+x  b
+x    c
+x d
+b
+3#      /a
+x b
+x  b
+x   c
+x      ///a
+x a
+b
+3#      a
+xf
+x d
+x  d
 2f
 b
 
-b2c  a
-3#    axcxax  d
 b
-2# dx   ax      a
-b2a   d
+2c  a
+3#    a
+xc
+xa
+x  d
+b
+2# d
+x   a
+x      a
+b
+2a   d
 3#    c&{
-xaxcxd  }
+xa
+xc
+xd  }
 b
-2#f   ax    cx  d d
+2#f   a
+x    c
+x  d d
 b
-3#   ax ax bx   cx   ex  d
-b3# dx     dx      ///ax bx ax  d
-b3# ax  bx  dx      ax ax  d
+3#   a
+x a
+x b
+x   c
+x   e
+x  d
+b
+3# d
+x     d
+x      ///a
+x b
+x a
+x  d
+b
+3# a
+x  b
+x  d
+x      a
+x a
+x  d
 b
 
 b
-2#  bx     dx      ///a
+2#  b
+x     d
+x      ///a
 b
 1 ab
 bbX
 2 a
-b2#     dx abx      /a
-b2#    dx bbcx     d
+b
+2#     d
+x ab
+x      /a
+b
+2#    d
+x bbc
+x     d
 b
 2. d  c
 3    a
 2    c
 b
-3#     d&{x ax bx d  }
+3#     d&{
+x a
+x b
+x d  }
 2a   d
 b
 1 dba d
-3# b  dx   a
-b3#   cx   dx a   dx bx dxa
+3# b  d
+x   a
 b
-2# bx    dx      /a
+3#   c
+x   d
+x a   d
+x b
+x d
+xa
+b
+2# b
+x    d
+x      /a
 b
 
-b2# bbx   cx    Qd
-b2. aba d&{
-3#  dx ax c  }
-b3# dx     c
-2     a
-3# dx c
 b
-2# dx   ax      a
+2# bb
+x   c
+x    Qd
+b
+2. aba d&{
+3#  d
+x a
+x c  }
+b
+3# d
+x     c
+2     a
+3# d
+x c
+b
+2# d
+x   a
+x      a
 b
 1 dd
 2 d
-b2#     dx abax     c
-b2#     axaabx  a
-b2#    ax cdc
+b
+2#     d
+x aba
+x     c
+b
+2#     a
+xaab
+x  a
+b
+2#    a
+x cdc
 x     d
-b2#     cx ddx b
 b
-
-b2#     dx abax     c
-b2#     axdabxc
-b2#    axfcdx     d
-b2#  d  cx   ax    d
-b2# aba dx  d dx  b c
-b2#   a  ax  b cx  a a
-b2#  bx     d&{
-3#  dx a  }
+2#     c
+x dd
+x b
 b
 
 b
-2#  dx     c&{
-3# ax b  }
+2#     d
+x aba
+x     c
+b
+2#     a
+xdab
+xc
+b
+2#    a
+xfcd
+x     d
+b
+2#  d  c
+x   a
+x    d
+b
+2# aba d
+x  d d
+x  b c
+b
+2#   a  a
+x  b c
+x  a a
+b
+2#  b
+x     d&{
+3#  d
+x a  }
+b
+
+b
+2#  d
+x     c&{
+3# a
+x b  }
 b
 2 dba d
-3#      ///axaxcx    a
-b3#d   cx    dx   axdxcx b
+3#      ///a
+xa
+xc
+x    a
 b
-2#dx     dx   a
+3#d   c
+x    d
+x   a
+xd
+xc
+x b
+b
+2#d
+x     d
+x   a
 b
 1dab
 bbX
 2 a
 b
-3#     dx ax  bx     bx     ax      a
-b3#      /ax      ax     ax     cx     dx    a
+3#     d
+x a
+x  b
+x     b
+x     a
+x      a
+b
+3#      /a
+x      a
+x     a
+x     c
+x     d
+x    a
 b
 
-b3#    c&{x  ax  bx  dx ax b }
-b3#     dx ax  bx    ax    cx    d
 b
-3#     d&{x dx ax  b }x    d&{xa
-b3# bx  b}x     d&{x ax  bx d  }
+3#    c&{
+x  a
+x  b
+x  d
+x a
+x b }
 b
-2# bx    dx      /a
+3#     d
+x a
+x  b
+x    a
+x    c
+x    d
+b
+3#     d&{
+x d
+x a
+x  b }
+x    d&{
+xa
+b
+3# b
+x  b}
+x     d&{
+x a
+x  b
+x d  }
+b
+2# b
+x    d
+x      /a
 b
 1 bbc
 2 a
 b
-3#     d&{x ax  bx  dx ax c  }
+3#     d&{
+x a
+x  b
+x  d
+x a
+x c  }
 b
 
-b3# dx     cx     ax dx cx  b
 b
-2# dx   ax      a
+3# d
+x     c
+x     a
+x d
+x c
+x  b
+b
+2# d
+x   a
+x      a
 b
 1 dd
 2 d
 b
 2. aba d
-3#    ax     dx     c
+3#    a
+x     d
+x     c
 b
-2#aabc ax   cx   a
+2#aabc a
+x   c
+x   a
 b
 2. cdca
-3#    cx    ax     d
+3#    c
+x    a
+x     d
 b
-2# dd  c&{x dx b  }
+2# dd  c&{
+x d
+x b  }
+b
+
+b
+3#     d
+x a
+x  b
+x  d
+x a
+x     c
+b
+3#     a
+xa
+x c
+x d
+xa
+x d
+b
+3#    a
+x c
+x  d
+x a
+x c
+x     d
+b
+3#     c
+x  d
+x  a
+x  b
+x  d
+x   a
+b
+3# ab  d
+x  a
+x   c
+x   a
+x    d
+x    c
 b
 
 b
-3#     dx ax  bx  dx ax     c
-b3#     axax cx dxax d
+3#      a
+x  a
+x    c
+x  b
+x    a
+x  a
 b
-3#    ax cx  dx ax cx     d
-b3#     cx  dx  ax  bx  dx   a
+3#     d&{
+x a
+x  b
+x  d
+x a
+x  b }
 b
-3# ab  dx  ax   cx   ax    dx    c
+3#     c&{
+x  d
+x  a
+x a
+x b
+x  d }
 b
-
-b3#      ax  ax    cx  bx    ax  a
+3#     d
+x d
+x   a
+x b
+x a
+x  d
 b
-3#     d&{x ax  bx  dx ax  b }
-b3#     c&{x  dx  ax ax bx  d }
-b3#     dx dx   ax bx ax  d
+3# a
+x    d
+x  d
+x      a
+x a
+x  d
 b
-3# ax    dx  dx      ax ax  d
-b
-2#  bx     dx      ///a
+2#  b
+x     d
+x      ///a
 b
 Ydab
 b
 B
 
 p
-{23. Les Larmes de Gautier - 7F8Ef9Df/GB-Cfm 689, f. 87r ii}BX
+{23. Les Larmes de Gautier - 7F8Ef9Df/GB-Cfm 689, f. 87r ii}
+BX
 bX
 S3
 2  b
 b
 1. bbb  /a
 b
-2# dx    cx  b
+2# d
+x    c
+x  b
 b
 2. eb d
-3# dx ex b
+3# d
+x e
+x b
 b
-2# dx     dx     b
-b2#      bx  e - ax  d
-b2#  bbx   dx      /a
+2# d
+x     d
+x     b
+b
+2#      b
+x  e - a
+x  d
+b
+2#  bb
+x   d
+x      /a
 b
 2# ebb
 x      a
 x      /a
-b2#bde - //axgxfg
-b2#dex  gx de
+b
+2#bde - //a
+xg
+xfg
+b
+2#de
+x  g
+x de
 b
 
-b2 bc
-3#dxbx exb
 b
-2#dx   dxd- b
-b2#bde bxdx   bd
-b2#   ax     d3#   dbx  b
+2 bc
+3#d
+xb
+x e
+xb
+b
+2#d
+x   d
+xd- b
+b
+2#bde b
+xd
+x   bd
+b
+2#   a
+x     d
+3#   db
+x  b
 b
 2   bd
 2.   a d
 4#    d
 x    c
 b
-2#    dx      /ax    d
+2#    d
+x      /a
+x    d
 b
 1 bbc
 bXQ
 bXQ
 2  b
-b2 bbb  /a
-3# ax bx dx b
-b3# d- cx    dx    cx    ax     dx   a
+b
+2 bbb  /a
+3# a
+x b
+x d
+x b
+b
+3# d- c
+x    d
+x    c
+x    a
+x     d
+x   a
 b
 
-b3#  bbx   dx   bx   ax    dx   b
+b
+3#  bb
+x   d
+x   b
+x   a
+x    d
+x   b
 b
 2b- a
-3# dbx   dx   bx   a
+3# db
+x   d
+x   b
+x   a
 b
 2 bbb
-3#     dx  ex  dx   a
-b3#  bxdxbx exbdx  e
+3#     d
+x  e
+x  d
+x   a
+b
+3#  b
+xd
+xb
+x e
+xbd
+x  e
 b
 2 ebb
-3#   ax   bx    dx   a
+3#   a
+x   b
+x    d
+x   a
 b
 2be- b
-3# dex  dx  bx   d
+3# de
+x  d
+x  b
+x   d
 b
 2  bb
-3# bx  bx   dx   b
+3# b
+x  b
+x   d
+x   b
 b
 
 b
 2 bc
-3#  bx   dx   bx   d
-b3#  bx  cx  bx   d
+3#  b
+x   d
+x   b
+x   d
+b
+3#  b
+x  c
+x  b
+x   d
 2d- b
 b
-3#b - bx exb
-xdx e- dxb
+3#b - b
+x e
+xb
+xd
+x e- d
+xb
 b
-2# dx     d
-3#d - bxb
+2# d
+x     d
+3#d - b
+xb
 b
 2 e- d
 2. dba d
-4# bx a
+4# b
+x a
 b
-2# bx      /ax    d
+2# b
+x      /a
+x    d
 b
 1 bbc
 bQX
@@ -8822,21 +16435,55 @@ b
 2.bde   //a
 3d
 2e- d
-b2# bx eb-dxb
+b
+2# b
+x eb-d
+xb
 b
 
-b2#dx     dx    a
-b2#   abx      //axb
-b2#      /ax ebx      a
-b2#     dx dx a a
-b2# ex    dxd
-b2#be- bx dex bc
-b2# abxdx    d
 b
-3# exbx dx ex bx d
+2#d
+x     d
+x    a
 b
-2# ax     dx  b
-b2#   b- /ax      ax     d
+2#   ab
+x      //a
+xb
+b
+2#      /a
+x eb
+x      a
+b
+2#     d
+x d
+x a a
+b
+2# e
+x    d
+xd
+b
+2#be- b
+x de
+x bc
+b
+2# ab
+xd
+x    d
+b
+3# e
+xb
+x d
+x e
+x b
+x d
+b
+2# a
+x     d
+x  b
+b
+2#   b- /a
+x      a
+x     d
 b
 
 b
@@ -8848,41 +16495,93 @@ b
 bXQ
 bXQ
 2b
-b3#b  -  //ax exbxdxex   d
 b
-3# b -- /ax  ex bx dx exb
+3#b  -  //a
+x e
+xb
+xd
+xe
+x   d
+b
+3# b -- /a
+x  e
+x b
+x d
+x e
+xb
 b
 2d
-3#     dx    ax    bx    d
+3#     d
+x    a
+x    b
+x    d
 b
 2   ab
-3#      //ax    bx    dx    a
-b3#    dx   ax   bx   d
+3#      //a
+x    b
+x    d
+x    a
+b
+3#    d
+x   a
+x   b
+x   d
 2   a
 b
 
 b
-3#     dx dx bx dx ax   a
+3#     d
+x d
+x b
+x d
+x a
+x   a
 b
 2 e
-3#    dxb
+3#    d
+xb
 2d- b
 b
-3#b - bx ex dx ex bx d
+3#b - b
+x e
+x d
+x e
+x b
+x d
 b
-2# abxdx    d
+2# ab
+xd
+x    d
 b
-3#   bx   dx   ax   bx    dx   a
-b3#    cx     dx    ax    cx    dx   a
-b3#   bx   d
-2#   ax     d
-b2#    dx      /ax    d
+3#   b
+x   d
+x   a
+x   b
+x    d
+x   a
+b
+3#    c
+x     d
+x    a
+x    c
+x    d
+x   a
+b
+3#   b
+x   d
+2#   a
+x     d
+b
+2#    d
+x      /a
+x    d
 b
 Y bbc
 b
 B
 
-{24a. Courante de Gaulthier - 7F8Ef10C/GB-Eu Coll.2073, ff. 183v-184v}BX
+{24a. Courante de Gaulthier - 7F8Ef10C/GB-Eu Coll.2073, ff. 183v-184v}
+BX
 bX
 S3
 2  a
@@ -9639,7 +17338,8 @@ b
 B
 
 { }
-{24c. Co: - 7F8E9D10C/RUS-SPan O No 124, ff. 47v-48r}BX
+{24c. Co: - 7F8E9D10C/RUS-SPan O No 124, ff. 47v-48r}
+BX
 bX
 S3
 2  a
@@ -10017,19 +17717,31 @@ b
 2.fh    a
 3h
 2f
-b2#d    ax ax c
-b2 dd  c
-3#     dxc
+b
+2#d    a
+x a
+x c
+b
+2 dd  c
+3#     d
+xc
 2a   a
 b
 1 d  c
 2a d e
 b
 2cdda
-3#      axd
+3#      a
+xd
 2f
-b2#ff    /axdxcdd   a
-b2#ax      ///ax    a
+b
+2#ff    /a
+xd
+xcdd   a
+b
+2#a
+x      ///a
+x    a
 b
 1acd
 bbX
@@ -10037,50 +17749,121 @@ bbX
 b
 
 b
-3#      axfx hxhxfxh
+3#      a
+xf
+x h
+xh
+xf
+xh
 b
-3#     axdx ax cx dxa
+3#     a
+xd
+x a
+x c
+x d
+xa
 b
-3#     cx ddx     dxcxa   ax  d
-b3#    cx dx  ax  cx    exa
-b3#   axcx      axd
+3#     c
+x dd
+x     d
+xc
+xa   a
+x  d
+b
+3#    c
+x d
+x  a
+x  c
+x    e
+xa
+b
+3#   a
+xc
+x      a
+xd
 2f
 b
-3#      /axfx fxdxc     ax d
+3#      /a
+xf
+x f
+xd
+xc     a
+x d
 b
-2#ax      ///ax    a
+2#a
+x      ///a
+x    a
 b
 1acd   ///a
 bbX
-3# dxa
+3# d
+xa
 b
 
 b
-2#cddax      axc
-b2#cdda
+2#cdda
+x      a
+xc
+b
+2#cdda
 2.acd a
 3     d
 b
-2#     cx ddax cd a
-b2# dd   axfx      ///a
-b2#ffh  fx    hxffhh
-b2# d  cx    axa    db2#cce  cx    ex   e
+2#     c
+x dda
+x cd a
+b
+2# dd   a
+xf
+x      ///a
+b
+2#ffh  f
+x    h
+xffhh
+b
+2# d  c
+x    a
+xa    d
+b
+2#cce  c
+x    e
+x   e
 b
 2.cce
-3#axcxa
+3#a
+xc
+xa
 b
 
 b
-2#      //ax ef cx    a
-b2#     exafx d
-b2#    ax cdcx     d
-b2# dd  cxad   ax c
-b2#cdd   axf     /axd
-b2cdd   a
-2.a     ///a
-4# dxa
+2#      //a
+x ef c
+x    a
 b
-2# dx      ax   a
+2#     e
+xaf
+x d
+b
+2#    a
+x cdc
+x     d
+b
+2# dd  c
+xad   a
+x c
+b
+2#cdd   a
+xf     /a
+xd
+b
+2cdd   a
+2.a     ///a
+4# d
+xa
+b
+2# d
+x      a
+x   a
 b
 Y dd
 b
@@ -10096,9 +17879,14 @@ b
 2#fh    a
 xh
 xf
-b2#df   ax ax c
-b2cd   c
-3#     dxc
+b
+2#df   a
+x a
+x c
+b
+2cd   c
+3#     d
+xc
 2a   a
 b
 2# da c
@@ -10106,10 +17894,16 @@ x  b
 xa d e
 b
 2c  a
-3#      axd
+3#      a
+xd
 2f
-b2#ff    /axdxc     a
-b2#a     ///ax    a
+b
+2#ff    /a
+xd
+xc     a
+b
+2#a     ///a
+x    a
 x   c
 b
 1acd
@@ -10120,50 +17914,98 @@ b
 2#fh    a
 xh
 xf
-b2#d    ax ax cb
-2cd   c3#     dxc2a   a
-b1 da c2a   e
-b1Qc  a2Q     a
+b
+2#d    a
+x a
+x c
+b
+2cd   c
+3#     d
+xc
+2a   a
+b
+1 da c
+2a   e
+b
+1Qc  a
+2Q     a
 b
 3#c    c
 x     d
-2#a   ax  d
+2#a   a
+x  d
 b
 2# dda
 x      a
 x   a
 b
-1 ddabbX
+1 dda
+bbX
 3# d
 xa
 b
 
 b
-2#cddax      axcdd
-b2cdda
+2#cdda
+x      a
+xcdd
+b
+2cdda
 2.acd a
 3     d
 b
-1 dd  c2 cb  a
-b2#      a
-x dd fxf
-b2#      ///ax    hxffh
-b2# da cx    axa    db2#c    cx    ex   e
+1 dd  c
+2 cb  a
+b
+2#      a
+x dd f
+xf
+b
+2#      ///a
+x    h
+xffh
+b
+2# da c
+x    a
+xa    d
+b
+2#c    c
+x    e
+x   e
 b
 1cce
-2ab
+2a
+b
 
 b
-2#    cx eax    a
-b2#     ex ffx d
-b2#      ///ax cdcx     d
-b2# dd  cxad   cx c
-b2#c     ax dxd    a
-b2c    c
-3#     d
-xc2a   a
+2#    c
+x ea
+x    a
 b
-2# ddax      ax   a
+2#     e
+x ff
+x d
+b
+2#      ///a
+x cdc
+x     d
+b
+2# dd  c
+xad   c
+x c
+b
+2#c     a
+x d
+xd    a
+b
+2c    c
+3#     d
+xc
+2a   a
+b
+2# dda
+x      a
+x   a
 b
 Y dd
 b
@@ -10179,9 +18021,14 @@ b
 2#fh    a
 xh
 xfh
-b2#df   Qax ax c
-b2cd   c
-3#     dxc
+b
+2#df   Qa
+x a
+x c
+b
+2cd   c
+3#     d
+xc
 2a   a
 b
 2# d  c
@@ -10189,102 +18036,17 @@ x  b
 xa d e
 b
 2-+c  a
-3#      axd
+3#      a
+xd
 2-\4f
-b2.ff    /a3d2cd   a
-b2#ax    a
-x      ///a
 b
-1acd
-bXQ
-bXQ
-2f
-b
-
-b
-2#fh    a
-xh
-xf
-b2#d    ax ax cb
-2cd   c3#     dxc2a&,   a
-b2# d  cx  b
-xa   e
-b2c&,  a3#     a
-xf
-xda   a
-x c
-b
-3#cd   c
-x     d
-2#a   ax  d
-b
-2# d
-x   a
-x      a
-b
-1 ddbbX
-3# d
-xa
-b
-
-b
-2#cdd   axcddxcdda
-b2cdd   a
-2.acd a
-3     d
-b
-2# d   \2c
-x  dx cb  a
-bQ
-1Q ddef
-2Q+f
-b2#      ///a
-x     fxffhQh
-b2# da cx    axaa   db2#+cce  cx   ex  f
-b
-2#cce
-x   e
-x fb
-
-b
-2# efex    cx    a&,
-b2#aa   ex   cx d
-b2#      ///ax cdcax     d
-b2# dda cx    cx cbc
-b1Qcdd   a2Qdf    /a
-b2cdd   a
-3#      ///a
-xcxa   a
-x  d
-b
-2# dx   a
-x      ab
-Y dd
-b
-B
-
-{25d. Untitled - 7F810C/I-Rvat Barberini Lat. 4180, f. 5v}
-BX
-bX
-S3
-2f
-b
-2.fh    a
-3h:
-2f.
-b2#d    ax a&,x c
-b2cd   c
-3#     dxc
-2a   a
-b
-1 da c
-2a   e
-b
-2.c  a
+2.ff    /a
 3d
-2f     a
-b1d    a3#dxc
-b2#acd ax      ///ax    a
+2cd   a
+b
+2#a
+x    a
+x      ///a
 b
 1acd
 bXQ
@@ -10298,19 +18060,175 @@ xh
 xf
 b
 2#d    a
-x a&,x c
-b2c    c
-3#     dxc
+x a
+x c
+b
+2cd   c
+3#     d
+xc
+2a&,   a
+b
+2# d  c
+x  b
+xa   e
+b
+2c&,  a
+3#     a
+xf
+xda   a
+x c
+b
+3#cd   c
+x     d
+2#a   a
+x  d
+b
+2# d
+x   a
+x      a
+b
+1 dd
+bbX
+3# d
+xa
+b
+
+b
+2#cdd   a
+xcdd
+xcdda
+b
+2cdd   a
+2.acd a
+3     d
+b
+2# d   \2c
+x  d
+x cb  a
+bQ
+1Q ddef
+2Q+f
+b
+2#      ///a
+x     f
+xffhQh
+b
+2# da c
+x    a
+xaa   d
+b
+2#+cce  c
+x   e
+x  f
+b
+2#cce
+x   e
+x f
+b
+
+b
+2# efe
+x    c
+x    a&,
+b
+2#aa   e
+x   c
+x d
+b
+2#      ///a
+x cdca
+x     d
+b
+2# dda c
+x    c
+x cbc
+b
+1Qcdd   a
+2Qdf    /a
+b
+2cdd   a
+3#      ///a
+xc
+xa   a
+x  d
+b
+2# d
+x   a
+x      a
+b
+Y dd
+b
+B
+
+{25d. Untitled - 7F810C/I-Rvat Barberini Lat. 4180, f. 5v}
+BX
+bX
+S3
+2f
+b
+2.fh    a
+3h:
+2f.
+b
+2#d    a
+x a&,
+x c
+b
+2cd   c
+3#     d
+xc
 2a   a
 b
 1 da c
 2a   e
-b2#c  ax      axd    a
 b
-3#c    cx     d
-2#a   ax  d
+2.c  a
+3d
+2f     a
 b
-2# ddax      ax   a
+1d    a
+3#d
+xc
+b
+2#acd a
+x      ///a
+x    a
+b
+1acd
+bXQ
+bXQ
+2f
+b
+
+b
+2#fh    a
+xh
+xf
+b
+2#d    a
+x a&,
+x c
+b
+2c    c
+3#     d
+xc
+2a   a
+b
+1 da c
+2a   e
+b
+2#c  a
+x      a
+xd    a
+b
+3#c    c
+x     d
+2#a   a
+x  d
+b
+2# dda
+x      a
+x   a
 b
 Y dd
 b
@@ -10322,76 +18240,140 @@ BX
 bX
 S3
 2 a
-b2# ab  dx bx d
-b2# bdca
-x  d3# a
+b
+2# ab  d
+x b
+x d
+b
+2# bdca
+x  d
+3# a
 x b
 b
-2# d  cxa   d
-3# d ax b
+2# d  c
+xa   d
+3# d a
+x b
 b
-2# a cx  bx dde
-b2# affx     dxd
-b2#f  ex dxddf  d
-b2#cddax      ax   a
+2# a c
+x  b
+x dde
+b
+2# aff
+x     d
+xd
+b
+2#f  e
+x d
+xddf  d
+b
+2#cdda
+x      a
+x   a
 b
 1cdd
 2 a
 b
 
-b2# ab  d
-x bx d
-b2# bdca
-x  d3# a
+b
+2# ab  d
+x b
+x d
+b
+2# bdca
+x  d
+3# a
 x b
 b
-2# d  cxa   d
-3# d ax b
+2# d  c
+xa   d
+3# d a
+x b
 b
-2# a cx  bx dde
-b2# affxdxa   d
-b2  d
+2# a c
+x  b
+x dde
+b
+2# aff
+xd
+xa   d
+b
+2  d
 2. dda
 3 b
 b
-2# abc dx    cx   a
+2# abc d
+x    c
+x   a
 b
 1 ab
 bbX
-3# ax  d
+3# a
+x  d
 b
 
 b
-2#  bx     dx   a
-b2dab
+2#  b
+x     d
+x   a
+b
+2dab
 2.cdda
 3    d
 b
-2#dd  cx    axc
-b2#da   Qdx ax c
-b2#cddax      ax   a
-b2#da cx   ax-Qf   d
-b2#cefecx      //ax    c
+2#dd  c
+x    a
+xc
+b
+2#da   Qd
+x a
+x c
+b
+2#cdda
+x      a
+x   a
+b
+2#da c
+x   a
+x-Qf   d
+b
+2#cefec
+x      //a
+x    c
 b
 1cef
-3# cx e
+3# c
+x e
 b
 
 b
-2#aa cx     ax   a
-b2#a   ex  d
-3# dxa
+2#aa c
+x     a
+x   a
 b
-2#cddax      ax    d
-b2# db cxabd axc
+2#a   e
+x  d
+3# d
+xa
+b
+2#cdda
+x      a
+x    d
+b
+2# db c
+xabd a
+xc
 b
 1dab  d
 2 dd  c
-b2 ab  d
+b
+2 ab  d
 2. dda
 3 b
 b
-2# aba dx    cx   a
+2# aba d
+x    c
+x   a
 b
 Y ab
 b
@@ -10412,27 +18394,46 @@ b
 2.}d&+a - a
 3a.
 2 d
-b2# cb  ax d&+a
-3#   cx   a.
 b
-2#a d ex     fx     d
-b2#cd - cxdc - ax-,cd -- a
-b2#,a  -  /ax  d.
-3# d -- axa.
+2# cb  a
+x d&+a
+3#   c
+x   a.
+b
+2#a d e
+x     f
+x     d
+b
+2#cd - c
+xdc - a
+x-,cd -- a
+b
+2#,a  -  /a
+x  d.
+3# d -- a
+xa.
 b
 
 b
 2-||c  a
 2.||a - a
-4#  d:x a.
+4#  d:
+x a.
 b
-2#  d:x    ax      ///a
+2#  d:
+x    a
+x      ///a
 b
 1  dc
 bbX
 2  d.
 b
-3#  def ax  a.x  b:x  d.x a:x c.
+3#  def a
+x  a.
+x  b:
+x  d.
+x a:
+x c.
 b
 3#  Qd
 x  Qb
@@ -10440,15 +18441,54 @@ x  Qd
 x   Qe
 x Qd
 x Qc
-b3# d -- axa.xc:x d.xa:x d.
-b3# c   ax  d.x  bx  a.x   cx   a.
+b
+3# d -- a
+xa.
+xc:
+x d.
+xa:
+x d.
+b
+3# c   a
+x  d.
+x  b
+x  a.
+x   c
+x   a.
 b
 
-b3#    e&+xa.x  d:x     fx     dxa.
-b3#c -- cx d.x c:x     ax d -- axc.
-b3#a  -  /ax d.x c:x  d.x d - axa.
-b3# c  ax d.x     ax c.x a:x   c.
-b2#  d:x    ax      ///a
+b
+3#    e&+
+xa.
+x  d:
+x     f
+x     d
+xa.
+b
+3#c -- c
+x d.
+x c:
+x     a
+x d -- a
+xc.
+b
+3#a  -  /a
+x d.
+x c:
+x  d.
+x d - a
+xa.
+b
+3# c  a
+x d.
+x     a
+x c.
+x a:
+x   c.
+b
+2#  d:
+x    a
+x      ///a
 b
 1  dc
 bbX
@@ -10467,8 +18507,12 @@ b
 2.  ||a - a
 3  d.
 2  b  a
-b2#  ||a  cx   c dx    a
-b2  ||a - a
+b
+2#  ||a  c
+x   c d
+x    a
+b
+2  ||a - a
 2.    a
 3  d.
 b
@@ -10476,40 +18520,101 @@ b
 2 c.
 b
 2. aa - //a
-3# c.x d  cxa.
-b3#c:x    ex   a.xc.xa:x  d.
+3# c.
+x d  c
+xa.
+b
+3#c:
+x    e
+x   a.
+xc.
+xa:
+x  d.
 b
 
 b
-2# d:x   ax      a
+2# d:
+x   a
+x      a
 b
 1 dd
 bbX
-3#   f:x   e.
-b3#   c:x      ///ax   e:x   c.x   a:x      //a
-b3#  b:x  a.x   c:x      /ax  d:x  b.
-b3#  a:x      ax a:x  d.x  b:x     a
-b3#     cx  a.x   c:x     dx    ax  b.
+3#   f:
+x   e.
+b
+3#   c:
+x      ///a
+x   e:
+x   c.
+x   a:
+x      //a
+b
+3#  b:
+x  a.
+x   c:
+x      /a
+x  d:
+x  b.
+b
+3#  a:
+x      a
+x a:
+x  d.
+x  b:
+x     a
+b
+3#     c
+x  a.
+x   c:
+x     d
+x    a
+x  b.
 b
 
-b3#  a:x      a
-3.   a:
-4  c.4#  d:x  c.x  a:x  c.
 b
-3#  d:x      ///ax   c:xa.x d:x c.
+3#  a:
+x      a
+3.   a:
+4  c.
+4#  d:
+x  c.
+x  a:
+x  c.
+b
+3#  d:
+x      ///a
+x   c:
+xa.
+x d:
+x c.
 b
 3. aa - //a
-4  a.4#  c:x  d.x a:x c.
-3# d: c;xa.
-b3#c:x    ex   axc.xa:x  d.
+4  a.
+4#  c:
+x  d.
+x a:
+x c.
+3# d: c;
+xa.
 b
-2# d:x    ax      a
+3#c:
+x    e
+x   a
+xc.
+xa:
+x  d.
+b
+2# d:
+x    a
+x      a
 b
 Y da
 b
 B
 
-{ }{26b. Autre du mesme ton - 7F8E9D10C/GB-Eu Coll.2073, f. 185r}BX
+{ }
+{26b. Autre du mesme ton - 7F8E9D10C/GB-Eu Coll.2073, f. 185r}
+BX
 bX
 S3
 2  d
@@ -10523,95 +18628,220 @@ b
 2. d    a
 3a
 2 d
-b2# cb  Qax da
-3#   cx   a
+b
+2# cb  Qa
+x da
+3#   c
+x   a
 b
 2#a d e
-x     fx     d
-b2#c    cxd    axc     a
-b2#a     /a
+x     f
+x     d
+b
+2#c    c
+xd    a
+xc     a
+b
+2#a     /a
 x  d
-3# d    axa
+3# d    a
+xa
 b
 
 b
 2 cb a
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx      ///ax    a
+2#  d
+x      ///a
+x    a
 b
 1  dc
 bXQ
 bXQ
 2  d
 b
-3#      ax  dx   ex   fx  dx  f
+3#      a
+x  d
+x   e
+x   f
+x  d
+x  f
 b
-2#  dx   ex d
+2#  d
+x   e
+x d
 b
-3#      ax dx   axcxax d
-b3#     Qax cdx   cx   ax    exa
+3#      a
+x d
+x   a
+xc
+xa
+x d
+b
+3#     Qa
+x cd
+x   c
+x   a
+x    e
+xa
 b
 
-b3#  dx    cx    ax     dx     cx dd
-b3#     ax axdx cx      axc
-b3#      /axax  dxcx d    axa
-b3# c  ax dx     ax cx a
+b
+3#  d
+x    c
+x    a
+x     d
+x     c
+x dd
+b
+3#     a
+x a
+xd
+x c
+x      a
+xc
+b
+3#      /a
+xa
+x  d
+xc
+x d    a
+xa
+b
+3# c  a
+x d
+x     a
+x c
+x a
 x  c
-b2#  d
-x      ///ax    a
+b
+2#  d
+x      ///a
+x    a
 b
 1  dc
 bXQ
 bXQ
 2  a
 b
-2.   c  ///a3   e2   a  //a
+2.   c  ///a
+3   e
+2   a  //a
 b
 
-b2  b
+b
+2  b
 2.   c  /a
 3  d
 b
 2.  a   a
 3  d
 2  b  a
-b2#  a  cx   c dx    a
-b2#  a   ax   ax  d
+b
+2#  a  c
+x   c d
+x    a
+b
+2#  a   a
+x   a
+x  d
 b
 1.  dc  /a
 b
 2. a    //a
-3# cx d  cxa
-b3#cx    ex   axcxa   ax  d
+3# c
+x d  c
+xa
+b
+3#c
+x    e
+x   a
+xc
+xa   a
+x  d
 b
 
-b2# dx      ax   a
+b
+2# d
+x      a
+x   a
 b
 1 dd
 bXQ
 bXQ
 2   a
 b
-3#      ///ax   cx    ax   ex      //ax  a
-b3#  bx  ax      /ax   cx  dx  b
-b3#      ax  ax   ax  dx     ax  b
-b3#     cx  ax   c dx    ax    cx    e
+3#      ///a
+x   c
+x    a
+x   e
+x      //a
+x  a
+b
+3#  b
+x  a
+x      /a
+x   c
+x  d
+x  b
+b
+3#      a
+x  a
+x   a
+x  d
+x     a
+x  b
+b
+3#     c
+x  a
+x   c d
+x    a
+x    c
+x    e
 b
 
-b3#      ax  ax   ax   cx  ax  b
-b3#      /ax  dx   cx ax cx d
-b3#      //ax  ax ax cx d  cxa
-b3#cx    ex   axcxa   ax  d
 b
-2# dx      ax   a
+3#      a
+x  a
+x   a
+x   c
+x  a
+x  b
+b
+3#      /a
+x  d
+x   c
+x a
+x c
+x d
+b
+3#      //a
+x  a
+x a
+x c
+x d  c
+xa
+b
+3#c
+x    e
+x   a
+xc
+xa   a
+x  d
+b
+2# d
+x      a
+x   a
 b
 Y dd
 b
 B
 
-p{26c. Cor: - 7F8E10C/RUS-SPan O No 124, f. 48v}
+p
+{26c. Cor: - 7F8E10C/RUS-SPan O No 124, f. 48v}
 BX
 bX
 S3
@@ -10627,247 +18857,413 @@ b
 x   a
 3#a
 x d
-b2# cdx da
-3#   cx   a
+b
+2# cd
+x da
+3#   c
+x   a
 b
 2#a d e
-x     fx     d
-b2#c    cx c   ax d    a
-b2#a     /a
+x     f
+x     d
+b
+2#c    c
+x c   a
+x d    a
+b
+2#a     /a
 x  d
-3# d    //axa
+3# d    //a
+xa
 b
 
 b
 2 c    ///a
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    a
-x      ///ab
+2#  d
+x    a
+x      ///a
+b
 1  dc
-bbX2  a
+bbX
+2  a
 b
-2.   c  ///a3   e2.   a  //a
-b3  b
+2.   c  ///a
+3   e
+2.   a  //a
+b
+3  b
 2.   c  /a
 3  d
 b
 2.  a   a
 3  d
 2  b
-b2#  ax   c dx    a
+b
+2#  a
+x   c d
+x    a
 b
 
 -l "4.5 in"
 b
-2#  aa  ax   ax  d
+2#  aa  a
+x   a
+x  d
 b
 2  dc  ///a
 3# a    //a
-x cx dxa
-b2c     a3#      /axcxa   ax  d
-b2# dx   a
-x      ab
+x c
+x d
+xa
+b
+2c     a
+3#      /a
+xc
+xa   a
+x  d
+b
+2# d
+x   a
+x      a
+b
 Y dda
 b
 B
 
 { }
 -l "7.35 in"
-{27a. Courante Gothier - 7F8Ef/CZ-Pnm G.IV.18, f. 21r}BX
-bX
-S3
-2b
-b
-2.bdd   a
-3#dxbxa
-b
-2 d
-2. c ca
-4# ax c
-b
-2. d
-3#    bx    ax     d
-b
-2#     bxb ex  d
-b2a d   /a
-3#b bx   d
-2d  c
-b2f  d
-2.d   d
-4# gxd
-b
-2#fx g  fxh
-b2#ix      /axd
-b2#     dxgdx f
-b
-
-b2#fg    dxdeg   /ax  e
-b2#bbd  bx    dx   d
-b
-1bbd
-bbX
-2f
-b
-2.fgd   a
-3 dxaxb
-b
-2d    d
-2.b     a
-4#axb
-b
-2#a    Qax bxd   c
-b2#d   dxbxa
-b
-2. dddf
-3 f
-2 bdca
-b2# dx a   ax   c
-b
-
-b2#  d  bx   cx   a
-b2  d e
-3#     Qax  b
-2 d
-b2# cdx    a
-3#  dx     d
-b
-2# d   bx     a
-3#      axb
-b
-2#a     /ax bxb
-b
-2.bbd  b
-3d
-2f
-b2# d   dxd exdc  a
-b2b d
-2.ac  a
-4# dxa
-b
-2# dx      ax   a
-b
-Y dd
-b
-B
-{27b. Untitled - 7F8Ef/RUS-SPan O No 124, f. 55r}BX
-bX
-S3
-2b
-b
-2.bdd   a
-3#dxbxa
-b
-2 d
-2. c  a
-4# ax c
-b
-2. d
-3#    bx    ax     d
-b
-2#     bx-Qb ex  d
-b2a d
-3#b dx   d
-2d  c
-b2f  d
-2.d   d
-4# gxd
-b
-2#fx g  fxh
-b2#i  hx      /axd
-b2#     dxgdx f
-b
-
-b2fd    d2.dfg   /a3  e
-b2#bbd  bx    dx   d
-b
-1bbd
-bbX
-2f
-b
-2.fg    a
-3# dxaxb
-b
-2#d    d
-xb     a
-3#axb
-b
-2#a     /ax bxd
-b2.db  d3b2a
-b
-2# d df
-x f
-x bdca
-b2# dx a   ax   c
-b
-
-b2  d  b3#   cx   a
-x    e
-x  Qd
-b3#     a
-x  b
-2# dx cd
-b
-2#    ax  dx     d
-b
-2  d  b3#     a
-x      a2b
-b
-2#a     /ax bxb
-b
-2.bbd  b
-3d
-2f
-b2# d   dxd exdcd a
-b2bd
-2.a   a
-4# dxa
-b
-2# dx   a
-x      ab
-Y dd
-b
-B
-
-{ }{27c. Courante - 7F8Ef/Moy 1631 f. 32v}
+{27a. Courante Gothier - 7F8Ef/CZ-Pnm G.IV.18, f. 21r}
 BX
 bX
 S3
 2b
 b
 2.bdd   a
-3#dxbxa
+3#d
+xb
+xa
+b
+2 d
+2. c ca
+4# a
+x c
+b
+2. d
+3#    b
+x    a
+x     d
+b
+2#     b
+xb e
+x  d
+b
+2a d   /a
+3#b b
+x   d
+2d  c
+b
+2f  d
+2.d   d
+4# g
+xd
+b
+2#f
+x g  f
+xh
+b
+2#i
+x      /a
+xd
+b
+2#     d
+xgd
+x f
+b
+
+b
+2#fg    d
+xdeg   /a
+x  e
+b
+2#bbd  b
+x    d
+x   d
+b
+1bbd
+bbX
+2f
+b
+2.fgd   a
+3 d
+xa
+xb
+b
+2d    d
+2.b     a
+4#a
+xb
+b
+2#a    Qa
+x b
+xd   c
+b
+2#d   d
+xb
+xa
+b
+2. dddf
+3 f
+2 bdca
+b
+2# d
+x a   a
+x   c
+b
+
+b
+2#  d  b
+x   c
+x   a
+b
+2  d e
+3#     Qa
+x  b
+2 d
+b
+2# cd
+x    a
+3#  d
+x     d
+b
+2# d   b
+x     a
+3#      a
+xb
+b
+2#a     /a
+x b
+xb
+b
+2.bbd  b
+3d
+2f
+b
+2# d   d
+xd e
+xdc  a
+b
+2b d
+2.ac  a
+4# d
+xa
+b
+2# d
+x      a
+x   a
+b
+Y dd
+b
+B
+
+{27b. Untitled - 7F8Ef/RUS-SPan O No 124, f. 55r}
+BX
+bX
+S3
+2b
+b
+2.bdd   a
+3#d
+xb
+xa
+b
+2 d
+2. c  a
+4# a
+x c
+b
+2. d
+3#    b
+x    a
+x     d
+b
+2#     b
+x-Qb e
+x  d
+b
+2a d
+3#b d
+x   d
+2d  c
+b
+2f  d
+2.d   d
+4# g
+xd
+b
+2#f
+x g  f
+xh
+b
+2#i  h
+x      /a
+xd
+b
+2#     d
+xgd
+x f
+b
+
+b
+2fd    d
+2.dfg   /a
+3  e
+b
+2#bbd  b
+x    d
+x   d
+b
+1bbd
+bbX
+2f
+b
+2.fg    a
+3# d
+xa
+xb
+b
+2#d    d
+xb     a
+3#a
+xb
+b
+2#a     /a
+x b
+xd
+b
+2.db  d
+3b
+2a
+b
+2# d df
+x f
+x bdca
+b
+2# d
+x a   a
+x   c
+b
+
+b
+2  d  b
+3#   c
+x   a
+x    e
+x  Qd
+b
+3#     a
+x  b
+2# d
+x cd
+b
+2#    a
+x  d
+x     d
+b
+2  d  b
+3#     a
+x      a
+2b
+b
+2#a     /a
+x b
+xb
+b
+2.bbd  b
+3d
+2f
+b
+2# d   d
+xd e
+xdcd a
+b
+2bd
+2.a   a
+4# d
+xa
+b
+2# d
+x   a
+x      a
+b
+Y dd
+b
+B
+
+{ }
+{27c. Courante - 7F8Ef/Moy 1631 f. 32v}
+BX
+bX
+S3
+2b
+b
+2.bdd   a
+3#d
+xb
+xa
 b
 2 d
 2. cdca
-4# ax c
+4# a
+x c
 b
 2. d
-3#    bx    ax     d
+3#    b
+x    a
+x     d
 b
-2#     bxbbx  d
-b2#a b   /a
+2#     b
+xbb
+x  d
+b
+2#a b   /a
 x   d
 x   c
-b2#f  d
-xd   d
-3#bxd
 b
-2#fxbddax      a
-b3# b  ax dxa
+2#f  d
+xd   d
+3#b
+xd
+b
+2#f
+xbdda
+x      a
+b
+3# b  a
+x d
+xa
 xb
 2d
-b2#     dxg -xa
+b
+2#     d
+xg -
+xa
 b
 2.cdda
 3d
 2f
 b
 
-b2f  d2.d   d4# g
+b
+2f  d
+2.d   d
+4# g
 xd
-b1 g
+b
+1 g
 2     b
 b
 1bbd
@@ -10875,33 +19271,56 @@ bbX
 2f
 b
 2.fg    a
-3# dxaxb
+3# d
+xa
+xb
 b
 2d    d
 2.bdd   a
-4#axb
+4#a
+xb
 b
-2#a   ax bxd   c
-b2#d   dx bxd   c
+2#a   a
+x b
+xd   c
+b
+2#d   d
+x b
+xd   c
 b
 2#dbbcd
 xb
 xa
-b2# ddaxa -x bdca
+b
+2# dda
+xa -
+x bdca
 b
 
-b2# dx a   Qax   c
-b2.  d  b
-3#   cx   a
+b
+2# d
+x a   Qa
+x   c
+b
+2.  d  b
+3#   c
+x   a
 x    e
-b2#   ax      a
-3#  bx d
 b
-2# cdx    a
-3#  dx     d
+2#   a
+x      a
+3#  b
+x d
 b
-2# d   bx     a
-3#      axb
+2# cd
+x    a
+3#  d
+x     d
+b
+2# d   b
+x     a
+3#      a
+xb
 b
 2#a     /a
 x b
@@ -10910,20 +19329,26 @@ b
 2.bbd  b
 3d
 2f
-b1dfg d
-2     d
-b2bd a
-2.a - a
-4# dxa
 b
-2# dx   a
-x      ab
+1dfg d
+2     d
+b
+2bd a
+2.a - a
+4# d
+xa
+b
+2# d
+x   a
+x      a
+b
 Y dd
 b
 B
 
 
-{28a. Courante Gothier - 7F8Ef10C/CZ-Pnm G.IV.18, ff. 20v-21r}BX
+{28a. Courante Gothier - 7F8Ef10C/CZ-Pnm G.IV.18, ff. 20v-21r}
+BX
 bX
 S3
 2  d
@@ -10931,25 +19356,52 @@ b
 2. dda  a
 3a
 2 d
-b2# c  ax  dx d
-b2 d  b
-3#     dxa
+b
+2# c  a
+x  d
+x d
+b
+2 d  b
+3#     d
+xa
 2b
-b2#b    bx bdxb
-b2bde
-3#  dx  b
+b
+2#b    b
+x bd
+xb
+b
+2bde
+3#  d
+x  b
 2   d
-b2#gd fx fxfg d
-b2#dg  dx fx  ea
-b2#  bcx bx   d
+b
+2#gd f
+x f
+xfg d
+b
+2#dg  d
+x f
+x  ea
+b
+2#  bc
+x b
+x   d
 b
 
 b
-3# d abx   cx   dxa
+3# d ab
+x   c
+x   d
+xa
 2b
 b
-2#      /axb dxa b
-b2#bx     bx    d
+2#      /a
+xb d
+xa b
+b
+2#b
+x     b
+x    d
 b
 1bbdd
 bXQ
@@ -10959,28 +19411,68 @@ b
 2. dda  a
 3a
 2 d
-b2# c  ax  dx d
 b
-3# d ax   cx   dx  bx  dxa
+2# c  a
+x  d
+x d
+b
+3# d a
+x   c
+x   d
+x  b
+x  d
+xa
 b
 2b
-3#     bx  ex bx d
+3#     b
+x  e
+x b
+x d
 b
 2 b
-3#bxd
+3#b
+xd
 2f
 b
 
-b2g  f
-3#  dx  exf  dxg
 b
-3#d   dx  gx d
-x fx gxd
-b3#fxgxixaxbxd
-b3# d  bx    dx   ax    bx    ax     d
-b3#     bxbx      /axbxaxd
+2g  f
+3#  d
+x  e
+xf  d
+xg
 b
-2#bx     bx    d
+3#d   d
+x  g
+x d
+x f
+x g
+xd
+b
+3#f
+xg
+xi
+xa
+xb
+xd
+b
+3# d  b
+x    d
+x   a
+x    b
+x    a
+x     d
+b
+3#     b
+xb
+x      /a
+xb
+xa
+xd
+b
+2#b
+x     b
+x    d
 b
 1bbdd
 bXQ
@@ -10992,29 +19484,56 @@ b
 2g
 b
 
-b2#df  dxfxd
 b
-2#b  ax  e
-3#ax d
+2#df  d
+xf
+xd
 b
-2# c  ax  bx dd   a
-b2#ax      ///ax    a
+2#b  a
+x  e
+3#a
+x d
+b
+2# c  a
+x  b
+x dd   a
+b
+2#a
+x      ///a
+x    a
 b
 1acd
 2 g
-b2# gd   ax    fx   f
+b
+2# gd   a
+x    f
+x   f
 b
 1 de
 2d
-b2#d     /ax    dx  b
-b2#ax bdxf
-b2#f   ax      axd    a
+b
+2#d     /a
+x    d
+x  b
+b
+2#a
+x bd
+xf
+b
+2#f   a
+x      a
+xd    a
 b
 
-b2b    b
-3#     dxb
+b
+2b    b
+3#     d
+xb
 2a   a
-b2# dx      ax   a
+b
+2# d
+x      a
+x   a
 b
 1 dd
 bXQ
@@ -11024,11 +19543,29 @@ b
 2.dfg
 3f
 2g
-b2#df  dxf3#    axd
-b3#b  ax  ex  dx  bx   dx   c
-b3#   ax   cx    exaxdxb
 b
-2#ax      ///ax    a
+2#df  d
+xf
+3#    a
+xd
+b
+3#b  a
+x  e
+x  d
+x  b
+x   d
+x   c
+b
+3#   a
+x   c
+x    e
+xa
+xd
+xb
+b
+2#a
+x      ///a
+x    a
 b
 1acd
 2b
@@ -11036,20 +19573,56 @@ b
 
 b
 2.bdd   a
-3#dxbxa
-b3# d  bx    dx   ax   cx   dx  b
-b3#      /axdx   cxbxax d
-b3# bx   dx   cx   ax    dx    b
-b3#    axfx  dx ax cxd
-b3#bx     dx    axbxax c
+3#d
+xb
+xa
 b
-2# dx      ax   a
+3# d  b
+x    d
+x   a
+x   c
+x   d
+x  b
+b
+3#      /a
+xd
+x   c
+xb
+xa
+x d
+b
+3# b
+x   d
+x   c
+x   a
+x    d
+x    b
+b
+3#    a
+xf
+x  d
+x a
+x c
+xd
+b
+3#b
+x     d
+x    a
+xb
+xa
+x c
+b
+2# d
+x      a
+x   a
 b
 Y dd
 b
 B
 
-p{28b. Curant - 7F8Ef10C/GB-Lbl Sloane 1021, ff. 49v-50r}BX
+p
+{28b. Curant - 7F8Ef10C/GB-Lbl Sloane 1021, ff. 49v-50r}
+BX
 bX
 S3
 2 d
@@ -11057,27 +19630,51 @@ b
 2. dda  a
 3a
 2 d
-b2# c  ax  dx d
-b2. dda  a
-3#axb
+b
+2# c  a
+x  d
+x d
+b
+2. dda  a
+3#a
+xb
 xd
-b2#a   dx bxb
-b2.bbd  b
-3d2f
-b1g  f2f  d
-b1.dfg db
+b
+2#a   d
+x b
+xb
+b
+2.bbd  b
+3d
+2f
+b
+1g  f
+2f  d
+b
+1.dfg d
+b
 2# Qb  Qa
 x-Qb Qd
 x-Qa
 b
 
-b2. d  b
-3#axbxd
+b
+2. d  b
+3#a
+xb
+xd
 b
 2f  d
-3#    dxf2d
-b2#bx     bx    d
-b1bbddbXQ
+3#    d
+xf
+2d
+b
+2#b
+x     b
+x    d
+b
+1bbdd
+bXQ
 bXQ
 2 d
 b
@@ -11085,31 +19682,62 @@ b
 3#b
 xa
 x d
-b3# c  ax dxa
+b
+3# c  a
+x d
+xa
 x  b
 x   d
 x   c
 b
-3#   ax cx dxaxbxd
+3#   a
+x c
+x d
+xa
+xb
+xd
 b
-3#a   dx  bx  dx a
+3#a   d
+x  b
+x  d
+x a
 x b
 xa
 b
 3# d  b
-xaxb
+xa
+xb
 xd
 2f
 b
 
-b3#   f
-xgxf  dx d
+b
+3#   f
+xg
+xf  d
+x d
 x f
 x g
-b2#dx    dx  g
-b3# b  ax   cx   dx  bx  dx b
-b3# d  bx    ax    bx    d2   a
-b4#    dx    b
+b
+2#d
+x    d
+x  g
+b
+3# b  a
+x   c
+x   d
+x  b
+x  d
+x b
+b
+3# d  b
+x    a
+x    b
+x    d
+2   a
+b
+4#    d
+x    b
 x    d
 x    b
 4#    d
@@ -11121,7 +19749,8 @@ x    b
 x     d
 x    a
 b
-2#     bx    d
+2#     b
+x    d
 x   d
 b
 1bbd
@@ -11133,32 +19762,55 @@ b
 2g    d
 b
 
-b2#d     /ax fxf
-b2.b  a3d
+b
+2#d     /a
+x f
+xf
+b
+2.b  a
+3d
 2a   d
 b
-2# d  bx c  ax d
-b2#ax      ///ax    a
+2# d  b
+x c  a
+x d
+b
+2#a
+x      ///a
+x    a
 b
 1acd
 2      a
-b1Qbdd2Q    b
+b
+1Qbdd
+2Q    b
 b
 1bde
 2     d
-b1dde2      /a
+b
+1dde
+2      /a
 b
 2.a -- a
 3#    b
 x    a
 x     d
-b2.fg
-3#dxb  axa
+b
+2.fg
+3#d
+xb  a
+xa
 b
 
-b2b2.a   a4# d
+b
+2b
+2.a   a
+4# d
 xa
-b2# dx   ax      a
+b
+2# d
+x   a
+x      a
 b
 1 dd
 bbX
@@ -11167,16 +19819,32 @@ b
 2.dfg d
 3g
 2f    Qd
-b3#d     /ax g
+b
+3#d     /a
+x g
 x f
-xdxf   axd
-b3#b  ax   cx   dx cx dxa
-b2 d  b
-4#   ax   c
+xd
+xf   a
+xd
+b
+3#b  a
+x   c
+x   d
+x c
+x d
+xa
+b
+2 d  b
+4#   a
+x   c
 3#   d
-x cx d
-b2a
-4#   cx   ax   c
+x c
+x d
+b
+2a
+4#   c
+x   a
+x   c
 x   a
 4#   c
 x   a
@@ -11188,26 +19856,45 @@ b
 3    a
 3. a
 4#  Qc
-x  dx a
+x  d
+x a
 3 c
 x    a
 b
 2.bdd
-3#   cx   ax    d
-b2. d  b3#    d
+3#   c
+x   a
+x    d
+b
+2. d  b
+3#    d
 x    b
 x    a
-b2.     d
-3#fxdx g
-b2.a -- a
-3#    bx    ax     d
+b
+2.     d
+3#f
+xd
+x g
+b
+2.a -- a
+3#    b
+x    a
+x     d
 b
 2.    Qa
-3#fxdx f
-b2Qb     a
-3#    axbxax  d
+3#f
+xd
+x f
 b
-2# dx   ax      a
+2Qb     a
+3#    a
+xb
+xa
+x  d
+b
+2# d
+x   a
+x      a
 b
 Y dd
 b
@@ -11223,23 +19910,51 @@ b
 2. dda  a
 3a
 2 d
-b2# c  ax  dx d
-b2 d  b
-3#     dxa
+b
+2# c  a
+x  d
+x d
+b
+2 d  b
+3#     d
+xa
 2b
-b2#b    bx bdxb
-b2bde
-3#  dx  b
+b
+2#b    b
+x bd
+xb
+b
+2bde
+3#  d
+x  b
 2   d
-b2#gd fx fxfg d
-b2#dg  dx fx  ea
-b2#  bcx bx   d
+b
+2#gd f
+x f
+xfg d
+b
+2#dg  d
+x f
+x  ea
+b
+2#  bc
+x b
+x   d
 b
 
 b
-2 d  b3#   dxa2Qb
-b2#      /axb dxa b
-b2#bx     bx   d
+2 d  b
+3#   d
+xa
+2Qb
+b
+2#      /a
+xb d
+xa b
+b
+2#b
+x     b
+x   d
 b
 1bbd:
 bbX
@@ -11248,32 +19963,60 @@ b
 2.dfg   /a
 3f
 2g
-b2#df  dxf
-3#  - axd
-b2#b  ax  e
-3#ax d
 b
-2# cdx    Qax dda  a
-b2#ax      ///ax    a
+2#df  d
+xf
+3#  - a
+xd
+b
+2#b  a
+x  e
+3#a
+x d
+b
+2# cd
+x    Qa
+x dda  a
+b
+2#a
+x      ///a
+x    a
 b
 1acd:
 2 g
-b2#  d   ax    fx   f
+b
+2#  d   a
+x    f
+x   f
 b
 
 b
 1 de
 2d
-b2#d     /ax    dx  b
-b2#ax bdxf
-b2#f  dax      axd
-b3#b    b
+b
+2#d     /a
+x    d
+x  b
+b
+2#a
+x bd
+xf
+b
+2#f  da
+x      a
+xd
+b
+3#b    b
 x     d
-x    axb
+x    a
+xb
 xa
 x  d
-b2# dx   a
-x      ab
+b
+2# d
+x   a
+x      a
+b
 1 dd:
 bQX
 bX
@@ -11282,30 +20025,70 @@ b
 1 dda  a
 3.a
 4 d
-b2# c  ax  dx d
 b
-3# d Qax   Qcx   Qdx  Qbx  Qdxa
+2# c  a
+x  d
+x d
+b
+3# d Qa
+x   Qc
+x   Qd
+x  Qb
+x  Qd
+xa
 b
 
 b
 2b
-3#     bx  ex bx d
+3#     b
+x  e
+x b
+x d
 b
 2 b
-3#bxd
+3#b
+xd
 2f
-b3#g  f
-x  dx  e
-xgxf  dxg
-b3#d   d{x  gx d
-x fx gxd  }
-b3#fxgxi - axaxbxd
-b3# d  bx    dx   ax    bx    ax     d
+b
+3#g  f
+x  d
+x  e
+xg
+xf  d
+xg
+b
+3#d   d{
+x  g
+x d
+x f
+x g
+xd  }
+b
+3#f
+xg
+xi - a
+xa
+xb
+xd
+b
+3# d  b
+x    d
+x   a
+x    b
+x    a
+x     d
 b
 
-b3#     bxbx      /axbxax d
 b
-2#b    bx    d
+3#     b
+xb
+x      /a
+xb
+xa
+x d
+b
+2#b    b
+x    d
 x   d
 b
 1bbd:
@@ -11315,11 +20098,29 @@ b
 2.df    /a
 3f
 2g
-b2d   d3#fx    a2d
-b3#b  ax  ex  dx  bx   dx   c
-b3#   ax   cx    exaxdxb
 b
-2#ax      ///ax    a
+2d   d
+3#f
+x    a
+2d
+b
+3#b  a
+x  e
+x  d
+x  b
+x   d
+x   c
+b
+3#   a
+x   c
+x    e
+xa
+xd
+xb
+b
+2#a
+x      ///a
+x    a
 b
 1acd:
 2b
@@ -11328,14 +20129,48 @@ b
 b
 2bdd   a
 3#   a
-xdxbxa
-b3# d  b {x    dx   ax   cx   dx  b }
-b3#      /axdx   cxbxax d
-b3# bx   dx   cx   ax    dx    b
-b3#    axfx  dx ax cxd
-b3#b    bx     dx    axbxax d
+xd
+xb
+xa
 b
-2# dx      ax   a
+3# d  b {
+x    d
+x   a
+x   c
+x   d
+x  b }
+b
+3#      /a
+xd
+x   c
+xb
+xa
+x d
+b
+3# b
+x   d
+x   c
+x   a
+x    d
+x    b
+b
+3#    a
+xf
+x  d
+x a
+x c
+xd
+b
+3#b    b
+x     d
+x    a
+xb
+xa
+x d
+b
+2# d
+x      a
+x   a
 b
 Ycdd:
 b
@@ -11347,28 +20182,55 @@ BX
 bX
 S3
 2  d
-b2.  dca3 a2  d
 b
-2#  c:  ax   c3#  a:
+2.  dca
+3 a
+2  d
+b
+2#  c:  a
+x   c
+3#  a:
 x  c
-b2  d a
-3#      ///a
-x ax bx d
 b
-2# b  d:x  bx b
-b2. b:    /a3 d2a
-b2.b:  a3 a2a   d
-b2# dx     dx   a
-b1.  bc:
+2  d a
+3#      ///a
+x a
+x b
+x d
+b
+2# b  d:
+x  b
+x b
+b
+2. b:    /a
+3 d
+2a
+b
+2.b:  a
+3 a
+2a   d
+b
+2# d
+x     d
+x   a
+b
+1.  bc:
 b
 
-b2.  d:
-3# ax bx d
 b
-2a:   d2. db  d&{
-4#ax d
+2.  d:
+3# a
+x b
+x d
 b
-2# b  }x    dx      /a
+2a:   d
+2. db  d&{
+4#a
+x d
+b
+2# b  }
+x    d
+x      /a
 b
 1 bbc
 bXQ
@@ -11376,35 +20238,99 @@ bXQ
 2  d
 b
 2  d a
-3#      ///ax ax bx  d
-b3#     ax ax  cx  dx ax  c
-b3#    ax bx  dx ax bx d
+3#      ///a
+x a
+x b
+x  d
 b
-2# b:    /ax  bx b
+3#     a
+x a
+x  c
+x  d
+x a
+x  c
 b
-3# b  dx ax bx dxax b
+3#    a
+x b
+x  d
+x a
+x b
+x d
+b
+2# b:    /a
+x  b
+x b
+b
+3# b  d
+x a
+x b
+x d
+xa
+x b
 b
 
-b3#b  axaxbxdxa   dxb
-b3# dx     d&{x   ax bx a:x  d }
-b3#  bcx  ax  bx  dx ax  b
-b3#  ddx  bx  dx ax bx d
-b3#ax    dx     dx dxax d
 b
-2# b:x    dx      /a
+3#b  a
+xa
+xb
+xd
+xa   d
+xb
+b
+3# d
+x     d&{
+x   a
+x b
+x a:
+x  d }
+b
+3#  bc
+x  a
+x  b
+x  d
+x a
+x  b
+b
+3#  dd
+x  b
+x  d
+x a
+x b
+x d
+b
+3#a
+x    d
+x     d
+x d
+xa
+x d
+b
+2# b:
+x    d
+x      /a
 b
 1 bbc
 bXQ
 bXQ
 2 d
-b2. db  d3a2b:  a
+b
+2. db  d
+3a
+2b:  a
 b
 
-b2# dffx axa  c
-b2# bd ax a:   a
+b
+2# dff
+x a
+xa  c
+b
+2# bd a
+x a:   a
 x  d
-b2#  c:  a
-x   cx  d  b
+b
+2#  c:  a
+x   c
+x  d  b
 b
 2# a:
 x     a
@@ -11430,76 +20356,181 @@ b
 x a
 b
 
-b3# b:
+b
+3# b:
 x d
 2. a   a
-4#  dx a
+4#  d
+x a
 b
-2#  d ax   cx      ///a
+2#  d a
+x   c
+x      ///a
 b
 1  dc
 bXQ
 bXQ
 2 d
 b
-3# d   dx bx ax bx dx a
-b3#a  cx d.x bx a.x  dx  b.
-b3#  d:x   dx   ax   cx   dx   a
-b3#     ax  cx  ax  cx  dx     b
+3# d   d
+x b
+x a
+x b
+x d
+x a
 b
-2# a:x     ax   c
-b2 ac
-3#  a:x  cx  dx a
+3#a  c
+x d.
+x b
+x a.
+x  d
+x  b.
+b
+3#  d:
+x   d
+x   a
+x   c
+x   d
+x   a
+b
+3#     a
+x  c
+x  a
+x  c
+x  d
+x     b
+b
+2# a:
+x     a
+x   c
+b
+2 ac
+3#  a:
+x  c
+x  d
+x a
 b
 
-b3# b  ax ax bx dx a   ax b
-b3#  d ax    cx    ax     dx     bx     a
-b3#      ax bx dxax b  ax d
-b3# a   dx bx ax     cx     ax      a
-b3#a  -  /ax dx bx ax  d   ax a
-b3# bx  d
-2. a:   a
-4#  dx a
 b
-2#  d ax   cx      ///a
+3# b  a
+x a
+x b
+x d
+x a   a
+x b
+b
+3#  d a
+x    c
+x    a
+x     d
+x     b
+x     a
+b
+3#      a
+x b
+x d
+xa
+x b  a
+x d
+b
+3# a   d
+x b
+x a
+x     c
+x     a
+x      a
+b
+3#a  -  /a
+x d
+x b
+x a
+x  d   a
+x a
+b
+3# b
+x  d
+2. a:   a
+4#  d
+x a
+b
+2#  d a
+x   c
+x      ///a
 b
 Y  dc
 b
 B
 
-p{28e. Courante LÕEspine - 7F8Ef10C/CH-SO DA 111, f. 41v}
+p
+{28e. Courante L'Espine - 7F8Ef10C/CH-SO DA 111, f. 41v}
 BX
 bX
 S3
 2  d
-b2.  dca3 a2  d
 b
-2#  cc ax   cx  d
-b2.  dc  ///a
-3 a2 b
+2.  dca
+3 a
+2  d
 b
-2# b- dx  Qbx Qb
-b2. bb   /a3 d2a
-b2bbd  b1abb d
-b2# db  dx   ax db:
-b1.  bc ab
+2#  cc a
+x   c
+x  d
+b
+2.  dc  ///a
+3 a
+2 b
+b
+2# b- d
+x  Qb
+x Qb
+b
+2. bb   /a
+3 d
+2a
+b
+2bbd  b
+1abb d
+b
+2# db  d
+x   a
+x db:
+b
+1.  bc a
+b
 
-b3#  dd{
+b
+3#  dd{
 x  b
-x  dx ax bx d }
+x  d
+x a
+x b
+x d }
 b
-2a   d2. db  d
-4#ax d
+2a   d
+2. db  d
+4#a
+x d
 b
-2# bx    dx      /a
+2# b
+x    d
+x      /a
 b
 1. bbc:
 bb
-2. db  d3a2b
-b2# d  cx axa   e
-b2. bd   ///a
-3 a2  d
-b2  cc a1  dd b
+2. db  d
+3a
+2b
+b
+2# d  c
+x a
+xa   e
+b
+2. bd   ///a
+3 a
+2  d
+b
+2  cc a
+1  dd b
 b
 1 acc a
 2   c
@@ -11528,14 +20559,18 @@ b
 1abb   /a
 3# d    a
 x a
-b3# b  a
+b
+3# b  a
 x d
 2. a   a
-4#  dx a
+4#  d
+x a
 b
 2#  d
-x      ///ax    a
-bY  dc
+x      ///a
+x    a
+b
+Y  dc
 b
 B
 
@@ -11545,37 +20580,79 @@ BX
 bX
 S3
 2  d
-b2#  dcax      ///a
-3# ax  d
 b
-2#  cc ax   cx  d-d
-b2  dca
-3#      ///ax ax bx d
+2#  dca
+x      ///a
+3# a
+x  d
 b
-2# a - ax   cx b- d
-b2# bddx dxa- c
-b2#b- ax axa - d
-b2# dbx     dx  d- b
-b2#  b- a x b cx a
+2#  cc a
+x   c
+x  d-d
+b
+2  dca
+3#      ///a
+x a
+x b
+x d
+b
+2# a - a
+x   c
+x b- d
+b
+2# bdd
+x d
+xa- c
+b
+2#b- a
+x a
+xa - d
+b
+2# db
+x     d
+x  d- b
+b
+2#  b- a 
+x b c
+x a
 b
 
-b2  d  b
-3#      ax ax bx d
 b
-2Qa - d2. d - d
-4#ax d
+2  d  b
+3#      a
+x a
+x b
+x d
 b
-2# bx    dx      /a
+2Qa - d
+2. d - d
+4#a
+x d
+b
+2# b
+x    d
+x      /a
 b
 1 bb
 bbX
 2 d
-b2# db- dxaxb- a
-b2# db- dx axa- c
-b2 bd
-3#    ax a
+b
+2# db- d
+xa
+xb- a
+b
+2# db- d
+x a
+xa- c
+b
+2 bd
+3#    a
+x a
 2  d
-b2#  c- ax  dc bx   a
+b
+2#  c- a
+x  dc b
+x   a
 b
 1aac  a
 2   c
@@ -11600,11 +20677,16 @@ b
 2.a - d
 3 d.
 2 b- a
-b3# dx b
-2. a - a
-4#  dx a
 b
-2#  dx    ax      ///a
+3# d
+x b
+2. a - a
+4#  d
+x a
+b
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b
@@ -11615,36 +20697,77 @@ BX
 bX
 S3
 2  d
-b2.  dca ///a3 a2  d
 b
-2#  c  ax   cx  d
-b2.  dc  ///a
-3# ax bx d
+2.  dca ///a
+3 a
+2  d
 b
-2# a   ax   cx b  d
-b2# b dx dxa  c
-b2#b  ax axa   d
-b2# dx     dx     b
-b2#     a x b cx a
+2#  c  a
+x   c
+x  d
+b
+2.  dc  ///a
+3# a
+x b
+x d
+b
+2# a   a
+x   c
+x b  d
+b
+2# b d
+x d
+xa  c
+b
+2#b  a
+x a
+xa   d
+b
+2# d
+x     d
+x     b
+b
+2#     a 
+x b c
+x a
 b
 
-b2  d  b
-3#   dx ax bx d
 b
-2a   d2. d   d
-4#ax d
+2  d  b
+3#   d
+x a
+x b
+x d
 b
-2# bx      /a
-x    db
+2a   d
+2. d   d
+4#a
+x d
+b
+2# b
+x      /a
+x    d
+b
 1 bbc
 bbX
 2 d
-b2. db  d3a2b
-b2# d fx a cxa
-b2 bd
-3#    ax a
+b
+2. db  d
+3a
+2b
+b
+2# d f
+x a c
+xa
+b
+2 bd
+3#    a
+x a
 2  d
-b2#  c  ax  d  bx   a
+b
+2#  c  a
+x  d  b
+x   a
 b
 1aac  a
 2   c
@@ -11671,17 +20794,23 @@ b
 x d
 x b
 x a
-b2 b  a
-2. a   a
-4#  dx a
 b
-2#  dx    ax      ///a
+2 b  a
+2. a   a
+4#  d
+x a
+b
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b
 B
 
-p{28h. Courante - 7F8D/CH-Bu F.IX.53, ff. 13v-14r}BX
+p
+{28h. Courante - 7F8D/CH-Bu F.IX.53, ff. 13v-14r}
+BX
 bX
 S3
 2 a
@@ -11689,49 +20818,129 @@ b
 2. aa c
 3 c
 2 a
-b2#  e  cx  ax a
-b2# a   dx     cx c   a
-b2# d    ax  dx d
+b
+2#  e  c
+x  a
+x a
+b
+2# a   d
+x     c
+x c   a
+b
+2# d    a
+x  d
+x d
 b
 2. dd  c
 3a
 2c
-b2#dx     dxc  a
-b2#a&,x    ax c
-b2#  dx     cx   a&,
+b
+2#d
+x     d
+xc  a
+b
+2#a&,
+x    a
+x c
+b
+2#  d
+x     c
+x   a&,
 b
 
 b
 2. a - d
-3# cx dxa
+3# c
+x d
+xa
 b
 2c  a
 2.a&,   a
-4# dxa
+4# d
+xa
 b
-2# dx   ax      a
+2# d
+x   a
+x      a
 b
 1 da
 bbX
 2 a
 b
-3#    cx ax  cx  ex ax  c
-b3#     cx c.x  ex  f.x cx  e.
-b3#     dx ax  bx  dx a   ax c
-b3# d    ax  dx ax c
-x dxa
+3#    c
+x a
+x  c
+x  e
+x a
+x  c
+b
+3#     c
+x c.
+x  e
+x  f.
+x c
+x  e.
+b
+3#     d
+x a
+x  b
+x  d
+x a   a
+x c
+b
+3# d    a
+x  d
+x a
+x c
+x d
+xa
 b
 
-b3#c  axa.xcx d.xaxc.
-b3#d  c.x  d.x ax c.x d axc:
-b3#a   ax d.x cx a.x  dx  b.
-b3#  a   ax   c.x  ax  b.x  dx  a.
-b3#     dx a.x  bx  d.x ax c.
-b3# d -- axc.
-2.a   a
-4# dxa
 b
-2# dx   ax      a
+3#c  a
+xa.
+xc
+x d.
+xa
+xc.
+b
+3#d  c.
+x  d.
+x a
+x c.
+x d a
+xc:
+b
+3#a   a
+x d.
+x c
+x a.
+x  d
+x  b.
+b
+3#  a   a
+x   c.
+x  a
+x  b.
+x  d
+x  a.
+b
+3#     d
+x a.
+x  b
+x  d.
+x a
+x c.
+b
+3# d -- a
+xc.
+2.a   a
+4# d
+xa
+b
+2# d
+x   a
+x      a
 b
 
 b
@@ -11742,12 +20951,23 @@ b
 2.acdca
 3c
 2d
-b2#a - ex  dxc  a
-b2 d  c
-3#    ax c
+b
+2#a - e
+x  d
+xc  a
+b
+2 d  c
+3#    a
+x c
 2 a   d
-b2#  e  cx   ex  fc
-b2# cx     cx   e
+b
+2#  e  c
+x   e
+x  fc
+b
+2# c
+x     c
+x   e
 b
 1 ce
 2     Qc
@@ -11767,45 +20987,101 @@ b
 
 b
 1cdd
-3# a - dx c.
-b3# dxa
-2. c&, - c
-4#  fx c
+3# a - d
+x c.
 b
-2#  fx      //a
-bbX2a
+3# d
+xa
+2. c&, - c
+4#  f
+x c
+b
+2#  f
+x      //a
+bbX
+2a
 b
 2.acdca
 3c
 2d
-b2#a   ex  d
-3#cxa
-b3#    cx dx     cx cx     dx a
+b
+2#a   e
+x  d
+3#c
+xa
+b
+3#    c
+x d
+x     c
+x c
+x     d
+x a
 b
 2  e  c
-3#  cx  ex   fx    c
+3#  c
+x  e
+x   f
+x    c
 b
-2# cx     cx   e
+2# c
+x     c
+x   e
 b
 
-b1 ce
-3# a.x c
-b3# d  cx cx dxax c  ax d
-b3# a   dx  d.x ax c.x dx a.
-b3#a -- ax dxaxcxax d.
-b3# c  ax a.x cx d.xax c
 b
-3#c  -  axa.x dx c.x a   ax c.
-b3# dxa.
+1 ce
+3# a.
+x c
+b
+3# d  c
+x c
+x d
+xa
+x c  a
+x d
+b
+3# a   d
+x  d.
+x a
+x c.
+x d
+x a.
+b
+3#a -- a
+x d
+xa
+xc
+xa
+x d.
+b
+3# c  a
+x a.
+x c
+x d.
+xa
+x c
+b
+3#c  -  a
+xa.
+x d
+x c.
+x a   a
+x c.
+b
+3# d
+xa.
 2. c&, - c
-4#  fx c.
+4#  f
+x c.
 b
-2  fY      //a
+2  f
+Y      //a
 b
 B
 
 p
-{28i. Current Con: - 7F8Ef9D10C/D-LEm II.6.15, p. 264}BX
+{28i. Current Con: - 7F8Ef9D10C/D-LEm II.6.15, p. 264}
+BX
 bX
 S3
 2 a
@@ -11813,30 +21089,49 @@ b
 2. a  c
 3 c
 2 a
-b2#  e  cx  ax a
-b2. a  c
-3# cx dxa
-b2# cd ax  dx d
+b
+2#  e  c
+x  a
+x a
+b
+2. a  c
+3# c
+x d
+xa
+b
+2# cd a
+x  d
+x d
 bQ
 2. da   a
 3a
 2c
-b2da c1cd a
-b1acd a
+b
+2da c
+1cd a
+b
+1acd a
 2      ///a
-b1acd2  d  c
+b
+1acd
+2  d  c
 b
 
 b
 2. ab  d
-3# cx dxa
+3# c
+x d
+xa
 b
 2c  a
 3#a   a
-x d2a
+x d
+2a
 bQ
-2# dx      a
-x    ab
+2# d
+x      a
+x    a
+b
 1 dda
 bbX
 2a
@@ -11844,11 +21139,20 @@ b
 2.acd a
 3c
 2Qda c
-bQ2.cdda3a2 da c
-b1 ca  c
+bQ
+2.cdda
+3a
+2 da c
+b
+1 ca  c
 2 a   e
-b1 ca  c2     c
-bQ1 da3# ax c
+b
+1 ca  c
+2     c
+bQ
+1 da
+3# a
+x c
 b
 
 -l "6.5 in"
@@ -11870,11 +21174,15 @@ x d
 x a
 b
 2.cdda
-3a   e2 da c
-b2. ca  c3 a
+3a   e
+2 da c
+b
+2. ca  c
+3 a
 2  e
 b
-1 aabc2      //a
+1 aabc
+2      //a
 bQ
 Y aa
 b
@@ -11882,7 +21190,8 @@ B
 
 { }
 -l "7.35 in"
-{28j. Courente - 7F8D/I-Tn IV.23.2, ff. 12v-13r}BX
+{28j. Courente - 7F8D/I-Tn IV.23.2, ff. 12v-13r}
+BX
 bX
 S3
 2 a
@@ -11891,10 +21200,19 @@ b
 x      //a
 3. c
 4 a
-b2#  ex   ex   c
-b2 a a
-3# cx   e2 d  c
-b2# cfex  ex     c
+b
+2#  e
+x   e
+x   c
+b
+2 a a
+3# c
+x   e
+2 d  c
+b
+2# cfe
+x  e
+x     c
 b
 3# a   d
 x c
@@ -11902,27 +21220,37 @@ x d
 xa
 xc
 x   a
-b2#d  cxc a
+b
+2#d  c
+xc a
 3#a b
 x d
-b2#a d
+b
+2#a d
 x    a
 x    c
-b2#  d e
+b
+2#  d e
 x     a
-x     cb
+x     c
+b
 
 b
 2 a   d
-3#   ax cx d
+3#   a
+x c
+x d
 xa
 b
 3#c
 x      a
-2.a   a4# d
+2.a   a
+4# d
 xa
 b
-2# dx    ax      a
+2# d
+x    a
+x      a
 b
 1 dda
 bbX
@@ -11934,15 +21262,24 @@ x c
 xc
 xd
 x a
-b3# cxa2#  e
+b
+3# c
+xa
+2#  e
 xc
-b3# df
+b
+3# df
 x c c
 x  f
-b2  ee2. a
+b
+2  ee
+2. a
 4#  e
 x a
-b2# cx   ex     c
+b
+2# c
+x   e
+x     c
 b
 
 -l "6.5 in"
@@ -11968,24 +21305,32 @@ x c
 x a
 b
 2#  d  c
-xfxd    a
-b3#c     ax d
+xf
+xd    a
+b
+3#c     a
+x d
 xa
 xc
 xa    a
 xc
 b
-3# dxa
+3# d
+xa
 2. c   c
-4#  fx c
+4#  f
+x c
 b
-2#  fx    cx      //a
+2#  f
+x    c
+x      //a
 b
 Y aaa
 b
 B
 
-{28k. Courante Francoyse - 7F/Valerius 1626 pp. 270-271}BX
+{28k. Courante Francoyse - 7F/Valerius 1626 pp. 270-271}
+BX
 bX
 S3
 2a
@@ -11993,11 +21338,21 @@ b
 2.aabc
 3c
 2a
-b2# e  cx a   axaabc
 b
-3#aabcx dxaxdxcxa
+2# e  c
+x a   a
+xaabc
 b
-2#c  ax d  cxddff
+3#aabc
+x d
+xa
+xd
+xc
+xa
+b
+2#c  a
+x d  c
+xddff
 b
 2.ddf  d
 3f
@@ -12007,7 +21362,9 @@ b
 2h  f
 b
 2.ff  a
-3#dxcxa
+3#d
+xc
+xa
 b
 2. dda
 3a
@@ -12015,11 +21372,17 @@ b
 b
 
 b
-3#a    ax dxaxcx-Qdxf
+3#a    a
+x d
+xa
+xc
+x-Qd
+xf
 b
 2h  f d
 2.f  Qe
-4#hxf
+4#h
+xf
 b
 1.ddff
 b
@@ -12030,13 +21393,19 @@ b
 2.ddff d
 3f
 2h    a
-b2#f   axc  exh  f a
+b
+2#f   a
+xc  e
+xh  f a
 b
 2.d  c
 3c
 2a   e
-b2# e  cx a
-3# d  cxa
+b
+2# e  c
+x a
+3# d  c
+xa
 b
 
 b
@@ -12054,35 +21423,54 @@ b
 2f   a
 b
 2.f  Qe
-3#dxcxa
+3#d
+xc
+xa
 b
 2 d   d
-3#axcxdxf
+3#a
+xc
+xd
+xf
 b
 2.h    d
-3#fxdxc
+3#f
+xd
+xc
 b
 2d    d
 2.cdda
-4#axc
+4#a
+xc
 b
 Yaacc a
 b
 B
 
 { }
-{29. Courante Gothier - 7F8Ef10C/CZ-Pnm G.IV.18, f. 7r}BX
+{29. Courante Gothier - 7F8Ef10C/CZ-Pnm G.IV.18, f. 7r}
+BX
 bX
 S3
 2  d
-b2#  d   ax   dx d
-b2# c    ///ax  d
-3# dxa
 b
-2#bx      ax   a
+2#  d   a
+x   d
+x d
+b
+2# c    ///a
+x  d
+3# d
+xa
+b
+2#b
+x      a
+x   a
 b
 2.bdd
-3# dxaxb
+3# d
+xa
+xb
 b
 2.d   d
 3    b
@@ -12091,254 +21479,421 @@ b
 1gd Qf d
 2fg    a
 b
-3#d     /axfxdx gx fx  g
+3#d     /a
+xf
+xd
+x g
+x f
+x  g
 b
 
-b3# g    axd
-2#fxe    a
+b
+3# g    a
+xd
+2#f
+xe    a
 b
 1f   a
 2      ///a
 b
 2.fcd
 bbX
-3#hxfxh
+3#h
+xf
+xh
 b
 2.i   a
 3h
 2f
 b
-3#f gxg
-2#d   dxb     a
-b2#      ///ax    ax   Qc
+3#f g
+xg
+2#d   d
+xb     a
+b
+2#      ///a
+x    a
+x   Qc
 b
 1aac
-3#bxa
+3#b
+xa
 b
 
 b
-2# d abx   cx b da
-b2# dQe  dx    fx   f
+2# d ab
+x   c
+x b da
 b
-2#bbd  bx    dx   d
-b2#bbd  bxd    axf     a
-b2f     ///a
-3#   cx   a
+2# dQe  d
+x    f
+x   f
+b
+2#bbd  b
+x    d
+x   d
+b
+2#bbd  b
+xd    a
+xf     a
+b
+2f     ///a
+3#   c
+x   a
 2df  e
-b2#bddaxa     ///ax  d
-b2# dx   ax      a
+b
+2#bdda
+xa     ///a
+x  d
+b
+2# d
+x   a
+x      a
 b
 Y dd
 b
 B
 
-{30a. Courante Gothier - 7F8Ef10C/CZ-Pnm G.IV.18, f. 7v}BX
+{30a. Courante Gothier - 7F8Ef10C/CZ-Pnm G.IV.18, f. 7v}
+BX
 bX
 S3
 2f
 b
 1.fda   a
 b
-2#b  ax dxf
+2#b  a
+x d
+xf
 b
 2.dde  d
-3#fxb     axd
+3#f
+xb     a
+xd
 b
 2.a   a
 3 b
 2b
-b2#bbd  bx    dx   d
-b2d   d
+b
+2#bbd  b
+x    d
+x   d
+b
+2d   d
 1    b
 b
 2.f   a
-3#dxb  axd
+3#d
+xb  a
+xd
 b
 
-b3#fx   dx    dxf
+b
+3#f
+x   d
+x    d
+xf
 2d
-b2#bbd  bx    dx   d
+b
+2#bbd  b
+x    d
+x   d
 b
 2bbd
 bbX
-3# b   ax dxa     axb
+3# b   a
+x d
+xa     a
+xb
 b
-2#d     /ax    dx    b
+2#d     /a
+x    d
+x    b
 b
 2.f   a
-3#dxbxa
+3#d
+xb
+xa
 b
-2# dx    b
-3#a    dx d
+2# d
+x    b
+3#a    d
+x d
 b
-2# c  ax   cx  d
+2# c  a
+x   c
+x  d
 b
 
 b
 2.b d   a
-4#axb
+4#a
+xb
 2 d
-b2d    a
-2.b d   a
-4#axb
 b
-2#ax      ///axb
+2d    a
+2.b d   a
+4#a
+xb
+b
+2#a
+x      ///a
+xb
 b
 1bbd  b
-3#d   dx    b
+3#d   d
+x    b
 b
 2.f   a
-3#dxb     axa
-b3# dxb
-2.a   a
-4# dxa
+3#d
+xb     a
+xa
 b
-2# dx      ax   a
+3# d
+xb
+2.a   a
+4# d
+xa
+b
+2# d
+x      a
+x   a
 b
 Y dd
 b
 B
 
 { }
-{30b. Courante Gothier - 7F8Ef10C/GB-Eu Coll.2073, f. 278r}BX
+{30b. Courante Gothier - 7F8Ef10C/GB-Eu Coll.2073, f. 278r}
+BX
 bX
 S3
 2f
 b
 1.fda   a
 b
-2#b  ax dxf
+2#b  a
+x d
+xf
 b
 2.dde  d
-3#fxb     axd
+3#f
+xb     a
+xd
 b
 2.a   a
 3 b
 2b
-b2#bbd  bx    dx   d
-b2db  d
+b
+2#bbd  b
+x    d
+x   d
+b
+2db  d
 1    b
 b
 2.f   a
-3#dxb  axd
+3#d
+xb  a
+xd
 b
 
-b3#fx   dx    dxf
+b
+3#f
+x   d
+x    d
+xf
 2d
-b2#b    bx    dx   d
+b
+2#b    b
+x    d
+x   d
 b
 2bbd
 bbX
-3# b   ax dxa     axb
+3# b   a
+x d
+xa     a
+xb
 b
-2#d     /ax    dx    b
+2#d     /a
+x    d
+x    b
 b
 2.f   a
-3#dxbxa
+3#d
+xb
+xa
 b
-2# dx    b
-3#a    dx d
+2# d
+x    b
+3#a    d
+x d
 b
-2# c  ax   cx  d
+2# c  a
+x   c
+x  d
 b
 
 b
 2.b d   a
-4#axb
+4#a
+xb
 2 d
-b2da   a
-2.b d   a
-4#axb
 b
-2#a   ax      ///axb
+2da   a
+2.b d   a
+4#a
+xb
+b
+2#a   a
+x      ///a
+xb
 b
 1bbd  b
-3#d   dx    b
+3#d   d
+x    b
 b
 2.f   a
-3#dxb     axa
-b3# dxb
-2.a   a
-4# dxa
+3#d
+xb     a
+xa
 b
-2# dx      ax   a
+3# d
+xb
+2.a   a
+4# d
+xa
+b
+2# d
+x      a
+x   a
 b
 Y dd
 b
 B
 
-{30c. Corant - 7F10CD/CZ-Pnm G.IV.18, ff. 64v-65r}BX
+{30c. Corant - 7F10CD/CZ-Pnm G.IV.18, ff. 64v-65r}
+BX
 bX
 S3
 2f
 b
 1.fd    a
 b
-2#b  ax dxf
+2#b  a
+x d
+xf
 b
 2.bbd  b
-3#fxdxb
-b2#d   bx d
-3#     dx b
+3#f
+xd
+xb
 b
-2#bb   bx    dx   d
-b2#abdx    ax    b
+2#d   b
+x d
+3#     d
+x b
+b
+2#bb   b
+x    d
+x   d
+b
+2#abd
+x    a
+x    b
 b
 2.f   d
-3#dxb  axd
+3#d
+xb  a
+xd
 b
 
 b
 2f  d
-3#    dxfxdxb
+3#    d
+xf
+xd
+xb
 b
-2#b    bx    dx   d
-b2bbd
-bbX3# b   ax dxa   axb
+2#b    b
+x    d
+x   d
 b
-2#dx    dx    b
+2bbd
+bbX
+3# b   a
+x d
+xa   a
+xb
+b
+2#d
+x    d
+x    b
 b
 2.f d a
 3#b
-xdxa
+xd
+xa
 b
-2# bx     b
-3#a    dx d
+2# b
+x     b
+3#a    d
+x d
 b
-2# c  ax   cx  d
+2# c  a
+x   c
+x  d
 b
 
 b
 2.b     a
-4#axb2 d
-b2dde  d
-2.b     a
-4#axb
+4#a
+xb
+2 d
 b
-2#ax      ///axb
+2dde  d
+2.b     a
+4#a
+xb
+b
+2#a
+x      ///a
+xb
 b
 1bbdd b
 2d   d
-b2#f   axd3#Qb    axa
-b3# dxb
-2.a   a
-4# dxa
 b
-2# dx   ax      a
+2#f   a
+xd
+3#Qb    a
+xa
+b
+3# d
+xb
+2.a   a
+4# d
+xa
+b
+2# d
+x   a
+x      a
 b
 Y dd
 b
 B
 
 { }
-{30d. Courante ab eod - Thomas Lindner - 7F8Ef10C/GB-Lbl Sloane 1021, f. 54v}BX
+{30d. Courante ab eod - Thomas Lindner - 7F8Ef10C/GB-Lbl Sloane 1021, f. 54v}
+BX
 bX
 S3
 2f
 b
 1.fd d  a
 b
-1bdda2f  d
+1bdda
+2f  d
 b
 1-\1d\3f  \1d
 2bdda
@@ -12346,32 +21901,45 @@ b
 2.ab  a
 3 d.
 2 b:
-b2.bdda3#ax d:
+b
+2.bdda
+3#a
+x d:
 xa.
-b2#b:
+b
+2#b:
 xb:  d
 xa
 b
 2.\4f   \1d
-3-\1d2-\4f
+3-\1d
+2-\4f
 b
 
-b2f  d1-\1d\3f  \1d
+b
+2f  d
+1-\1d\3f  \1d
 b
 2#QbQbQd  Qb
 x    Qd
 x   Qd
-b1.bbdbb
+b
+1.bbd
+bb
 1.db  d
 b
 2f
 3#    a
-xd.xb:xa.
+xd.
+xb:
+xa.
 b
 2# d  b
 x  b b
-xab
-2# c: ax  d
+xa
+b
+2# c: a
+x  d
 3# d
 xa
 b
@@ -12386,80 +21954,128 @@ b
 4#a
 xb
 b
-2#a&#x    ax      ///a
-b2#bd  bx    axd    d
-b2#     bxf.xd.    /a
-b2b     a
-2.ad&#  a
-4# dxa
+2#a&#
+x    a
+x      ///a
 b
-2# dx   ax      a
+2#bd  b
+x    a
+xd    d
+b
+2#     b
+xf.
+xd.    /a
+b
+2b     a
+2.ad&#  a
+4# d
+xa
+b
+2# d
+x   a
+x      a
 b
 Y dda
 b
 B
 
-{30e. Untitled - 7F8Ef10C/PL-Kj 40153, ff. 30v-31r}BX
+{30e. Untitled - 7F8Ef10C/PL-Kj 40153, ff. 30v-31r}
+BX
 bX
 S3
 2-\4f.
 b
 1.\4fdd   a
 b
-2#xb  ax \3d.x-\4f
+2#xb  a
+x \3d.
+x-\4f
 b
 2#xd -- a
-xf.x-xb  -  a
+xf.
+x-xb  -  a
 b
 2#xa - a
 x b.
 xb
-b2#bbd  bx   dxbbd
-b2dbb d
+b
+2#bbd  b
+x   d
+xbbd
+b
+2dbb d
 1    xb
 b
 2.xf   a
-3#\4d.x-\1b  ax-\4d.
+3#\4d.
+x-\1b  a
+x-\4d.
 b
 
-b3#\4fx   d2#xd
+b
+3#\4f
+x   d
+2#xd
 x    d
-b2#bx     bx   d
+b
+2#b
+x     b
+x   d
 b
 1bbd
 bbX
 2d
 b
-2#d - dx      /ax    b
+2#d - d
+x      /a
+x    b
 b
 2.xf   a
-3#d.xbxa.
+3#d.
+xb
+xa.
 b
-2# dx    b
-3#a -- dx d.
+2# d
+x    b
+3#a -- d
+x d.
 b
-2# xc- ax      ///ax  \4d.
+2# xc- a
+x      ///a
+x  \4d.
 b
 
 b
 2.x\1b  -  a
-4#axb.
+4#a
+xb.
 2 d
-b2-\4d -- a
-2.xb  -  a
-4#axb.
 b
-2#ax      ///axb.
+2-\4d -- a
+2.xb  -  a
+4#a
+xb.
+b
+2#a
+x      ///a
+xb.
 b
 1bbd  b
-2d   bb
-2.xf
-3#d.xbxa.
-b2-xb  a
-2.xa - a
-4# dxa.
+2d   b
 b
-2# dx      ax   a
+2.xf
+3#d.
+xb
+xa.
+b
+2-xb  a
+2.xa - a
+4# d
+xa.
+b
+2# d
+x      a
+x   a
 b
 Y dd
 b
@@ -12474,25 +22090,41 @@ S3
 b
 1.abd a
 b
-2# b  ax dxa   d
+2# b  a
+x d
+xa   d
 b
 2. dba d
-3#ax b  ax d
+3#a
+x b  a
+x d
 b
-2# a   ax  bx b
+2# a   a
+x  b
+x b
 b
 1. bbcd
 b
-2# dba d&{x fx d  }
-b2a   d3#      /a
-x dx bx d
+2# dba d&{
+x f
+x d  }
+b
+2a   d
+3#      /a
+x d
+x b
+x d
 b
 
 b
-2#ax dba d&{
-3# bx a  }
+2#a
+x dba d&{
+3# b
+x a  }
 b
-2# bx    dx      /a
+2# b
+x    d
+x      /a
 b
 1 bbc
 bbX
@@ -12501,29 +22133,55 @@ b
 1. dba
 b
 2a   d
-3#      /ax dx bx a
+3#      /a
+x d
+x b
+x a
 b
 2#  d  b
-x      a3# ax  d
-b2#  c  a
-x   cx  d
+x      a
+3# a
+x  d
+b
+2#  c  a
+x   c
+x  d
 b
 
 b
-2  d a3#      ///a
-x ax b
+2  d a
+3#      ///a
+x a
+x b
 x  d
-b2# d   dx b  a
-3# ax b
 b
-2# ax     ax   c
-b2# bx    ax d  c
-b2a   d3#      /ax dx bx a
-b2 b  a
+2# d   d
+x b  a
+3# a
+x b
+b
+2# a
+x     a
+x   c
+b
+2# b
+x    a
+x d  c
+b
+2a   d
+3#      /a
+x d
+x b
+x a
+b
+2 b  a
 2. a    a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 Y  dQc
 b
@@ -12537,53 +22195,98 @@ S3
 b
 1.fdddf
 b
-2#b  ax dxf  d
+2#b  a
+x d
+xf  d
 b
 2#dfg
-xfxbd
+xf
+xbd
 b
 2#a d
 x b
 3# db
 xa
-b2#bx   dxbbd
-b2.d
+b
+2#b
+x   d
+xbbd
+b
+2.d
 3   d
 2dbbc
 b
 1f  d
-3#dxf
+3#d
+xf
 b
 
-b3#gxf2.d   d4# g
+b
+3#g
+xf
+2.d   d
+4# g
 xd
-b2# gx     bx   d
+b
+2# g
+x     b
+x   d
 b
 1bbd
 bXQ
 bXQ
 2f
-b2fdddf
+b
+2fdddf
 1      a
 b
-3#b  axaxbxdxfx   d
-b3#d   dxdx fxfxb  axd
-b3#a   ax  dx ax bx d   dxa
+3#b  a
+xa
+xb
+xd
+xf
+x   d
+b
+3#d   d
+xd
+x f
+xf
+xb  a
+xd
+b
+3#a   a
+x  d
+x a
+x b
+x d   d
+xa
 b
 
 b
-2#bx     dxbbd
+2#b
+x     d
+xbbd
 b
 2.d
 3   d
 2d  c
 b
-3#f  dx gxdxfxdxf
-b3#gxf
-2.d   d
-4# gxd
+3#f  d
+x g
+xd
+xf
+xd
+xf
 b
-2# gx     bx   d
+3#g
+xf
+2.d   d
+4# g
+xd
+b
+2# g
+x     b
+x   d
 b
 1bbd
 bXQ
@@ -12596,34 +22299,51 @@ b
 b
 2f
 3#    a
-xdxbxa
+xd
+xb
+xa
 b
 2# d  b
-x  bxa
+x  b
+xa
 b
-2# c  ax  d3# d   d
+2# c  a
+x  d
+3# d   d
 xa
 b
 2#b    b
-x   axd  c a
-b2    e
-2.b d   a
-4#axb
+x   a
+xd  c a
 b
-2#ax    axb
+2    e
+2.b d   a
+4#a
+xb
+b
+2#a
+x    a
+xb
 b
 2#bde b
-x    axd  c d
+x    a
+xd  c d
 b
 
 b
 2.f     d
-3f2d    a
-b2bdd   a2.a   a
-4# dxa
+3f
+2d    a
 b
-2# dx   a
-x      ab
+2bdd   a
+2.a   a
+4# d
+xa
+b
+2# d
+x   a
+x      a
+b
 2 dda
 bXQ
 bXQ
@@ -12635,87 +22355,174 @@ b
 b
 2f
 3#    a
-xdxbxa
-b3#    bx dx  bx dxax  d
-b3# c  ax  dx ax cx d   dxa
+xd
+xb
+xa
+b
+3#    b
+x d
+x  b
+x d
+xa
+x  d
+b
+3# c  a
+x  d
+x a
+x c
+x d   d
+xa
 b
 
-b3#b    bx dxaxbxa    axb
-b3#dx c2.b d   a
-4#axb
 b
-2#ax    axb
-b2#bde bx    axd  c d
+3#b    b
+x d
+xa
+xb
+xa    a
+xb
 b
-3#f     dx gxdxfxd    dxf
-b3#bxd
+3#d
+x c
+2.b d   a
+4#a
+xb
+b
+2#a
+x    a
+xb
+b
+2#bde b
+x    a
+xd  c d
+b
+3#f     d
+x g
+xd
+xf
+xd    d
+xf
+b
+3#b
+xd
 2.a   a
-4# dxa
+4# d
+xa
 b
-2# dx   ax      a
+2# d
+x   a
+x      a
 b
 Y dd
 b
 B
 
 { }
-{30h. Untitled - 7F8Ef10C/A-SPL KK 35, p. 66}BX
+{30h. Untitled - 7F8Ef10C/A-SPL KK 35, p. 66}
+BX
 bX
 S3
 2f
 b
 1.\4f\1da   a
 b
-2#b&,  ax dx-\4f
+2#b&,  a
+x d
+x-\4f
 b
 2.dd\2e  d
-3#\4fxb  axd
+3#\4f
+xb  a
+xd
 b
-2#a&,   ax bxb
-b2#bb\4d  bx    \2dx   \3d
-b1dbb \3d
+2#a&,   a
+x b
+xb
+b
+2#bb\4d  b
+x    \2d
+x   \3d
+b
+1dbb \3d
 2    b&,
 b
 2@f&, - a
-3#dxb- axd
+3#d
+xb- a
+xd
 b
 
-b3#f    Ux   d
-2    dX
-3#fxd
 b
-2#bx    \2dx   \3d
+3#f    U
+x   d
+2    dX
+3#f
+xd
+b
+2#b
+x    \2d
+x   \3d
 b
 2Qbb\4d
 bbX
-3# b   ax dxaxb
+3# b   a
+x d
+xa
+xb
 b
-2#d     8x    \3dx    b&,
-b2@f&,   a3#\4d
-xbxa
+2#d     8
+x    \3d
+x    b&,
 b
-2# dx    b
-3#a -- \3dx \4d
+2@f&,   a
+3#\4d
+xb
+xa
 b
-2# \2c  ax   \1cx  d
+2# d
+x    b
+3#a -- \3d
+x \4d
+b
+2# \2c  a
+x   \1c
+x  d
 b
 
 b
 2.b&, --  a
-4#axb
+4#a
+xb
 2 d
-b2#d -- axb- a
-3#axb
-b2#a&,   ax      N10xb
-b2#bbd  bx-\4d   \3dx    b&,
+b
+2#d -- a
+xb- a
+3#a
+xb
+b
+2#a&,   a
+x      N10
+xb
+b
+2#bbd  b
+x-\4d   \3d
+x    b&,
 b
 2.f - a
-3#dxbxa
-b2# dxb
-2.a&, - a
-4# \4dxa
+3#d
+xb
+xa
 b
-2# dx   ax      aY dd
+2# d
+xb
+2.a&, - a
+4# \4d
+xa
+b
+2# d
+x   a
+x      a
+Y dd
 b
 B
 
@@ -12998,46 +22805,85 @@ b
 B
 
 { }
-{32a. Courante Gauthier - 7F/GB-Cfm 689, f. 37r i}BX
+{32a. Courante Gauthier - 7F/GB-Cfm 689, f. 37r i}
+BX
 bX
 S3
 2f
-b2fgia
-3#      axg
+b
+2fgia
+3#      a
+xg
 2f
-b2fde
+b
+2fde
 2.d
-4# gxd
+4# g
+xd
 b
-2#f-dx   ax   c
+2#f-d
+x   a
+x   c
 b
-3# d-dx  b
+3# d-d
+x  b
 2.a-d
-4# dxa
+4# d
+xa
 b
-2#bx   axd- c
+2#b
+x   a
+xd- c
 b
 2.f- d
-3#dxb- axd
+3#d
+xb- a
+xd
 b
-2#ax    ax   c
-b2#acdx     dx dd- b
+2#a
+x    a
+x   c
+b
+2#acd
+x     d
+x dd- b
 b
 
-b2#a -- ax  d e
-3#fxd
 b
-2#b- ax      axd -- a
-b2# bdd-bx    dxb
-b2#     axa b ex  d
-b2#      ax dddfxf
-b2# d- bxd
-3#     dxb
+2#a -- a
+x  d e
+3#f
+xd
 b
-2#a - axfx c c
-b2 d-d
+2#b- a
+x      a
+xd -- a
+b
+2# bdd-b
+x    d
+xb
+b
+2#     a
+xa b e
+x  d
+b
+2#      a
+x dddf
+xf
+b
+2# d- b
+xd
+3#     d
+xb
+b
+2#a - a
+xf
+x c c
+b
+2 d-d
 2.fc ca
-4#   ax   c
+4#   a
+x   c
 b
 
 b
@@ -13048,31 +22894,125 @@ b
 bXQ
 bXQ
 2f
-b2fgia
-3#      ax ix gx f
-b3#  ix  gx  exfxd
-4# gxd
 b
-3#fx  dx fx gx fx   f
-b3# d dx  dx   fx  exa-dx c
-b3#bx  ex dx  dxd bx   c
-b3#f- dx   fx  dxd-exb- axd
+2fgia
+3#      a
+x i
+x g
+x f
+b
+3#  i
+x  g
+x  e
+xf
+xd
+4# g
+xd
+b
+3#f
+x  d
+x f
+x g
+x f
+x   f
+b
+3# d d
+x  d
+x   f
+x  e
+xa-d
+x c
+b
+3#b
+x  e
+x d
+x  d
+xd b
+x   c
+b
+3#f- d
+x   f
+x  d
+xd-e
+xb- a
+xd
 b
 
-b3#ax    ax  dcx ax cx d
-b3#ax  dx cx     dx  d- bx d
-b3#a b- ax   ax    ex  dxfxd
-b3#b- ax      ax dx  exdx     a
-b3# bx     bx  dx   dxbx   a
-b3#     ax   axa - ex  dx  bx  d
-b3#      ax  dx ax   fxf- ex    f
-b3# dx    bxdx     dx   axb
+b
+3#a
+x    a
+x  dc
+x a
+x c
+x d
+b
+3#a
+x  d
+x c
+x     d
+x  d- b
+x d
+b
+3#a b- a
+x   a
+x    e
+x  d
+xf
+xd
+b
+3#b- a
+x      a
+x d
+x  e
+xd
+x     a
+b
+3# b
+x     b
+x  d
+x   d
+xb
+x   a
+b
+3#     a
+x   a
+xa - e
+x  d
+x  b
+x  d
+b
+3#      a
+x  d
+x a
+x   f
+xf- e
+x    f
+b
+3# d
+x    b
+xd
+x     d
+x   a
+xb
 b
 
-b3#ax    ax  dx dx   dx d
-b3#  bx   d
+b
+3#a
+x    a
+x  d
+x d
+x   d
+x d
+b
+3#  b
+x   d
 3 c ca
-4   dx   c4#   dx   cx   ax   c
+4   d
+x   c
+4#   d
+x   c
+x   a
+x   c
 b
 1 Qd a
 2      a
@@ -13081,39 +23021,87 @@ b
 bXQ
 bXQ
 2  d
-b2#  ddx bx   c
-b2# ddaxa d ex  b
-b2bdda
-3#      axdxbxa
-b3# d- bx    dx   ax   cx   dx  b
+b
+2#  dd
+x b
+x   c
+b
+2# dda
+xa d e
+x  b
+b
+2bdda
+3#      a
+xd
+xb
+xa
+b
+3# d- b
+x    d
+x   a
+x   c
+x   d
+x  b
 b
 
 b
-2# b cax   dx  d
-b2    b
-2.  b-d
-4#   dx   c
+2# b ca
+x   d
+x  d
 b
-2#   dx     bx  d
-b2# a - dx c cx    a
-b2# d-abxbx    a
+2    b
+2.  b-d
+4#   d
+x   c
+b
+2#   d
+x     b
+x  d
+b
+2# a - d
+x c c
+x    a
+b
+2# d-ab
+xb
+x    a
 b
 2.dde- d
-3#fxgxd
+3#f
+xg
+xd
 b
 2.f  -  a
-3#dxbxa
-b3# d-ax   cx   dx   ax    ex    c
+3#d
+xb
+xa
 b
-2# c caxfxd
+3# d-a
+x   c
+x   d
+x   a
+x    e
+x    c
+b
+2# c ca
+xf
+xd
 b
 
-b2#bx  dxa b
-b2#    ax  ddx d
 b
-3#  bx   d
+2#b
+x  d
+xa b
+b
+2#    a
+x  dd
+x d
+b
+3#  b
+x   d
 2. c ca
-4#   dx   c
+4#   d
+x   c
 b
 1   a
 2      a
@@ -13123,34 +23111,131 @@ bXQ
 bXQ
 2   a
 b
-3#  dx   dx bx   cx   ax   c
-b3# d-dx  bx  dxbxa
-4# dxa
+3#  d
+x   d
+x b
+x   c
+x   a
+x   c
 b
-3#bx   ax      axdxbxa
+3# d-d
+x  b
+x  d
+xb
+xa
+4# d
+xa
+b
+3#b
+x   a
+x      a
+xd
+xb
+xa
 b
 
-b3# d- bx    dx   ax   cx   dx  b
 b
-3# b- ax   dx dx bx  e- dx    a
-b4#    b
-x    dx   a
-x   c4#   dx   cx   dx   c4#   dx   cx   ax   c
+3# d- b
+x    d
+x   a
+x   c
+x   d
+x  b
 b
-3#   dx  bx   cx bx  dx   d
-b3# ax     dx   cx cx    ax  dd
-b3# dx   cxb- ax    dx    bx    a
-b3#d -- dx dx  exfxgxd
+3# b- a
+x   d
+x d
+x b
+x  e- d
+x    a
+b
+4#    b
+x    d
+x   a
+x   c
+4#   d
+x   c
+x   d
+x   c
+4#   d
+x   c
+x   a
+x   c
+b
+3#   d
+x  b
+x   c
+x b
+x  d
+x   d
+b
+3# a
+x     d
+x   c
+x c
+x    a
+x  dd
+b
+3# d
+x   c
+xb- a
+x    d
+x    b
+x    a
+b
+3#d -- d
+x d
+x  e
+xf
+xg
+xd
 b
 
-b3#fx      ax dxdxbxa
-b3# d-ax   cx   dx   ax    ex    c
-b3# cx    axfxdxbx  d
-b3#ax  bx  dxbx cx d
-b3#a
-x    ax  dx  bx   dx d
-b3#   cx   a3 c ca
-4#   dx   c4#   dx   cx   ax   c
+b
+3#f
+x      a
+x d
+xd
+xb
+xa
+b
+3# d-a
+x   c
+x   d
+x   a
+x    e
+x    c
+b
+3# c
+x    a
+xf
+xd
+xb
+x  d
+b
+3#a
+x  b
+x  d
+xb
+x c
+x d
+b
+3#a
+x    a
+x  d
+x  b
+x   d
+x d
+b
+3#   c
+x   a
+3 c ca
+4#   d
+x   c
+4#   d
+x   c
+x   a
+x   c
 b
 1   a
 2      a
@@ -13159,46 +23244,84 @@ Y dd
 b
 B
 
-{ }{32b. Untitled - 7F10C/RUS-SPan O No 124, ff. 58v-59r}BX
+{ }
+{32b. Untitled - 7F10C/RUS-SPan O No 124, ff. 58v-59r}
+BX
 bX
 S3
 2f
-b2.fgia
+b
+2.fgia
 3g
 2f
-b2fde
+b
+2fde
 2.d
-4# gxd
+4# g
+xd
 b
-2#fx   ax   c
+2#f
+x   a
+x   c
 b
-3# d dx  b
+3# d d
+x  b
 2.a d
-4# dxa
+4# d
+xa
 b
-2#bx   axd  c
+2#b
+x   a
+xd  c
 b
 2.fd a
-3#dxb  axd
+3#d
+xb  a
+xd
 b
-2#ax    ax   c
-b2#acdx     dx dd  b
+2#a
+x    a
+x   c
+b
+2#acd
+x     d
+x dd  b
 b
 
-b2#a    ax  d e
-3#fxd
 b
-2#b  ax      axd    a
-b2# bdd bx  dddxb
-b2#     axa d ex  b
-b2#      ax dd fxf
-b2# d  bxd    d
+2#a    a
+x  d e
+3#f
+xd
+b
+2#b  a
+x      a
+xd    a
+b
+2# bdd b
+x  ddd
 xb
 b
-2.a   a3f2 c c
-b2 d d
+2#     a
+xa d e
+x  b
+b
+2#      a
+x dd f
+xf
+b
+2# d  b
+xd    d
+xb
+b
+2.a   a
+3f
+2 c c
+b
+2 d d
 2. c ca
-4# ax c
+4# a
+x c
 b
 
 b
@@ -13209,31 +23332,125 @@ b
 1 dd
 bbX
 2f
-b2fgia
-3#      ax ix gx f
-b3#  ix  gx  exfxd
-4# Qgxd
 b
-3#fx  dx fx gx fx   f
-b3# d dx  dx   fx  exa dx c
-b3#bx  ex dx  dxd bx   c
-b3#f  dx   fx  dxd exb  axd
+2fgia
+3#      a
+x i
+x g
+x f
+b
+3#  i
+x  g
+x  e
+xf
+xd
+4# Qg
+xd
+b
+3#f
+x  d
+x f
+x g
+x f
+x   f
+b
+3# d d
+x  d
+x   f
+x  e
+xa d
+x c
+b
+3#b
+x  e
+x d
+x  d
+xd b
+x   c
+b
+3#f  d
+x   f
+x  d
+xd e
+xb  a
+xd
 b
 
-b3#ax    ax  dcx ax cx d
-b3#ax  d ax cx     dx  d  bx d
-b3#a    ax   ax    ex  dxfxd
-b3#b  ax      ax dx  exdx     a
-b3#     bx bx  dx   dxbx   a
-b3#     ax   axa   ex  dx  bx  d
-b3#      ax  dx dx   fx-Qf  ex    f
-b3# dxdx    bx     dx   axb
+b
+3#a
+x    a
+x  dc
+x a
+x c
+x d
+b
+3#a
+x  d a
+x c
+x     d
+x  d  b
+x d
+b
+3#a    a
+x   a
+x    e
+x  d
+xf
+xd
+b
+3#b  a
+x      a
+x d
+x  e
+xd
+x     a
+b
+3#     b
+x b
+x  d
+x   d
+xb
+x   a
+b
+3#     a
+x   a
+xa   e
+x  d
+x  b
+x  d
+b
+3#      a
+x  d
+x d
+x   f
+x-Qf  e
+x    f
+b
+3# d
+xd
+x    b
+x     d
+x   a
+xb
 b
 
-b3#ax    ax  dx dx   dx d
-b3#  bx   d
+b
+3#a
+x    a
+x  d
+x d
+x   d
+x d
+b
+3#  b
+x   d
 x c ca
-4   dx   cx   dx   cx   ax   c
+4   d
+x   c
+x   d
+x   c
+x   a
+x   c
 b
 2   a
 x      a
@@ -13242,40 +23459,88 @@ b
 1 dd
 bbX
 2  d
-b2#  ddx bx   c
-b2# ddaxa d ex  b
-b2b da
-3#      axdxbxa
-b3# d  bx    dx   ax   cx   dx  b
+b
+2#  dd
+x b
+x   c
+b
+2# dda
+xa d e
+x  b
+b
+2b da
+3#      a
+xd
+xb
+xa
+b
+3# d  b
+x    d
+x   a
+x   c
+x   d
+x  b
 b
 
 b
-2# b  ax   dx  d
-b3#    b
+2# b  a
+x   d
+x  d
+b
+3#    b
 x  d
 2.  b d
-4#   dx   c
+4#   d
+x   c
 b
-2#   dx     bx  d
-b2# a   dx c cx    a
-b2# d Qabxbx    a
+2#   d
+x     b
+x  d
+b
+2# a   d
+x c c
+x    a
+b
+2# d Qab
+xb
+x    a
 b
 2.dde  d
-3#fxgxd
+3#f
+xg
+xd
 b
 2.f     a
-3#dxbxa
-b3# d ax   cx   dx   ax    ex    c
+3#d
+xb
+xa
 b
-2# c  axfxd
+3# d a
+x   c
+x   d
+x   a
+x    e
+x    c
+b
+2# c  a
+xf
+xd
 b
 
-b2#bx  dxa b
-b2#      ///ax  dQdax d
 b
-3#  bx   d
+2#b
+x  d
+xa b
+b
+2#      ///a
+x  dQda
+x d
+b
+3#  b
+x   d
 2. c ca
-4#   ax   c
+4#   a
+x   c
 b
 2#   a
 x      a
@@ -13285,34 +23550,126 @@ b
 bbX
 2  d
 b
-3#  dx   dx bx   cx   ax   c
-b3# d dx  bx  dxa
-x dxa
+3#  d
+x   d
+x b
+x   c
+x   a
+x   c
 b
-3#bx   ax      axdxbxa
+3# d d
+x  b
+x  d
+xa
+x d
+xa
+b
+3#b
+x   a
+x      a
+xd
+xb
+xa
 b
 
-b3# d  bx    dx   ax   cx   dx  b
 b
-3# b  ax   cx dx bx  e  dx    a
-b3#    b
-x    d4#   a
-x   cx   dx   c4#   dx   cx   ax   c
+3# d  b
+x    d
+x   a
+x   c
+x   d
+x  b
 b
-3#   dx  bx   cx bx  dx   d
-b3# ax     dx   cx cx    ax  Qdd
-b3# dx   cxb  ax    dx    bx    a
-b3#     dxdx dxfxgxd
+3# b  a
+x   c
+x d
+x b
+x  e  d
+x    a
+b
+3#    b
+x    d
+4#   a
+x   c
+x   d
+x   c
+4#   d
+x   c
+x   a
+x   c
+b
+3#   d
+x  b
+x   c
+x b
+x  d
+x   d
+b
+3# a
+x     d
+x   c
+x c
+x    a
+x  Qdd
+b
+3# d
+x   c
+xb  a
+x    d
+x    b
+x    a
+b
+3#     d
+xd
+x d
+xf
+xg
+xd
 b
 
-b2f3# dxdxbxa
-b3# d ax   cx   dx   ax    ex    c
-b2 c  a3#fxdxbx  d
-b3#ax  bx  dxbx cx d
-b3#a
-x      ///ax  dx  bx   dx d
-b3#  bx   d3 c ca
-4#   dx   c4#   dx   cx   ax   c
+b
+2f
+3# d
+xd
+xb
+xa
+b
+3# d a
+x   c
+x   d
+x   a
+x    e
+x    c
+b
+2 c  a
+3#f
+xd
+xb
+x  d
+b
+3#a
+x  b
+x  d
+xb
+x c
+x d
+b
+3#a
+x      ///a
+x  d
+x  b
+x   d
+x d
+b
+3#  b
+x   d
+3 c ca
+4#   d
+x   c
+4#   d
+x   c
+x   a
+x   c
 b
 2#   a
 x      a
@@ -13323,164 +23680,442 @@ b
 B
 
 { }
-{32c. Untitled - 7F8Ef9D10C/RUS-SPan O No 124, ff. 28v-29r}BX
+{32c. Untitled - 7F8Ef9D10C/RUS-SPan O No 124, ff. 28v-29r}
+BX
 bX
 S3
 2a
 b
 2.abd a
 3#      ///a
-xbxa
+xb
+xa
 b
 2.a dd
-3# dx bx d
+3# d
+x b
+x d
 b
-2#ax    ax    c
-b3#  d dx   a
+2#a
+x    a
+x    c
+b
+3#  d d
+x   a
 2. a c
-4#  dx a
+4#  d
+x a
 b
-2# bx    ax d  c
+2# b
+x    a
+x d  c
 b
 2.a d a
-3# dx bx d
+3# d
+x b
+x d
 b
-2# ax     ax   c
-b2# aQcx      Qax  dc  /a
+2# a
+x     a
+x   c
+b
+2# aQc
+x      Qa
+x  dc  /a
 b
 
-b2# ax   c e
-3#ax d
 b
-2# b  ax      ///ax d    //a
-b2#  bcd /ax   cddx b
-b2#      //ax a c ex   Qa
-b2#      ///ax  dcaxa
-b2#  d  bx dx      a
-b2 b
-3# a   axa
+2# a
+x   c e
+3#a
+x d
+b
+2# b  a
+x      ///a
+x d    //a
+b
+2#  bcd /a
+x   cdd
+x b
+b
+2#      //a
+x a c e
+x   Qa
+b
+2#      ///a
+x  dca
+xa
+b
+2#  d  b
+x d
+x      a
+b
+2 b
+3# a   a
+xa
 2  c c
-b2  d d
+b
+2  d d
 2.  c ca
-4#    ax    c
+4#    a
+x    c
 b
 
 b
-2#    ax      ///ax     a
+2#    a
+x      ///a
+x     a
 b
 1  dc
 bbX
 2a
 b
-3#abd ax      ///ax dx bx ax  d
-b3#  bx   dxax dx Qbx d
-b3#ax   cx ax bx ax   a
-b3#  d dx   cx   ax   dx a cx  c
-b3# bx   dx dx   cx d ax    c
-b3#a   dx   ax   cx d dx b  ax d
+3#abd a
+x      ///a
+x d
+x b
+x a
+x  d
+b
+3#  b
+x   d
+xa
+x d
+x Qb
+x d
+b
+3#a
+x   c
+x a
+x b
+x a
+x   a
+b
+3#  d d
+x   c
+x   a
+x   d
+x a c
+x  c
+b
+3# b
+x   d
+x d
+x   c
+x d a
+x    c
+b
+3#a   d
+x   a
+x   c
+x d d
+x b  a
+x d
 b
 
-b3# ax     ax   ccx  ax  cx  d
-b3# ax   c ax  cx      ax   c  /ax  d
-b3# a    //ax    ax     ex   cxax d
-b3# b  ax      ///ax  dx   dx dx      //a
-b3#      /ax  bx   cx    dx bx    a
-b3#      //ax    ax a   ex   cx   ax   c
-b3#      ///ax   cx  dx   ax-Qa   ex    a
-b3#  dx     b
-x Qdx      ax   ax bbQ
+b
+3# a
+x     a
+x   cc
+x  a
+x  c
+x  d
+b
+3# a
+x   c a
+x  c
+x      a
+x   c  /a
+x  d
+b
+3# a    //a
+x    a
+x     e
+x   c
+xa
+x d
+b
+3# b  a
+x      ///a
+x  d
+x   d
+x d
+x      //a
+b
+3#      /a
+x  b
+x   c
+x    d
+x b
+x    a
+b
+3#      //a
+x    a
+x a   e
+x   c
+x   a
+x   c
+b
+3#      ///a
+x   c
+x  d
+x   a
+x-Qa   e
+x    a
+b
+3#  d
+x     b
+x Qd
+x      a
+x   a
+x b
+bQ
 
 bQ
 3# a
 x   c
-x     Qax  d
-x    dx  d
-b3#   ax    d
-x  c ca
-4#    dx    cx    dx    cx    ax    c
+x     Qa
+x  d
+x    d
+x  d
 b
-2#    ax      ///ax     a
+3#   a
+x    d
+x  c ca
+4#    d
+x    c
+x    d
+x    c
+x    a
+x    c
+b
+2#    a
+x      ///a
+x     a
 b
 1  dc
 bbX
 2   c
-b2#   cQdx  bx    c
-b2#  dcax a c ex   a
+b
+2#   cQd
+x  b
+x    c
+b
+2#  dca
+x a c e
+x   a
 b
 2. b ca ///a
-3# dx bx a
-b3#  d  bx     dx    ax    cx    dx   a
+3# d
+x b
+x a
+b
+3#  d  b
+x     d
+x    a
+x    c
+x    d
+x   a
 b
 
 b
-2#  b  ax    dx   c
+2#  b  a
+x    d
+x   c
 b
-3#     bx   c
+3#     b
+x   c
 2.   a d
-4#    dx    c
+4#    d
+x    c
 b
-2#    dx      /ax   c
-b2#  a   ax  c cx     a
-b2  d  b
+2#    d
+x      /a
+x   c
+b
+2#  a   a
+x  c c
+x     a
+b
+2  d  b
 1 b   a
 b
 2. ddd  a
-3#axbx d
+3#a
+xb
+x d
 b
 2.a     ///a
-3# dx bx a
-b3#  d ax    cx    dx    ax     ex     c
+3# d
+x b
+x a
 b
-2#  c  axax d
+3#  d a
+x    c
+x    d
+x    a
+x     e
+x     c
+b
+2#  c  a
+xa
+x d
 b
 
-b2# bx   Qcx Qa a
-b2#     ax   cx  d
-b3#   ax    d
-2.  c ca
-4#    ax    c
 b
-2#    ax      ///ax    a
+2# b
+x   Qc
+x Qa a
+b
+2#     a
+x   c
+x  d
+b
+3#   a
+x    d
+2.  c ca
+4#    a
+x    c
+b
+2#    a
+x      ///a
+x    a
 b
 1  dca
 bb
 2   c
 b
-3#   cx    dx  bx    cx    ax    c
-b3#  d dx   ax   cx bx a4#  dx a
-b3# bx    ax      ///ax dx bx a
+3#   c
+x    d
+x  b
+x    c
+x    a
+x    c
+b
+3#  d d
+x   a
+x   c
+x b
+x a
+4#  d
+x a
+b
+3# b
+x    a
+x      ///a
+x d
+x b
+x a
 b
 
-b3#  d  bx     dx    ax    Qcx    Qdx   Qa
-b3#  b  ax    cx  dx  bx   d  ax     a
-b3#     bx     d
-4#    ax    cx    dx    c4#    dx    cx    ax    c
 b
-3#    dx   ax    cx  bx   cx    d
-b3# ax      ax    cx  cx     ax    d
-b3#  dx    cx b  ax     dx     bx     a
-b3#      ax dx  dxaxbx d
+3#  d  b
+x     d
+x    a
+x    Qc
+x    Qd
+x   Qa
+b
+3#  b  a
+x    c
+x  d
+x  b
+x   d  a
+x     a
+b
+3#     b
+x     d
+4#    a
+x    c
+x    d
+x    c
+4#    d
+x    c
+x    a
+x    c
+b
+3#    d
+x   a
+x    c
+x  b
+x   c
+x    d
+b
+3# a
+x      a
+x    c
+x  c
+x     a
+x    d
+b
+3#  d
+x    c
+x b  a
+x     d
+x     b
+x     a
+b
+3#      a
+x d
+x  d
+xa
+xb
+x d
 b
 
-b3#ax      ///ax  dx dx bx a
-b3#  d ax    cx    dx    ax     ex     c
-b3#  c
-x     Qaxax dx bx   c
-bQ3# a
-x   Qax   Qcx bx  cx  d
-b3# ax     ax   cx   ax    dx  d
-b3#   ax    d
+b
+3#a
+x      ///a
+x  d
+x d
+x b
+x a
+b
+3#  d a
+x    c
+x    d
+x    a
+x     e
+x     c
+b
+3#  c
+x     Qa
+xa
+x d
+x b
+x   c
+bQ
+3# a
+x   Qa
+x   Qc
+x b
+x  c
+x  d
+b
+3# a
+x     a
+x   c
+x   a
+x    d
+x  d
+b
+3#   a
+x    d
 2.  c ca
-4#    ax    c
+4#    a
+x    c
 b
-2#    ax      ///ax    a
+2#    a
+x      ///a
+x    a
 b
 Y  dca
 b
 B
 
 p
-{33a. Courante Gothier - 7F8E9D10C/CZ-Pnm G.IV.18, f. 22v}BX
+{33a. Courante Gothier - 7F8E9D10C/CZ-Pnm G.IV.18, f. 22v}
+BX
 bX
 S3
 2 a
@@ -13488,83 +24123,151 @@ b
 2.aa   a
 3c
 2e
-b2#ef  axcf  c
-3 e
-4# cx e
 b
-2# fx     ax    c
+2#ef  a
+xcf  c
+3 e
+4# c
+x e
+b
+2# f
+x     a
+x    c
 b
 2.aac
-3h3#exf
+3h
+3#e
+xf
 b
-2#hxc     //ax a
-b2e
+2#h
+xc     //a
+x a
+b
+2e
 2.a     /a
-4# exa
+4# e
+xa
 b
-2# ex     ex c
-b2# ax cf  cx  e
+2# e
+x     e
+x c
+b
+2# a
+x cf  c
+x  e
 b
 
-b2# a    //ax    cx    e
 b
-2#    fx  ax  c
-b2#  dex cx e
-b2#ax acx cd
-b2# e  cx  dx  c
+2# a    //a
+x    c
+x    e
 b
-3#  ax   c
+2#    f
+x  a
+x  c
+b
+2#  de
+x c
+x e
+b
+2#a
+x ac
+x cd
+b
+2# e  c
+x  d
+x  c
+b
+3#  a
+x   c
 2.c     //a
-4# fxc
+4# f
+xc
 b
-2# fx     ax    c
+2# f
+x     a
+x    c
 b
 1aac
 bbX
 2e
 b
 
-b2#e  cxfxh  g
+b
+2#e  c
+xf
+xh  g
 b
 1 f h
 2 h
-b2 k
-3#     axfxexc
 b
-3#ax ax cx exaxc
+2 k
+3#     a
+xf
+xe
+xc
 b
-2#exc     ax a
-b2#hx f    /axg
-b2.he    //a
-3a3#cxe
+3#a
+x a
+x c
+x e
+xa
+xc
 b
-2#fx     cx      /a
+2#e
+xc     a
+x a
+b
+2#h
+x f    /a
+xg
+b
+2.he    //a
+3a
+3#c
+xe
+b
+2#f
+x     c
+x      /a
 b
 
 b
 2.ecc e
-3  c2#  dx a
+3  c
+2#  d
+x a
 b
-2# cx      ///ax    a
+2# c
+x      ///a
+x    a
 b
 1 acc a
 2     c
 b
 1  dee
 2      /a
-b2#      axhaaxf
-b2e    a
-2.c     //a
-4# fxc
 b
-2# fx     ax   Qc
+2#      a
+xhaa
+xf
+b
+2e    a
+2.c     //a
+4# f
+xc
+b
+2# f
+x     a
+x   Qc
 b
 Yaac
 b
 B
 
 { }
-{33b. Courante - 7F8E9D10C/GB-Eu Coll.2073, f. 238v}BX
+{33b. Courante - 7F8E9D10C/GB-Eu Coll.2073, f. 238v}
+BX
 bX
 S3
 2 a
@@ -13572,81 +24275,150 @@ b
 2.aa   a
 3c
 2e
-b2ef c2.c   c
+b
+2ef c
+2.c   c
 4# f
 xc
 b
-2# fx     ax    c
+2# f
+x     a
+x    c
 b
 2.aac
-3#hxexf
+3#h
+xe
+xf
 b
-2#hxc     //ax a
-b2e    a
+2#h
+xc     //a
+x a
+b
+2e    a
 2.a     /a
-4# exa
+4# e
+xa
 b
-2# ex     ex c
-b2# ax cf  cx  e
+2# e
+x     e
+x c
+b
+2# a
+x cf  c
+x  e
 b
 
-b2# a    //ax    cx    e
-b2#    fx  ax  c
-b2#  dex cx e
-b2#ax acx cd
-b2# e  cx  dx  c
 b
-3#  ax   c
+2# a    //a
+x    c
+x    e
+b
+2#    f
+x  a
+x  c
+b
+2#  de
+x c
+x e
+b
+2#a
+x ac
+x cd
+b
+2# e  c
+x  d
+x  c
+b
+3#  a
+x   c
 2.c     //a
-4# fxc
+4# f
+xc
 b
-2# fx     ax    c
+2# f
+x     a
+x    c
 b
 1aac
 bbX
 2e
 b
 
-b2#e  cxfxh  g
+b
+2#e  c
+xf
+xh  g
 b
 1 fhh
 2 h
-b2 k
-3#     axfxexc
-b3#ax ax cx exaxc
 b
-2#exc     ax a
-b2#hx f    /axg
-b2.he    //a
-3#axcxe
+2 k
+3#     a
+xf
+xe
+xc
 b
-2#fx     cx      /a
+3#a
+x a
+x c
+x e
+xa
+xc
+b
+2#e
+xc     a
+x a
+b
+2#h
+x f    /a
+xg
+b
+2.he    //a
+3#a
+xc
+xe
+b
+2#f
+x     c
+x      /a
 b
 
 b
 2.eccce
-3#  cx  dx a
+3#  c
+x  d
+x a
 b
-2# cx      ///ax    a
+2# c
+x      ///a
+x    a
 b
 1 acc a
 2     c
 b
 1  dee
 2      /a
-b2#      axhaaxf
-b2e    a
-2.c     //a
-4# fxc
 b
-2# fx     ax   c
+2#      a
+xhaa
+xf
+b
+2e    a
+2.c     //a
+4# f
+xc
+b
+2# f
+x     a
+x   c
 b
 Yaac
 b
 B
 
 { }
-{34. Courante par gautie - 7F9D/Moy 1631 f. 20v}BX
+{34. Courante par gautie - 7F9D/Moy 1631 f. 20v}
+BX
 bX
 S3
 2 a
@@ -13657,24 +24429,42 @@ b
 b
 2     c
 2.aabc a
-4#cx f
+4#c
+x f
 b
-2# ex    cx      //a
-b2.  f
-3#fxd  c
+2# e
+x    c
+x      //a
+b
+2.  f
+3#f
+xd  c
 xf
 b
 2.d
-3#hxf  exh
+3#h
+xf  e
+xh
 b
 2.f
-3#ixh  fxi
-b3#hx   hx  fx  hx  ix f
+3#i
+xh  f
+xi
+b
+3#h
+x   h
+x  f
+x  h
+x  i
+x f
 b
 
-b3# hx i
+b
+3# h
+x i
 2.f   Qf
-4# ixf
+4# i
+xf
 b
 1 i
 2     d
@@ -13682,36 +24472,57 @@ b
 1ddf
 bbX
 2  b
-b2# db c
+b
+2# db c
 xa - d
-3# b  ax d
+3# b  a
+x d
 b
 1. aba d
 b
 2.  da  a
 3 a
 2  d
-b2.  bc a
-3#  dx a bx  d
+b
+2.  bc a
+3#  d
+x a b
+x  d
 b
 
-b3#  bcx  d
+b
+3#  bc
+x  d
 2.  a   //a
-4#   cx  a
+4#   c
+x  a
 b
-2#   cx     ax b
-b2#  dx     c
-3# dx b
+2#   c
+x     a
+x b
 b
-2# aba dx     axa
+2#  d
+x     c
+3# d
+x b
+b
+2# aba d
+x     a
+xa
 b
 1. Qe -- //a
 b
 2h
-3#fxdxcxd
-b3#fxd
+3#f
+xd
+xc
+xd
+b
+3#f
+xd
 2.c - c
-4# fxc
+4# f
+xc
 b
 1af-
 2     a
@@ -13726,24 +24537,47 @@ BX
 bX
 S3
 2 a
-b2# ab  ax      ax      /a
-b2# a c  //ax   bx  d
-b2# abcx     ax   c
+b
+2# ab  a
+x      a
+x      /a
+b
+2# a c  //a
+x   b
+x  d
+b
+2# abc
+x     a
+x   c
 b
 2@aab
-3# ax c
-x ebQ2#a
-x     ax      a
+3# a
+x c
+x e
+bQ
+2#a
+x     a
+x      a
 b
-3#a     /axc
+3#a     /a
+xc
 2d
-3#cxa
+3#c
+xa
 b
-2# e    //ax axa
-b2#cx a    //ax b
+2# e    //a
+x a
+xa
+b
+2#c
+x a    //a
+x b
 b
 
-b2# dx  a cx  b
+b
+2# d
+x  a c
+x  b
 b
 2. b  a
 3 d
@@ -13752,75 +24586,162 @@ b
 2. a   d
 3 d
 2 b  a
-b2# a  cx  d d
-3# a ax  d
-b2#  bcx     ax  d  c
 b
-3# a   dx  dx  b  ax  d
+2# a  c
+x  d d
+3# a a
+x  d
+b
+2#  bc
+x     a
+x  d  c
+b
+3# a   d
+x  d
+x  b  a
+x  d
 2  a c
-b2#   cx     ax   c
+b
+2#   c
+x     a
+x   c
 b
 1aac
 bbX
 2a
 b
 
-b2aac  a
-3#      axc
+b
+2aac  a
+3#      a
+xc
 2d     /a
-b3#      //axd
-2#cx  d
-b2#aab  ax   cx   a
-b2#  b cx  dx a  c
 b
-3# b  ax    cx    dx   ax   cx   e
+3#      //a
+xd
+2#c
+x  d
 b
-2# a fx  d fx      a
-b2#  b  dx  d  cx     a
-b2# a bx    cx  d
+2#aab  a
+x   c
+x   a
+b
+2#  b c
+x  d
+x a  c
+b
+3# b  a
+x    c
+x    d
+x   a
+x   c
+x   e
+b
+2# a f
+x  d f
+x      a
+b
+2#  b  d
+x  d  c
+x     a
+b
+2# a b
+x    c
+x  d
 b
 
-b2#  bx     ax  a   a
-b2   c  /a
-3#  dx  bx  ax   c
-b3#   b  //ax   cx  ax  bx  dx a
-b3#  bx  dx ax c
-x exa
-b3# e    //axaxcx ax cx e
-b3#axc
-2. e    //a
-4# cx e
 b
-2# fx     a
+2#  b
+x     a
+x  a   a
+b
+2   c  /a
+3#  d
+x  b
+x  a
+x   c
+b
+3#   b  //a
+x   c
+x  a
+x  b
+x  d
+x a
+b
+3#  b
+x  d
+x a
+x c
+x e
+xa
+b
+3# e    //a
+xa
+xc
+x a
+x c
+x e
+b
+3#a
+xc
+2. e    //a
+4# c
+x e
+b
+2# f
+x     a
 x   c
 b
 Yaac
 b
 B
 
-p{35b. Corr: franc. - 7F8Ef9D/I-PEas VII-H-2, p. 99}BX
+p
+{35b. Corr: franc. - 7F8Ef9D/I-PEas VII-H-2, p. 99}
+BX
 bX
 S3
 2 a
-b2. abcca3      a2      /a
-b2# a c  //ax   bx  d
-b2#  bx     ax   c
+b
+2. abcca
+3      a
+2      /a
+b
+2# a c  //a
+x   b
+x  d
+b
+2#  b
+x     a
+x   c
 b
 2.  Qb
-3# ax c
+3# a
+x c
 x e
-b2# fx     a
+b
+2# f
+x     a
 x      a
 b
-2.a     /a3#d
-xcxa
+2.a     /a
+3#d
+xc
+xa
 b
-2# e    //ax  fxa
-b2#cx ax b
+2# e    //a
+x  f
+xa
+b
+2#c
+x a
+x b
 b
 
-b3#    c
-x dx  b
+b
+3#    c
+x d
+x  b
 xa
 x d
 xa
@@ -13837,22 +24758,32 @@ b
 x b
 x a
 x b
-b3#     cx  d
+b
+3#     c
+x  d
 x   b
 x a
 x  d
 x a
-b2  b  a
-3#  ax  bx  d 
+b
+2  b  a
+3#  a
+x  b
+x  d 
 x  b
 b
 2  b   //a
 2.  a&+
-4#   cx  ab2#   cx     a
+4#   c
+x  a
+b
+2#   c
+x     a
 x   Qc
 bQ
 1QQaQaQc
-bbX2a
+bbX
+2a
 b
 
 b
@@ -13861,33 +24792,81 @@ b
 xc
 xd
 x      /a
-b2#d     //axc
+b
+2#d     //a
+xc
 x e
-b2#af   ax   cx   a
-b2    d
-3#  bx  d2 a  c
 b
-3# b  ax    cx    dx   ax   cx   e
+2#af   a
+x   c
+x   a
 b
-2#   fx  d fx   e
-b2# a   dx  d  cx     a
-b2# abx   cx  d
+2    d
+3#  b
+x  d
+2 a  c
+b
+3# b  a
+x    c
+x    d
+x   a
+x   c
+x   e
+b
+2#   f
+x  d f
+x   e
+b
+2# a   d
+x  d  c
+x     a
+b
+2# ab
+x   c
+x  d
 b
 
-b2#  bx     ax      a
-b3#      /a
+b
+2#  b
+x     a
+x      a
+b
+3#      /a
 x   c
-x  dx  bx  ax   c
-b3#   b  //ax   cx  ax  bx  dx a
-b3#  bx  dx ax c
-x exa
-b3# exaxcx ax cx e
-b3#axc
+x  d
+x  b
+x  a
+x   c
+b
+3#   b  //a
+x   c
+x  a
+x  b
+x  d
+x a
+b
+3#  b
+x  d
+x a
+x c
+x e
+xa
+b
+3# e
+xa
+xc
+x a
+x c
+x e
+b
+3#a
+xc
 xd
 xf
 2c     //a
 b
-2# fx     a
+2# f
+x     a
 x   c
 b
 Yaac
@@ -13895,30 +24874,53 @@ b
 B
 
 p
-{35c. Courante de Gauthier - 7F8Ef9D/CH-Bu F.IX.53, ff. 18v-19r}BX
+{35c. Courante de Gauthier - 7F8Ef9D/CH-Bu F.IX.53, ff. 18v-19r}
+BX
 bX
 S3
 2 a
-b2# ab  ax      ax  d - /a
-b2# Qa c  //ax   bx  d
-b2#  b&+x   cx     a
+b
+2# ab  a
+x      a
+x  d - /a
+b
+2# Qa c  //a
+x   b
+x  d
+b
+2#  b&+
+x   c
+x     a
 b
 2. ab
-3# ax c
+3# a
+x c
 x e
-b2#af
-x     ax      a
 b
-2a&+ --  /a3#c
+2#af
+x     a
+x      a
+b
+2a&+ --  /a
+3#c
 xd
-xcxa
+xc
+xa
 b
 2 e    //a
-2.a4# exa
-b2#cx a    //ax Qb
+2.a
+4# e
+xa
+b
+2#c
+x a    //a
+x Qb
 b
 
-b2# dx a  cx  b
+b
+2# d
+x a  c
+x  b
 b
 2# Qb  Qa
 x QdQa
@@ -13927,45 +24929,109 @@ b
 2. aba d
 3 d
 2 b  a
-b2# a  cx  d d
-3# a ax  d
-b2#  bcx     ax  d  c
 b
-3# a - dx  dx  b  ax  d
+2# a  c
+x  d d
+3# a a
+x  d
+b
+2#  bc
+x     a
+x  d  c
+b
+3# a - d
+x  d
+x  b  a
+x  d
 2  a c
-b2#   cx     ax   c
+b
+2#   c
+x     a
+x   c
 b
 1aab
 bbX
 2a
 b
 
-b2aab  a
-3#      axc
+b
+2aab  a
+3#      a
+xc
 2d --  /a
-b2#d  -  //axcx  d
-b2#aabx   cx   a&,
-b2#  b dx  dx a  c
 b
-3# b  ax    cx    dx   ax   cx   e
+2#d  -  //a
+xc
+x  d
 b
-2# a fx  dx      a
-b2#  b- dx  d  cx     a
-b2# a    bx    cx  d
+2#aab
+x   c
+x   a&,
+b
+2#  b d
+x  d
+x a  c
+b
+3# b  a
+x    c
+x    d
+x   a
+x   c
+x   e
+b
+2# a f
+x  d
+x      a
+b
+2#  b- d
+x  d  c
+x     a
+b
+2# a    b
+x    c
+x  d
 b
 
-b2#  bx     ax  a - a
-b2   c  /a
-3#  dx  bx  ax   c
-b3#   b  //ax   cx  ax  bx  dx a
-b3#  bx  dx ax c
-x exa
-b3# e -- //axaxcx ax cx e
-b3#axc
-xdxf
+b
+2#  b
+x     a
+x  a - a
+b
+2   c  /a
+3#  d
+x  b
+x  a
+x   c
+b
+3#   b  //a
+x   c
+x  a
+x  b
+x  d
+x a
+b
+3#  b
+x  d
+x a
+x c
+x e
+xa
+b
+3# e -- //a
+xa
+xc
+x a
+x c
+x e
+b
+3#a
+xc
+xd
+xf
 2ca -- //a
 b
-2#ax     a
+2#a
+x     a
 x   c
 b
 Yaab
@@ -13973,29 +25039,52 @@ b
 B
 
 p
-{35d. Courente - 7F8Ef9D/I-Tn IV.23.2, ff. 10v-11r}BX
+{35d. Courente - 7F8Ef9D/I-Tn IV.23.2, ff. 10v-11r}
+BX
 bX
 S3
 2 a
-b2# abc ax      ax      /a
-b2# a c  //ax   bx  d
-b2# abcx     ax    c
+b
+2# abc a
+x      a
+x      /a
+b
+2# a c  //a
+x   b
+x  d
+b
+2# abc
+x     a
+x    c
 b
 2. ab
-3# ax c
+3# a
+x c
 x e
-b2#a
-x     ax      a
 b
-3#a     /axc
+2#a
+x     a
+x      a
+b
+3#a     /a
+xc
 2Qd
-3#cxa
+3#c
+xa
 b
-2# e    //ax axa
-b2#cx aa   //ax b
+2# e    //a
+x a
+xa
+b
+2#c
+x aa   //a
+x b
 b
 
-b2# dx  a cx  b
+b
+2# d
+x  a c
+x  b
 b
 2# b  a
 x da
@@ -14004,45 +25093,109 @@ b
 2# aba d
 x d
 x b  a
-b2# a  cx  d d
-3# a ax  d
-b2#  bcx     ax  d  c
 b
-3# a   dx  dx  b  ax  d
+2# a  c
+x  d d
+3# a a
+x  d
+b
+2#  bc
+x     a
+x  d  c
+b
+3# a   d
+x  d
+x  b  a
+x  d
 2  a c
-b2#   cx     ax    c
+b
+2#   c
+x     a
+x    c
 b
 1aac
 bbX
 2a
 b
 
-b2aa   a
-3#      axc
+b
+2aa   a
+3#      a
+xc
 2d     /a
-b2#d     //axcx  d
-b2#a b  ax   cx   a
-b2#  b dx  dx a  c
 b
-3# b  ax    cx    dx   ax   cx   e
+2#d     //a
+xc
+x  d
 b
-2# a fx  d fx      a
-b2#  b  dx  d  cx     a
-b2# a    bx    cx  d
+2#a b  a
+x   c
+x   a
+b
+2#  b d
+x  d
+x a  c
+b
+3# b  a
+x    c
+x    d
+x   a
+x   c
+x   e
+b
+2# a f
+x  d f
+x      a
+b
+2#  b  d
+x  d  c
+x     a
+b
+2# a    b
+x    c
+x  d
 b
 
-b2#  bx     ax  a   a
-b2   c  /a
-3#  dx  bx  ax   c
-b3#   b  //ax   cx  ax  bx  dx a
-b3#  bx  dx ax c
-x exa
-b3# e    //axaxcx ax cx e
-b3#axc
-2. ea   //a
-4# cx e
 b
-2# fx     a
+2#  b
+x     a
+x  a   a
+b
+2   c  /a
+3#  d
+x  b
+x  a
+x   c
+b
+3#   b  //a
+x   c
+x  a
+x  b
+x  d
+x a
+b
+3#  b
+x  d
+x a
+x c
+x e
+xa
+b
+3# e    //a
+xa
+xc
+x a
+x c
+x e
+b
+3#a
+xc
+2. ea   //a
+4# c
+x e
+b
+2# f
+x     a
 x   c
 b
 Yaac
@@ -14050,19 +25203,28 @@ b
 B
 
 p
-{35e. Corenta É Ascanio Garsi - 7F8Ef9D/PL Kj 40153, f. 15v}
+{35e. Corenta Ascanio Garsi - 7F8Ef9D/PL Kj 40153, f. 15v}
 BX
 bX
 S3
 2 a
-b2# abc ax      ax      /a
-b2# a c  //ax   bx  d
+b
+2# abc a
+x      a
+x      /a
+b
+2# a c  //a
+x   b
+x  d
 b
 2# QaQbQc
 x     Qa
 x    Qc
-b2 abc3#     a
-x ax c
+b
+2 abc
+3#     a
+x a
+x c
 x e
 b
 2#af
@@ -14070,15 +25232,25 @@ x     a
 x      a
 b
 3#      /a
-xaxc
+xa
+xc
 xd
-xcxa
+xc
+xa
 b
-2# e    //ax axa
-b2#cx a    //ax b
+2# e    //a
+x a
+xa
+b
+2#c
+x a    //a
+x b
 b
 
-b2# dx    cx  b
+b
+2# d
+x    c
+x  b
 b
 2# b  a
 x  da
@@ -14087,52 +25259,105 @@ b
 2. ab  d
 3 d
 2 b  a
-b2# a  cx  d d
-3# a ax  d
-b2#  bcx     ax  d  c
 b
-3# a   dx  dx  b ax  d
+2# a  c
+x  d d
+3# a a
+x  d
+b
+2#  bc
+x     a
+x  d  c
+b
+3# a   d
+x  d
+x  b a
+x  d
 2  a c
-b2#   cx     ax   c
+b
+2#   c
+x     a
+x   c
 bQ
 1QQaQaQc
 bbX
 2a
 b
 
-b2aa   a
-3#      axc
+b
+2aa   a
+3#      a
+xc
 2Qd     /a
-b2#da    //axcx  d
-b2#aab  ax   cx   a
-b2#  b cx  dx a  c
 b
-3# b  ax    cx    dx   ax   cx   e
+2#da    //a
+xc
+x  d
 b
-2# a fx  d fx      a
-b2#  b  dx  d  cx  b  a
-b2# ax    cx  d
+2#aab  a
+x   c
+x   a
+b
+2#  b c
+x  d
+x a  c
+b
+3# b  a
+x    c
+x    d
+x   a
+x   c
+x   e
+b
+2# a f
+x  d f
+x      a
+b
+2#  b  d
+x  d  c
+x  b  a
+b
+2# a
+x    c
+x  d
 b
 
-b2#  b  ax  a   a
+b
+2#  b  a
+x  a   a
 x      /a
-b2   b  //a
+b
+2   b  //a
 3#  d
 x  b
 x  a
 x   c
 b
-2#   b  //ax     cx a c
-b3#  bx  dx ax c
-x exa
-b2 ea c
-3#      //a
-x Qax cx e
-b3#axc
-2. e    //a
-4# cx e
+2#   b  //a
+x     c
+x a c
 b
-2#ax     a
+3#  b
+x  d
+x a
+x c
+x e
+xa
+b
+2 ea c
+3#      //a
+x Qa
+x c
+x e
+b
+3#a
+xc
+2. e    //a
+4# c
+x e
+b
+2#a
+x     a
 x   Qc
 b
 Yaac
@@ -14140,80 +25365,560 @@ b
 B
 
 p
-{36. Courante Gothier - 7F8Ef9D10C/CZ-Pnm G.IV.18, ff. 67v-68r}BXbXS3
-2 ab2#  bx   cx  abb2#  bc ax    dx  db2# aa   //ax  bx   cb2. aab3  d3#  bx  ab2#  bcx     ax  d  cb2# a   dx  b  ax cb2# ddax      axab2#c  bx      //axdb2#a     /ax      ///axfbb2c     a3#   axax dx bb2. a   d3  d2#  b ax  ab3#   cx  b2.  a   //a4#   cx  ab2#   cx     ax    cb1aacbQX
-bX2 ab3#  b  ax  ax   cx  bx  a cx   bb3#     ax  bx   cx   ax    dx  dbb3#      //ax ax  ax  bx   cx  ab3#   bx  ax ax  dx  bx  ab3#     ax  bx   cx     cx  dx   ab3#     dx ax  bx     ax cx  db3#      ax dx ax cx dxab3#c  ax   cx   ax    dx    cxdb3#      /axax bx  dx      ///axfb
-
-b3#      axcx   axax dx bb2. a   d3  d3#  b ax  ab3#   cx  b2.  a   //a4#   cx  ab2#   cx     ax    cb1aacbbX2ab2.aa c3c2ab2# efxafxceb2#d    ax      axf     /a
-b1h     //a2    gb
-
-b2#    hx ffx    fb2. ff d3  d3#   fx  db2#  fx      //ax    cb2# aabx     ax  bcb2#  da cx      ax dab2# b  ax  a3# dx bb2. a   d3  d3#  b ax  ab3#   cx  b2.  a   //a4#   cx  ab2#   cx     ax    cb
-
-b1aacbQX
-bQX2ab3#     axax ax bxcxab3#      //ax ex axaxcx eb3#     axdx fx      ax      /axfb3#      //axhx    gxfxhxfb3#    hx  fx   fx  gx  fx    fb3#    dx ax  bx a3  d4#  bx  db
-
-b3#      //ax ax  ax  bx   cx  ab3#   bx ax     ax  bx   cx bb3#     cx  dx   ax      ax  ax db3#    ax dx bx  ax dx bb3#     dx ax  bx  dx  b ax  ab3#   cx  b2.  a   //a4#   cx  ab2#   cx     ax    cbYaacbB
-
-{37a. Untitled - 7F8Ef9D11Bf/CZ-Pnm IV.G.18, f. 35v-36r}BX
-bXS3
-3#   cx  a
-b2@  bc a3Q  d2Q a   d
-bQ2@  da  a3# ax  b  a
-x  d
-bQ2#  ax      //ax    c
-bQ1Q aab3# ax b
+{36. Courante Gothier - 7F8Ef9D10C/CZ-Pnm G.IV.18, ff. 67v-68r}
+BX
+bX
+S3
+2 a
 b
-2# d  cx  b3# b  ax d
-b2# a   d
-x  da  a3# a
-x  dbQ2Q#  Qb
-x      5xdbQ2#c     axdxab    /abQ
+2#  b
+x   c
+x  ab
+b
+2#  bc a
+x    d
+x  d
+b
+2# aa   //a
+x  b
+x   c
+b
+2. aab
+3  d
+3#  b
+x  a
+b
+2#  bc
+x     a
+x  d  c
+b
+2# a   d
+x  b  a
+x c
+b
+2# dda
+x      a
+xa
+b
+2#c  b
+x      //a
+xd
+b
+2#a     /a
+x      ///a
+xf
+b
+
+b
+2c     a
+3#   a
+xa
+x d
+x b
+b
+2. a   d
+3  d
+2#  b a
+x  a
+b
+3#   c
+x  b
+2.  a   //a
+4#   c
+x  a
+b
+2#   c
+x     a
+x    c
+b
+1aac
+bQX
+bX
+2 a
+b
+3#  b  a
+x  a
+x   c
+x  b
+x  a c
+x   b
+b
+3#     a
+x  b
+x   c
+x   a
+x    d
+x  d
+b
+
+b
+3#      //a
+x a
+x  a
+x  b
+x   c
+x  a
+b
+3#   b
+x  a
+x a
+x  d
+x  b
+x  a
+b
+3#     a
+x  b
+x   c
+x     c
+x  d
+x   a
+b
+3#     d
+x a
+x  b
+x     a
+x c
+x  d
+b
+3#      a
+x d
+x a
+x c
+x d
+xa
+b
+3#c  a
+x   c
+x   a
+x    d
+x    c
+xd
+b
+3#      /a
+xa
+x b
+x  d
+x      ///a
+xf
+b
+
+b
+3#      a
+xc
+x   a
+xa
+x d
+x b
+b
+2. a   d
+3  d
+3#  b a
+x  a
+b
+3#   c
+x  b
+2.  a   //a
+4#   c
+x  a
+b
+2#   c
+x     a
+x    c
+b
+1aac
+bbX
+2a
+b
+2.aa c
+3c
+2a
+b
+2# ef
+xaf
+xce
+b
+2#d    a
+x      a
+xf     /a
+b
+1h     //a
+2    g
+b
+
+b
+2#    h
+x ff
+x    f
+b
+2. ff d
+3  d
+3#   f
+x  d
+b
+2#  f
+x      //a
+x    c
+b
+2# aab
+x     a
+x  bc
+b
+2#  da c
+x      a
+x da
+b
+2# b  a
+x  a
+3# d
+x b
+b
+2. a   d
+3  d
+3#  b a
+x  a
+b
+3#   c
+x  b
+2.  a   //a
+4#   c
+x  a
+b
+2#   c
+x     a
+x    c
+b
+
+b
+1aac
+bQX
+bQX
+2a
+b
+3#     a
+xa
+x a
+x b
+xc
+xa
+b
+3#      //a
+x e
+x a
+xa
+xc
+x e
+b
+3#     a
+xd
+x f
+x      a
+x      /a
+xf
+b
+3#      //a
+xh
+x    g
+xf
+xh
+xf
+b
+3#    h
+x  f
+x   f
+x  g
+x  f
+x    f
+b
+3#    d
+x a
+x  b
+x a
+3  d
+4#  b
+x  d
+b
+
+b
+3#      //a
+x a
+x  a
+x  b
+x   c
+x  a
+b
+3#   b
+x a
+x     a
+x  b
+x   c
+x b
+b
+3#     c
+x  d
+x   a
+x      a
+x  a
+x d
+b
+3#    a
+x d
+x b
+x  a
+x d
+x b
+b
+3#     d
+x a
+x  b
+x  d
+x  b a
+x  a
+b
+3#   c
+x  b
+2.  a   //a
+4#   c
+x  a
+b
+2#   c
+x     a
+x    c
+b
+Yaac
+b
+B
+
+{37a. Untitled - 7F8Ef9D11Bf/CZ-Pnm IV.G.18, f. 35v-36r}
+BX
+bX
+S3
+3#   c
+x  a
+b
+2@  bc a
+3Q  d
+2Q a   d
+bQ
+2@  da  a
+3# a
+x  b  a
+x  d
+bQ
+2#  a
+x      //a
+x    c
+bQ
+1Q aab
+3# a
+x b
+b
+2# d  c
+x  b
+3# b  a
+x d
+b
+2# a   d
+x  da  a
+3# a
+x  d
+bQ
+2Q#  Qb
+x      5
+xd
+bQ
+2#c     a
+xd
+xab    /a
+bQ
 
 bQ
 2Q eb   //a
-3#ax d
-2Q b  abQ2Q a  c3#    d
-x  dx  bx  dbQ2#  Qf
-x      //ax    cbQ1Q aab
-bbX3#   cx  abQ3#     ax  ax  bx  dx a   dx  bbQ3#      ax  dx   ax ax  b  ax  dbQ3#      //ax  ax    cx   cx  ax   bbQ
+3#a
+x d
+2Q b  a
+bQ
+2Q a  c
+3#    d
+x  d
+x  b
+x  d
+bQ
+2#  Qf
+x      //a
+x    c
+bQ
+1Q aab
+bbX
+3#   c
+x  a
+bQ
+3#     a
+x  a
+x  b
+x  d
+x a   d
+x  b
+bQ
+3#      a
+x  d
+x   a
+x a
+x  b  a
+x  d
+bQ
+3#      //a
+x  a
+x    c
+x   c
+x  a
+x   b
+bQ
 
-bQ3#     ax  ax  b
-x  dx ax bbQ3#    cx dx  bx dx    ax bbQ3#     dx ax      ax  dx Qax  d
-bQ2#   fx      5
+bQ
+3#     a
+x  a
+x  b
+x  d
+x a
+x b
+bQ
+3#    c
+x d
+x  b
+x d
+x    a
+x b
+bQ
+3#     d
+x a
+x      a
+x  d
+x Qa
+x  d
+bQ
+2#   f
+x      5
 xd
 bQ
-3#      axcx axd2Qa     /a
-b3#c     //ax axax d
-x    ax b
+3#      a
+xc
+x a
+xd
+2Qa     /a
+b
+3#c     //a
+x a
+xa
+x d
+x    a
+x b
 bQ
-3#    cx ax    dx  dx  bx  dbQ
-
-bQ2#  fx      //ax    cbQ1Q aab
-bb3# ax b
-b2# d  cx      //a3#  a
-x  bbQ2#  dax      a3#  b
-x  abQ2#   cdx    ax  a
-b2#   bcx      //ax  bbQ2#   cdx      /ax  dbQ2#  aax      ax dbQ
-
-bQ2Q ab  d3#      5x ax  d  cx a
-bQ3#  b  ax  d2Q  a   //a3#   cx  a
-b2#   cx     ax    c
-bQ2@aaccbQ
-bQ3#  d
-x ax b
-b3#    cx dx      //ax   cx  ax  bbQ3#   ax  dx      ax  dx  bx  abQ3#    dx   cx    a
+3#    c
+x a
+x    d
+x  d
 x  b
-x  ax   c
+x  d
 bQ
 
-bQ3#    cx   bx      //ax  dx  b
+bQ
+2#  f
+x      //a
+x    c
+bQ
+1Q aab
+bb
+3# a
+x b
+b
+2# d  c
+x      //a
+3#  a
+x  b
+bQ
+2#  da
+x      a
+3#  b
 x  a
-bQ3#    Qd
+bQ
+2#   cd
+x    a
+x  a
+b
+2#   bc
+x      //a
+x  b
+bQ
+2#   cd
+x      /a
+x  d
+bQ
+2#  aa
+x      a
+x d
+bQ
+
+bQ
+2Q ab  d
+3#      5
+x a
+x  d  c
+x a
+bQ
+3#  b  a
+x  d
+2Q  a   //a
+3#   c
+x  a
+b
+2#   c
+x     a
+x    c
+bQ
+2@aacc
+bQ
+bQ
+3#  d
+x a
+x b
+b
+3#    c
+x d
+x      //a
+x   c
+x  a
+x  b
+bQ
+3#   a
+x  d
+x      a
+x  d
+x  b
+x  a
+bQ
+3#    d
+x   c
+x    a
+x  b
+x  a
+x   c
+bQ
+
+bQ
+3#    c
+x   b
+x      //a
+x  d
+x  b
+x  a
+bQ
+3#    Qd
 x   c
 x      /a
 x  a
 2Q  b
-bQ3#   c
+bQ
+3#   c
 x  a
 x      a
 x  b
@@ -14230,10 +25935,12 @@ bQ
 x  a   //a
 3#   c
 x  a
-bQ2#   Qc
+bQ
+2#   Qc
 x     a
 x    c
-bQYaacc
+bQ
+Yaacc
 b
 B
 
@@ -14242,131 +25949,243 @@ p
 BX
 bX
 S3
-3#   cx  a
+3#   c
+x  a
 b
 2.  bc a
 3  d
 2 a   d
 b
 2.  da  a
-3# ax  b  ax  d
+3# a
+x  b  a
+x  d
 b
-2#  ax      //ax    c
+2#  a
+x      //a
+x    c
 b
 1 aab
-3# ax b
+3# a
+x b
 b
-2# da   //ax  bx b  a
-b2 a   d
+2# da   //a
+x  b
+x b  a
+b
+2 a   d
 2.  da  a
-4#   fx  d
+4#   f
+x  d
 b
-2#   fx     dxd
+2#   f
+x     d
+xd
 b
 
-b2#cdd   ax axa     /a
-b2 ea   //a
-3#ax d
-2 b -- ///a
-b2 aa   //a
-3#      /ax  dx  bx  d
 b
-2#  fx      //ax    c
+2#cdd   a
+x a
+xa     /a
+b
+2 ea   //a
+3#a
+x d
+2 b -- ///a
+b
+2 aa   //a
+3#      /a
+x  d
+x  b
+x  d
+b
+2#  f
+x      //a
+x    c
 b
 1 aab
 bbX
-3# ax b
+3# a
+x b
 b
-2# da cx      //a
-3#  ax  b
+2# da c
+x      //a
+3#  a
+x  b
 b
-2#  d   ax   a
-3#  bx  a
+2#  d   a
+x   a
+3#  b
+x  a
 b
 
 b
-2#   cQdx     ax  a
-b2#   QbQcx      //a
-3#  bx  a
+2#   cQd
+x     a
+x  a
 b
-2#   cdx      /a
-3#  dx  b
+2#   QbQc
+x      //a
+3#  b
+x  a
 b
-2#  aax      a
-3# dx b
+2#   cd
+x      /a
+3#  d
+x  b
+b
+2#  aa
+x      a
+3# d
+x b
 b
 2. aba d
-3# ax  d ax a
-b3#  b  ax  d
-2.  a   //a
-4#   cx  a
+3# a
+x  d a
+x a
 b
-2#   cx     ax   c
+3#  b  a
+x  d
+2.  a   //a
+4#   c
+x  a
+b
+2#   c
+x     a
+x   c
 b
 Yaac
 b
 B
 
 { }
-{38. Courante par gautie - 7F8Ef/Moy 1631 f. 17r}BX
+{38. Courante par gautie - 7F8Ef/Moy 1631 f. 17r}
+BX
 bX
 S3
 2 b
-b2# bdd bx    dx   d
-b2#bbdxdb cx b
-b2#f  dx   axi  h
-b2# i  hx  g
-3#ixg
 b
-2#f  dx  gx g
-b2#db cx  exbdda
-b2#a - dx      /axa
+2# bdd b
+x    d
+x   d
 b
-3# b  ax  Qex  dx  bx   dx   c
+2#bbd
+xdb c
+x b
+b
+2#f  d
+x   a
+xi  h
+b
+2# i  h
+x  g
+3#i
+xg
+b
+2#f  d
+x  g
+x g
+b
+2#db c
+x  e
+xbdda
+b
+2#a - d
+x      /a
+xa
+b
+3# b  a
+x  Qe
+x  d
+x  b
+x   d
+x   c
 b
 
-b3#   ax    dx    bx    ax     dx     b
+b
+3#   a
+x    d
+x    b
+x    a
+x     d
+x     b
 b
 2      /a
 2. bb d
 3   c
 b
-2#   dx     bx    d
+2#   d
+x     b
+x    d
 b
 1bbd  b
 bbX
 2  d
-b2#  d  bx   cdx b
-b2#  d   ax  bc ax d
-b2# bbc  /ax    dx    b
-b2# bd ax d  bx     d
-b2d
+b
+2#  d  b
+x   cd
+x b
+b
+2#  d   a
+x  bc a
+x d
+b
+2# bbc  /a
+x    d
+x    b
+b
+2# bd a
+x d  b
+x     d
+b
+2d
 2.a  -  /a
-4# dxa
+4# d
+xa
 b
 
 b
 2 b
-3#  Qex  dx  bx   d
+3#  Qe
+x  d
+x  b
+x   d
 b
-2#   cx bx  dd
-b2  e
-3#   ax    d
+2#   c
+x b
+x  dd
+b
+2  e
+3#   a
+x    d
 2 d  b
-b2#    ax b cx   d
-b2#     dx  eax   c
-b2#    ax  d dx    b
-b2      /a
+b
+2#    a
+x b c
+x   d
+b
+2#     d
+x  ea
+x   c
+b
+2#    a
+x  d d
+x    b
+b
+2      /a
 2.  b d
 3   c
 b
-2#   dx     bx    d
+2#   d
+x     b
+x    d
 b
 Y-bbd
 b
 B
 
-{39a. Larmes - 7F8Ef9D/D-B N479, f. 71v-72r}BX
+{39a. Larmes - 7F8Ef9D/D-B N479, f. 71v-72r}
+BX
 bX
 S3
 2a
@@ -14376,59 +26195,136 @@ b
 b
 2      /a
 2.  d d
-4#   fx  d
+4#   f
+x  d
 b
-2#  fx      //ax    c
+2#  f
+x      //a
+x    c
 b
 1 aab
 2    a
-b2# a   dx    cxa
-b2#c    cx fxce
-b2# fx     ax   c
+b
+2# a   d
+x    c
+xa
+b
+2#c    c
+x f
+xce
+b
+2# f
+x     a
+x   c
 b
 1aab
-3# d:x b
+3# d:
+x b
 b
-2# a   dx  bxd
-b2    a
+2# a   d
+x  b
+xd
+b
+2    a
 2.c:  c
-4#  cx  e
+4#  c
+x  e
 b
 
 b
 2  f
-3#      //ax cx ex a
-b3#axcxdx  dxcx a
-b2#ax     ax    c{
+3#      //a
+x c
+x e
+x a
+b
+3#a
+xc
+xd
+x  d
+xc
+x a
+b
+2#a
+x     a
+x    c{
 b
 1aabc}
 bbX
-3#   cx  a
+3#   c
+x  a
 b
-2#  bx     d
-3# d:x b
+2#  b
+x     d
+3# d:
+x b
 b
-2# ax  bxa
-b2 d
-3#      //ax b
+2# a
+x  b
+xa
+b
+2 d
+3#      //a
+x b
 2 a
 b
-3# b  ax ax bx dx a   dx b
-b3#  d   ax   ax   cx  ax  bx  d
+3# b  a
+x a
+x b
+x d
+x a   d
+x b
+b
+3#  d   a
+x   a
+x   c
+x  a
+x  b
+x  d
 b
 
-b3# a   dx  b2.  d   a
-4# ax  d
 b
-2#  bx     dxd
-b2#abx  dxc
-b2# e    //ax a:x  d
-b2# abx  a:x   c
-b2#      //ax ax c
-b2# ex  dxa b
-b2#c     //ax ax  d
-b2# abxax ea
-b2#ax     a{x    c
+3# a   d
+x  b
+2.  d   a
+4# a
+x  d
+b
+2#  b
+x     d
+xd
+b
+2#ab
+x  d
+xc
+b
+2# e    //a
+x a:
+x  d
+b
+2# ab
+x  a:
+x   c
+b
+2#      //a
+x a
+x c
+b
+2# e
+x  d
+xa b
+b
+2#c     //a
+x a
+x  d
+b
+2# ab
+xa
+x ea
+b
+2#a
+x     a{
+x    c
 b
 Yaabc}
 b
@@ -14443,64 +26339,130 @@ S3
 b
 1ccd  c
 2     a
-b2      a
-2. a a
-4#  dx a
 b
-2# cx      /ax    e
+2      a
+2. a a
+4#  d
+x a
+b
+2# c
+x      /a
+x    e
 b
 1 ccd
 2    c
-b2# c  ax  axc    c
-b2#ex     ex   d
-b2#cx     cx    e
+b
+2# c  a
+x  a
+xc    c
+b
+2#e
+x     e
+x   d
+b
+2#c
+x     c
+x    e
 b
 2.ccde
 3a
 2 d
-b2# c  ax  dxf
-b2cdf c
+b
+2# c  a
+x  d
+xf
+b
+2cdf c
 2.eeg  e
-4#  ex  g
+4#  e
+x  g
 b
 
 b
 2  h   /a
-3#axcxax d
+3#a
+xc
+xa
+x d
 b
-2# c  axfxec
-b2#cx     cx    e
+2# c  a
+xf
+xec
+b
+2#c
+x     c
+x    e
 b
 1ccde
 bbX
-3#  ax  c
+3#  a
+x  c
 b
-2#  d   ///ax   c
-3#ax d
+2#  d   ///a
+x   c
+3#a
+x d
 b
-2# c   cx  dxc
-b2.acd   ///a
+2# c   c
+x  d
+xc
+b
+2.acd   ///a
 3 d
 2 c
-b2# da   //ax  cx cd   ///a
-b2. ac  a
+b
+2# da   //a
+x  c
+x cd   ///a
+b
+2. ac  a
 3 c
-3#  d   /ax a
+3#  d   /a
+x a
 b
 
-b3# c    ax  d
-2. a   a
-4#  dx a
 b
-2#  dx      ///axf
-b2#c     ax axe
-b2#b     /ax cx a
-b2# cdx  cx   e
-b2#      /ax cx e
-b2#bcx axc d
-b2#b     /ax cx a
-b2# cQdxcxb c
-b2#cx     cx    e
+3# c    a
+x  d
+2. a   a
+4#  d
+x a
+b
+2#  d
+x      ///a
+xf
+b
+2#c     a
+x a
+xe
+b
+2#b     /a
+x c
+x a
+b
+2# cd
+x  c
+x   e
+b
+2#      /a
+x c
+x e
+b
+2#bc
+x a
+xc d
+b
+2#b     /a
+x c
+x a
+b
+2# cQd
+xc
+xb c
+b
+2#c
+x     c
+x    e
 b
 Yccee
 b
@@ -14514,22 +26476,33 @@ S3
 b
 1cce  c
 2     a
-b2#      a
+b
+2#      a
 x c
 3 a-a
-4#  ex a
+4#  e
+x a
 b
-2# cx    e
-x      /ab
+2# c
+x    e
+x      /a
+b
 1. ccde
-b3#  a
+b
+3#  a
 x  c
 x  d
 x a
 x c
 x e
-b2#a -x    cx    e
-b2# c  ax  dxc
+b
+2#a -
+x    c
+x    e
+b
+2# c  a
+x  d
+xc
 b
 2#Qe
 x     Qe
@@ -14544,9 +26517,13 @@ x     c
 xcce
 b
 
-b2.a - e
-3#cx dxa
-b2# c  a
+b
+2.a - e
+3#c
+x d
+xa
+b
+2# c  a
 x  d
 xf
 b
@@ -14554,7 +26531,9 @@ b
 2.eeg  e
 4#  e
 x  g
-b1  h2      /a
+b
+1  h
+2      /a
 b
 1  h -
 4#e
@@ -14562,20 +26541,29 @@ xc
 xa
 x d
 b
-2# cdxf
+2# cd
+xf
 xec
 b
-2#cx     cx   e
-b2cce
+2#c
+x     c
+x   e
+b
+2cce
 bQ
 bQ
 2#  a
 x  c
-bX2#  d   ///ax   c3#a
+bX
+2#  d   ///a
+x   c
+3#a
 x d
 b
 
-b2. ca  c3  d
+b
+2. ca  c
+3  d
 2cdda
 b
 2.acd   /a
@@ -14584,24 +26572,56 @@ b
 b
 1 dda  a
 2 c    ///a
-b2. a - a
-3# cx  dx a
-b3# cx  d2. a - a
+b
+2. a - a
+3# c
+x  d
+x a
+b
+3# c
+x  d
+2. a - a
 4#  d
 x a
-b2#  dx      ///axf
-b2#c     //ax axe
-b2#b  -  /ax cx a -
+b
+2#  d
+x      ///a
+xf
+b
+2#c     //a
+x a
+xe
+b
+2#b  -  /a
+x c
+x a -
 b
 
 -l "5 in"
-b2# cdx  cx   e
-b2#   d  /ax cx e
-b2#bcx axc a
 b
-2#Qb     /ax cx a -
-b2# cdxcxb c
-b2#cx     cx   e
+2# cd
+x  c
+x   e
+b
+2#   d  /a
+x c
+x e
+b
+2#bc
+x a
+xc a
+b
+2#Qb     /a
+x c
+x a -
+b
+2# cd
+xc
+xb c
+b
+2#c
+x     c
+x   e
 b
 Ycce
 b
@@ -14776,36 +26796,63 @@ b
 B
 
 p
-{40a. Courante Gothier - 7F8Ef9Df10Bf/CZ-Pnm G.IV.18, ff. 163v-164r}BX
+{40a. Courante Gothier - 7F8Ef9Df10Bf/CZ-Pnm G.IV.18, ff. 163v-164r}
+BX
 bX
 S3
 2 d
 b
 2. dff
-3   d3#   cx   a
+3   d
+3#   c
+x   a
 b
 2a b d
-3#    cxd
+3#    c
+xd
 2cb  a
-b2#ddf  dx    fx   f
+b
+2#ddf  d
+x    f
+x   f
 b
 2.ddf
-3#fx ix h
+3#f
+x i
+x h
 b
-2# fg axfx hi
-b2# f   fx  h
-3#fx i
+2# fg a
+xf
+x hi
+b
+2# f   f
+x  h
+3#f
+x i
 b
 2 h    a
-3#   ax i2Qf
+3#   a
+x i
+2Qf
 b
-3#      //axh
-2# ix  i
-b2#      /axa gx  f
+3#      //a
+xh
+2# i
+x  i
+b
+2#      /a
+xa g
+x  f
 b
 
-b2#      ax  ffx  de
-b2#  bx     dx   a
+b
+2#      a
+x  ff
+x  de
+b
+2#  b
+x     d
+x   a
 b
 1 ab
 bXQ
@@ -14813,172 +26860,452 @@ bXQ
 2 d
 b
 2. dff
-3#   dx   cx   a
-b3#    dx bxax    cxc   ax b
-b2Qd3#     dx dx fx  g
-b3#  fx  dx  fxfx ix h
-b3#    ax fx  gxfx hx  i
+3#   d
+x   c
+x   a
+b
+3#    d
+x b
+xa
+x    c
+xc   a
+x b
+b
+2Qd
+3#     d
+x d
+x f
+x  g
+b
+3#  f
+x  d
+x  f
+xf
+x i
+x h
+b
+3#    a
+x f
+x  g
+xf
+x h
+x  i
 b
 
-b3#     fx fx  hxhxfx i
-b3#      ax hx  ix ixfx h
-b3#      //axhx ix hx fx  i
-b3#      /ax  gxax  fx  gx  f
-b3#      ax   fx   ex  dx  fx  d
 b
-2#   fx      ///ax     d
+3#     f
+x f
+x  h
+xh
+xf
+x i
+b
+3#      a
+x h
+x  i
+x i
+xf
+x h
+b
+3#      //a
+xh
+x i
+x h
+x f
+x  i
+b
+3#      /a
+x  g
+xa
+x  f
+x  g
+x  f
+b
+3#      a
+x   f
+x   e
+x  d
+x  f
+x  d
+b
+2#   f
+x      ///a
+x     d
 b
 1 a a
 bXQ
 bXQ
 2  b
-b2#  b  dx   ax  b
+b
+2#  b  d
+x   a
+x  b
 b
 
 b
-3#      //ax  f
+3#      //a
+x  f
 2   f
-3#    d /ax    c
+3#    d /a
+x    c
 b
-2#   aa ax    cx  b
-b2#  d dx ax  b c
-b2# dx    Qax     d
-b2#     cx bdx ab  d
-b2#  d   ax d ex f f
-b2# hdx dfxd
+2#   aa a
+x    c
+x  b
+b
+2#  d d
+x a
+x  b c
+b
+2# d
+x    Qa
+x     d
+b
+2#     c
+x bd
+x ab  d
+b
+2#  d   a
+x d e
+x f f
+b
+2# hd
+x df
+xd
 b
 2.    h
-3#  gx   fx a
+3#  g
+x   f
+x a
 b
 
 b
 2.   h
-3# ax      ax   f
+3# a
+x      a
+x   f
 b
 1  i
 2 a
 b
 1 aff
-3#  dx      a
-b2#     ax b cx     c
-b2 a   d
-2.  d   a
-4#   fx  d
+3#  d
+x      a
 b
-2#   fx      ///ax     d
+2#     a
+x b c
+x     c
+b
+2 a   d
+2.  d   a
+4#   f
+x  d
+b
+2#   f
+x      ///a
+x     d
 b
 1  ba
 bXQ
 bXQ
 2  b
 b
-3#     dx   ax  bx    ax    cx d
+3#     d
+x   a
+x  b
+x    a
+x    c
+x d
 b
 
-b3#      //ax   Qfx    Qfx  dx   cdx    c
-b3#      ax    ax   ax    cx  bx   c
-b3#    dx  dx   ax ax  bx    c
-b3# dx  ax  Qbx    cx    ax     d
-b3#     cx bx  dx dx     dx a
-b3#      ax  dx   ex dx   fx f
-b3#  dxcx  fx dxdxf
+b
+3#      //a
+x   Qf
+x    Qf
+x  d
+x   cd
+x    c
+b
+3#      a
+x    a
+x   a
+x    c
+x  b
+x   c
+b
+3#    d
+x  d
+x   a
+x a
+x  b
+x    c
+b
+3# d
+x  a
+x  Qb
+x    c
+x    a
+x     d
+b
+3#     c
+x b
+x  d
+x d
+x     d
+x a
+b
+3#      a
+x  d
+x   e
+x d
+x   f
+x f
+b
+3#  d
+xc
+x  f
+x d
+xd
+xf
 b
 
-b3#    hx  ix  fx   fx ix f
-b3#   hx  gx  fx fx      ax   f
-b3#  ix hx    hx  Qgx ax d
-b3#    fx  fx  dx   ex   cdx a
-b3#     ax bx  bx   cx  dx     c
-b3#     dx ax   cx  dx      ax a
 b
-2#  bx      ///ax     d
+3#    h
+x  i
+x  f
+x   f
+x i
+x f
+b
+3#   h
+x  g
+x  f
+x f
+x      a
+x   f
+b
+3#  i
+x h
+x    h
+x  Qg
+x a
+x d
+b
+3#    f
+x  f
+x  d
+x   e
+x   cd
+x a
+b
+3#     a
+x b
+x  b
+x   c
+x  d
+x     c
+b
+3#     d
+x a
+x   c
+x  d
+x      a
+x a
+b
+2#  b
+x      ///a
+x     d
 b
 Y aba
 b
 B
-{40b. Courante - 7F8Ef9Df10Bf/CH-Bu F.IX.53, ff. 5r-6r}
+
+{40b. Courante - 7F8Ef9Df10Bf/CH-Bu F.IX.53, ff. 5r-6r}
 BX
 bX
 S3
 2 d
 b
 2. dfffd
-3#   e.x   c&,x   a.
+3#   e.
+x   c&,
+x   a.
 b
 2a   d
-3#    c&,xd.
+3#    c&,
+xd.
 2c&,   a
-b2#d    dx    fx   f
+b
+2#d    d
+x    f
+x   f
 b
 2.ddf
-3#fx ix h&,
+3#f
+x i
+x h&,
 b
-2# fg axf.x h-f
-b2# f&,   fx  h.
-3.f4 i.
+2# fg a
+xf.
+x h-f
+b
+2# f&,   f
+x  h.
+3.f
+4 i.
 b
 2 h&,    a
-3#   a:x i.2f
+3#   a:
+x i.
+2f
 b
-3#      //axh
-2# ix  i&+
-b2#      /axafgx  f&+.
+3#      //a
+xh
+2# i
+x  i&+
+b
+2#      /a
+xafg
+x  f&+.
 b
 
-b2#      ax a fx  de&,
-b2#  b:x     dx      ///a
+b
+2#      a
+x a f
+x  de&,
+b
+2#  b:
+x     d
+x      ///a
 b
 1 aba
 bbX
 2 d
 b
-3#      ///ax d&,.
+3#      ///a
+x d&,.
 x  f
 x   e.
 x   c&,:
 x   a.
-b2a   d
-3#    c&,xdxc&,   ax b.
-b2.d f  d3# .dx  f:xf.
-b3#d&+x  f
-x dxfx ix h
-b3#    ax f&,.x  hx   h.xfx h.
+b
+2a   d
+3#    c&,
+xd
+xc&,   a
+x b.
+b
+2.d f  d
+3# .d
+x  f:
+xf.
+b
+3#d&+
+x  f
+x d
+xf
+x i
+x h
+b
+3#    a
+x f&,.
+x  h
+x   h.
+xf
+x h.
 b
 
-b3#     fx f.x  hxfx ixf
-b3#      ax h&,x   a:x i.xfx h
-b3#      //ax hx ixi.xfx  i.
-b3#      /ax fx  g:x dx  gx  f&,
-b3#      ax   fx    f:x  Qf.x  Qd&,x   Qe.
+b
+3#     f
+x f.
+x  h
+xf
+x i
+xf
+b
+3#      a
+x h&,
+x   a:
+x i.
+xf
+x h
+b
+3#      //a
+x h
+x i
+xi.
+xf
+x  i.
+b
+3#      /a
+x f
+x  g:
+x d
+x  g
+x  f&,
+b
+3#      a
+x   f
+x    f:
+x  Qf.
+x  Qd&,
+x   Qe.
 b
 2#   Qf
-x     dx      ///ab
+x     d
+x      ///a
+b
 1 aba
 bbX
 2  b.
-b1  bacd2      a
+b
+1  bacd
+2      a
 b
 
 b
-3#      //ax   f
+3#      //a
+x   f
 2    f
-3#   cd /ax    c
+3#   cd /a
+x    c
 b
-2#   aa ax    c:x  b
-b1  d d2 ab2#  b&, cx d3#    a&,
+2#   aa a
+x    c:
+x  b
+b
+1  d d
+2 a
+b
+2#  b&, c
+x d
+3#    a&,
 x     d
-b2#     cx bdx ab  d
-b2#  de  ax d dx f f
-b2.c da3#  f:
-x d.xd
+b
+2#     c
+x bd
+x ab  d
+b
+2#  de  a
+x d d
+x f f
+b
+2.c da
+3#  f:
+x d.
+xd
 b
 2.    h&+:
-3#  gx  f&,x f.
+3#  g
+x  f&,
+x f.
 b
 
 b
 2.   h&+:
-3# ax      ax   f
+3# a
+x      a
+x   f
 b
 2.  i&+
 3# fhh
@@ -14986,42 +27313,132 @@ x  a
 x a
 b
 2# aff
-x  d&,.x   e:
-b2#     ax bbcx     c
-b2# aba d
-x  d   a
-3. a&,4  d
+x  d&,.
+x   e:
 b
-2#  b&,x     d
-x      ///ab
+2#     a
+x bbc
+x     c
+b
+2# aba d
+x  d   a
+3. a&,
+4  d
+b
+2#  b&,
+x     d
+x      ///a
+b
 1 aba
 bbX
 2  b
 b
-3#     dx   a.x  bx    a:x    c:x d.
+3#     d
+x   a.
+x  b
+x    a:
+x    c:
+x d.
 b
 
-b3#      //ax   f.x    f.x  d.x   cd /ax    c.
-b3#      ax    a.x   ax    c:x  b.x   c:
-b3#    d:x  d.x   a:x a.x  bx    c
-b3# d.x  ax  b.x    c:x    a&,:x     d:
-b3#     c:x bx  dx d.x     dx a.
-b3#      ax  d
-x   ex dx   f:x f.
-b3#  d:xc.x  fx dxdxf
+b
+3#      //a
+x   f.
+x    f.
+x  d.
+x   cd /a
+x    c.
+b
+3#      a
+x    a.
+x   a
+x    c:
+x  b.
+x   c:
+b
+3#    d:
+x  d.
+x   a:
+x a.
+x  b
+x    c
+b
+3# d.
+x  a
+x  b.
+x    c:
+x    a&,:
+x     d:
+b
+3#     c:
+x b
+x  d
+x d.
+x     d
+x a.
+b
+3#      a
+x  d
+x   e
+x d
+x   f:
+x f.
+b
+3#  d:
+xc.
+x  f
+x d
+xd
+xf
 b
 
-b3#    hx  i.x  f:x   f:x i.x f
-b3#   h:x  g.x  f&,x f.x      ax   f
-b3#  ix h.x   h:x  gx ax d
-b3#   f:x  f.x  d&,x   e:x   cdx a.
-b3#     ax bx  b.x   c:x  d.x     c
-b3# a - dx   c.x      ax  d:
+b
+3#    h
+x  i.
+x  f:
+x   f:
+x i.
+x f
+b
+3#   h:
+x  g.
+x  f&,
+x f.
+x      a
+x   f
+b
+3#  i
+x h.
+x   h:
+x  g
+x a
+x d
+b
+3#   f:
+x  f.
+x  d&,
+x   e:
+x   cd
+x a.
+b
+3#     a
+x b
+x  b.
+x   c:
+x  d.
+x     c
+b
+3# a - d
+x   c.
+x      a
+x  d:
 x   a:
 x a.
 b
-2#  b&,x     d
-x      ///ab
+2#  b&,
+x     d
+x      ///a
+b
 Y aba
 b
 B
@@ -15469,74 +27886,150 @@ b
 B
 
 { }
-{41d. Untitled - 7F8E10Bf/A-SPL KK 35, p. 68}BX
+{41d. Untitled - 7F8E10Bf/A-SPL KK 35, p. 68}
+BX
 bX
 S3
 2 d
-b2# db cx    ax     d
-b2#  d&, - a
-x   e3#  fx  d
 b
-2#  b&,x     ax   c
-b2#aab
-xcdd - ax      8
-b2ddf
-3#      N10xf2Qh
+2# db c
+x    a
+x     d
+b
+2#  d&, - a
+x   e
+3#  f
+x  d
+b
+2#  b&,
+x     a
+x   c
+b
+2#aab
+xcdd - a
+x      8
+b
+2ddf
+3#      N10
+xf
+2Qh
 b
 2#d&,     Q8
-x f3#fxd
+x f
+3#f
+xd
 b
-2#cdx   ax      a
+2#cd
+x   a
+x      a
 b
 
 b
 1cdda
 2Qd&,f
-b2# dx  fx fg
-b2#fx  dxa b
-b2# dax  aax  bc
 b
-2# Qbx   Qex  ff
-b2#  dx   ax db c
+2# d
+x  f
+x fg
 b
-3# bb dx a2Q  d   a
-3# ax  d
+2#f
+x  d
+xa b
 b
-2#  ba dx      N10
+2# da
+x  aa
+x  bc
+b
+2# Qb
+x   Qe
+x  ff
+b
+2#  d
+x   a
+x db c
+b
+3# bb d
+x a
+2Q  d   a
+3# a
+x  d
+b
+2#  ba d
+x      N10
 x     Qd
 bQ
 
 bQ
 1Q QaQbQa
-bbX2 d
-b2#ddffx     dx    a
-b2# d  c
-x  b3#dxc
+bbX
+2 d
 b
-2#ax      8x    d
+2#ddff
+x     d
+x    a
+b
+2# d  c
+x  b
+3#d
+xc
+b
+2#a
+x      8
+x    d
 b
 2.a b
-3#    cx    ax     d
-b2#     cx  QdQax d
-b2     d
-2. c ca
-4#   ax   c
+3#    c
+x    a
+x     d
 b
-2#   ax      ax   a
+2#     c
+x  QdQa
+x d
+b
+2     d
+2. c ca
+4#   a
+x   c
+b
+2#   a
+x      a
+x   a
 b
 
 b
 1 dd
 2  bc
-b2#  dex      ax  ff
-b2# b&,x     ax      a
-b2#a     Q8x  d dx   a
-b2#  bcx     ax  d  c
-b2# aba dx  d  cx  b  a
 b
-2#      ax  fff3#  dex a
-b2#  bx   ax     d
-bY      N10
+2#  de
+x      a
+x  ff
+b
+2# b&,
+x     a
+x      a
+b
+2#a     Q8
+x  d d
+x   a
+b
+2#  bc
+x     a
+x  d  c
+b
+2# aba d
+x  d  c
+x  b  a
+b
+2#      a
+x  fff
+3#  de
+x a
+b
+2#  b
+x   a
+x     d
+b
+Y      N10
 b
 B
 
@@ -15545,135 +28038,347 @@ BX
 bX
 S3
 2 d
-b2# dba dx ax  b
-b2# dx    cx   a
-b2abb d
-3#      /axc
+b
+2# dba d
+x a
+x  b
+b
+2# d
+x    c
+x   a
+b
+2abb d
+3#      /a
+xc
 2dd  c
-b2#f   ax ixfh
-b2#hix      ///ax     d
+b
+2#f   a
+x i
+xfh
+b
+2#hi
+x      ///a
+x     d
 b
 1 ab
 2 d
-b2# dd  cx     axa b
-b2#cdd   ax   a
-3#dxc
 b
-2#aabc ax      ax      /a
+2# dd  c
+x     a
+xa b
+b
+2#cdd   a
+x   a
+3#d
+xc
+b
+2#aabc a
+x      a
+x      /a
 b
 
-b2# d    //ax    c
-3#  bx  a
 b
-2# bdcax dx a   d
-b2#  d   ax   e
-3# ax  d
+2# d    //a
+x    c
+3#  b
+x  a
 b
-2#  bx     dx      ///a
+2# bdca
+x d
+x a   d
+b
+2#  d   a
+x   e
+3# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1 ab
 bbX
 2 d
-b2#da   dx bxcd
-b2#aabcx     ax  d
-b2#ca bx    cx    a
+b
+2#da   d
+x b
+xcd
+b
+2#aabc
+x     a
+x  d
+b
+2#ca b
+x    c
+x    a
 b
 
-b2#     dx abx     c
-b2#     ax cx  b
-b2#      ax dbx  a
-b2#    axaddx c
-b2#      ax ddx    f
-b2# f  dx  dxf
-b2#      axcddx    c
-b2#      /axabbx  d
-b2#  ax      a
-3# ax  d
 b
-2#  bx     dx      ///a
+2#     d
+x ab
+x     c
+b
+2#     a
+x c
+x  b
+b
+2#      a
+x db
+x  a
+b
+2#    a
+xadd
+x c
+b
+2#      a
+x dd
+x    f
+b
+2# f  d
+x  d
+xf
+b
+2#      a
+xcdd
+x    c
+b
+2#      /a
+xabb
+x  d
+b
+2#  a
+x      a
+3# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 Y ab
 b
 B
 
-p{42b. La presedente avec le Redouble - 7F8Ef9D10C/CH-SO DA 111, ff. 7v-8r}
+p
+{42b. La presedente avec le Redouble - 7F8Ef9D10C/CH-SO DA 111, ff. 7v-8r}
 BX
 bX
 S3
 2 d
-b2# dba dx ax  b
-b2# dx    cx   a
-b2abb d
-3#      /axc
+b
+2# dba d
+x a
+x  b
+b
+2# d
+x    c
+x   a
+b
+2abb d
+3#      /a
+xc
 2dd  c
-b2#f   Qax ixfh
-b2#hix      ///a
+b
+2#f   Qa
+x i
+xfh
+b
+2#hi
+x      ///a
 x     d
 b
 1 ab
 2 d
-b2# dd  cx     axa b
-b2#cdd   a
-x   a
-3#dxc
 b
-2#aabc ax      ax      /a
+2# dd  c
+x     a
+xa b
+b
+2#cdd   a
+x   a
+3#d
+xc
+b
+2#aabc a
+x      a
+x      /a
 b
 
-b2# d    //ax    c
-3#  bx  a
+b
+2# d    //a
+x    c
+3#  b
+x  a
 b
 2. bdca
 3 d
 2 a   d
-b2#  d   ax   e
-3# ax  d
 b
-2#  bx     dx      ///a
-b2#     dx ab
+2#  d   a
+x   e
+3# a
+x  d
+b
+2#  b
+x     d
+x      ///a
+b
+2#     d
+x ab
 bXQ
-bXQ2 d
+bXQ
+2 d
 b
-3# dba dx bx ax  dx  bx   c
-b3# dx    cx  bx   dx   cx   a
-b3#a   dx  bx      /axcxdx    c
+3# dba d
+x b
+x a
+x  d
+x  b
+x   c
+b
+3# d
+x    c
+x  b
+x   d
+x   c
+x   a
+b
+3#a   d
+x  b
+x      /a
+xc
+xd
+x    c
 b
 
-b3#fx    ax  gx ixfx h
-b3#hx ix      ///ax  gx  fx   h
-b3# ax  bx     dx  dx ax c
-b3# dx     cx  dxax cx     Qa
-b3#cx      ax   axdxcxd
-b3#ax     ax  bx      axax      /a
-b3# dx      //ax    cx  bx  ax  b
+b
+3#f
+x    a
+x  g
+x i
+xf
+x h
+b
+3#h
+x i
+x      ///a
+x  g
+x  f
+x   h
+b
+3# a
+x  b
+x     d
+x  d
+x a
+x c
+b
+3# d
+x     c
+x  d
+xa
+x c
+x     Qa
+b
+3#c
+x      a
+x   a
+xd
+xc
+xd
+b
+3#a
+x     a
+x  b
+x      a
+xa
+x      /a
+b
+3# d
+x      //a
+x    c
+x  b
+x  a
+x  b
 b
 
-b3# bx    ax   cx dx ax     d
-b3#  dx      ax   ax  fx  dx   e
 b
-2# ax      ///ax     d
+3# b
+x    a
+x   c
+x d
+x a
+x     d
+b
+3#  d
+x      a
+x   a
+x  f
+x  d
+x   e
+b
+2# a
+x      ///a
+x     d
 b
 1 aba
 bXQ
 bXQ
 2 d
-b2#da   dx bxcd
-b2#aabcx     ax  d
-b2#ca bx    cx    a
-b2#     dx abx     c
+b
+2#da   d
+x b
+xcd
+b
+2#aabc
+x     a
+x  d
+b
+2#ca b
+x    c
+x    a
+b
+2#     d
+x ab
+x     c
 b
 
-b2#     ax cdx  b
 b
-2#      ax dbx  a
+2#     a
+x cd
+x  b
 b
-2#    axaddx c
-b2#      ax ddx    f
-b2# f  ex  dxf
-b2#      axcddx    c
-b2#      /axabbx  d
-b2#  ax      ax   a
-b2# ax     dx      ///a
+2#      a
+x db
+x  a
+b
+2#    a
+xadd
+x c
+b
+2#      a
+x dd
+x    f
+b
+2# f  e
+x  d
+xf
+b
+2#      a
+xcdd
+x    c
+b
+2#      /a
+xabb
+x  d
+b
+2#  a
+x      a
+x   a
+b
+2# a
+x     d
+x      ///a
 b
 
 b
@@ -15682,28 +28387,102 @@ bXQ
 bXQ
 2 d
 b
-3#d     ///ax bx ax bxcx d
-b3#ax  bx     ax  ax  bx  d
-b3#cx   Qbx ax  dx   cx  a
-b3#     dx   ax    cx    dx   ax     c
-b3#     ax dx cx ax  dx  b
-b3#  a   ax ax  bx  ax   cx   a
+3#d     ///a
+x b
+x a
+x b
+xc
+x d
+b
+3#a
+x  b
+x     a
+x  a
+x  b
+x  d
+b
+3#c
+x   Qb
+x a
+x  d
+x   c
+x  a
+b
+3#     d
+x   a
+x    c
+x    d
+x   a
+x     c
+b
+3#     a
+x d
+x c
+x a
+x  d
+x  b
+b
+3#  a   a
+x a
+x  b
+x  a
+x   c
+x   a
 b
 
-b3#    ax dx cx dxa dx c
-b3#      ax dx   ex   fx  dx    f
-b3# f  ex  dx   fx  dx   exf
-b3#      axdxcxax dx    c
-b3#      /axax  bx   cx  dx   a
-b3# dx bx ax     dx  dx      a
 b
-2# ax      ///ax     d
+3#    a
+x d
+x c
+x d
+xa d
+x c
+b
+3#      a
+x d
+x   e
+x   f
+x  d
+x    f
+b
+3# f  e
+x  d
+x   f
+x  d
+x   e
+xf
+b
+3#      a
+xd
+xc
+xa
+x d
+x    c
+b
+3#      /a
+xa
+x  b
+x   c
+x  d
+x   a
+b
+3# d
+x b
+x a
+x     d
+x  d
+x      a
+b
+2# a
+x      ///a
+x     d
 b
 Y ab
 b
 B
 
-{43a. Courante Gauthier - 7F8Ef9D10Bf/GB-Cfm 689, f. 46v i}BX
+{43a. Courante Gauthier - 7F8Ef9D10Bf/GB-Cfm 689, f. 46v i}
+BX
 bX
 S3
 2 a
@@ -15711,29 +28490,51 @@ b
 2. aba d
 3 b
 2 a
-b2#  ff  ax  dx   e
-b2#  ffx     dx d
-b2 db c
+b
+2#  ff  a
+x  d
+x   e
+b
+2#  ff
+x     d
+x d
+b
+2 db c
 2. bbcd
 3 a
 b
-2#  defx      axf
-b2# f  ex  d
-3#fxd
+2#  def
+x      a
+xf
+b
+2# f  e
+x  d
+3#f
+xd
 b
 2.c- a
 3    d
 2 db c
-b2#a b dx    cxcb- a
+b
+2#a b d
+x    c
+xcb- a
 b
 
-b2#ddf  dx d -- //ax  b
 b
-3# b -- /ax a
+2#ddf  d
+x d -- //a
+x  b
+b
+3# b -- /a
+x a
 2.  d - a
-4# ax  d
+4# a
+x  d
 b
-2#  bx      ///ax     d
+2#  b
+x      ///a
+x     d
 b
 1  bac
 bXQ
@@ -15741,22 +28542,74 @@ bXQ
 2 a
 b
 2. aba d
-3# bx dx a
-b3#      ax  fx  dx   fx  dx   e
-b3#   cx  bx  dx ax bx   c
-b3#   ax    dx d- cx  bx b- dx a
+3# b
+x d
+x a
+b
+3#      a
+x  f
+x  d
+x   f
+x  d
+x   e
+b
+3#   c
+x  b
+x  d
+x a
+x b
+x   c
+b
+3#   a
+x    d
+x d- c
+x  b
+x b- d
+x a
 b
 
-b3#      ax  dx  fx  gx dx f
-b3# hxd
+b
+3#      a
+x  d
+x  f
+x  g
+x d
+x f
+b
+3# h
+xd
 2.f
 3d
-b3#c- ax   cx   ax    dx d- cx  b
-b3#dxbxa - dx   ax   cx   e
-b3#   fx dxaxcxdxf
-b3#hx   f
-2#fx    f
-b2#dx     dx   f
+b
+3#c- a
+x   c
+x   a
+x    d
+x d- c
+x  b
+b
+3#d
+xb
+xa - d
+x   a
+x   c
+x   e
+b
+3#   f
+x d
+xa
+xc
+xd
+xf
+b
+3#h
+x   f
+2#f
+x    f
+b
+2#d
+x     d
+x   f
 b
 1ddf
 bXQ
@@ -15768,32 +28621,52 @@ b
 2. aba d
 3 c
 2 d
-b2#     cxadb- ax c
+b
+2#     c
+xadb- a
+x c
 b
 2.cdd - a
 3d
 2f
-b2#      /ax fg
-3#dxf
 b
-2#hx      //axl
+2#      /a
+x fg
+3#d
+xf
+b
+2#h
+x      //a
+xl
 b
 2#h
 x  i
 xf g
-b2#d f   ax  dx d e
-b2#  ffx fx c-c
+b
+2#d f   a
+x  d
+x d e
+b
+2#  ff
+x f
+x c-c
 b
 2.cdda
-3#    dx d- c
+3#    d
+x d- c
 x  b
 b
 
-b3# b- dx a
-2  d - a
-3# ax  d
 b
-2#  bx     dx   a
+3# b- d
+x a
+2  d - a
+3# a
+x  d
+b
+2#  b
+x     d
+x   a
 b
 1  b
 bXQ
@@ -15801,24 +28674,77 @@ bXQ
 2 a
 b
 2. aba d
-3# cx dx     c
-b3#a -- axcxdxaxfxd
+3# c
+x d
+x     c
 b
-3#      axcx dxdxfx d
-b3# bx ax  dx ax bx d
-b3#axcxdxfxhxl
+3#a -- a
+xc
+xd
+xa
+xf
+xd
+b
+3#      a
+xc
+x d
+xd
+xf
+x d
+b
+3# b
+x a
+x  d
+x a
+x b
+x d
+b
+3#a
+xc
+xd
+xf
+xh
+xl
 b
 
-b3#   axixhx  ixfx  g
-b3#      axd fx  dx   fx   ex   f
-b3#  dx   ex   fx  fx   ex   c
 b
-3#   axcx dx    dx d- cx  b
-b3# b- dx a
+3#   a
+xi
+xh
+x  i
+xf
+x  g
+b
+3#      a
+xd f
+x  d
+x   f
+x   e
+x   f
+b
+3#  d
+x   e
+x   f
+x  f
+x   e
+x   c
+b
+3#   a
+xc
+x d
+x    d
+x d- c
+x  b
+b
+3# b- d
+x a
 2  d - a
-3# ax  d
+3# a
+x  d
 b
-2#  bx      ///ax     d
+2#  b
+x      ///a
+x     d
 b
 Y  bac
 b
@@ -15834,31 +28760,53 @@ b
 2. aba d
 3 b
 2 a
-b2#  ff  Qax  dx   e
-b2#  ffx     dx d
-b2 db c
+b
+2#  ff  Qa
+x  d
+x   e
+b
+2#  ff
+x     d
+x d
+b
+2 db c
 2. bbcd
 3 a
 b
-2#  defx      axf
-b2# f  ex  d
-3#fxd
+2#  def
+x      a
+xf
+b
+2# f  e
+x  d
+3#f
+xd
 b
 2.c  a
 3#    d
 x d  c
 x  b
-b2#a   dx    cxc   a
+b
+2#a   d
+x    c
+xc   a
 b
 
-b2#da   dx d    //ax  b
 b
-3# b    /ax a
+2#da   d
+x d    //a
+x  b
+b
+3# b    /a
+x a
 x  d   a
 x   a
-x ax  d
+x a
+x  d
 b
-2#  bx      ///ax     d
+2#  b
+x      ///a
+x     d
 b
 1  bac
 bXQ
@@ -15866,24 +28814,73 @@ bXQ
 2 a
 b
 2. aba d
-3# bx dx a
-b3#      ax ax  dx  bx  dx  a
-b3#   cx  bx  dx ax bx   c
-b3#   ax    dx    cx dx b  dx a
+3# b
+x d
+x a
+b
+3#      a
+x a
+x  d
+x  b
+x  d
+x  a
+b
+3#   c
+x  b
+x  d
+x a
+x b
+x   c
+b
+3#   a
+x    d
+x    c
+x d
+x b  d
+x a
 b
 
-b3#      ax  d
-x ax cx dxa
-b3#cxd
+b
+3#      a
+x  d
+x a
+x c
+x d
+xa
+b
+3#c
+xd
 2.f
 3d
-b3#c  ax   cx   ax    d2 d  c
-b3#dxbxa   dx   ax   cx  a
-b3#  bx dxaxcxdxf
-b3#hx   f
-2#fx    f
-b2#d
-x      ///ax     d
+b
+3#c  a
+x   c
+x   a
+x    d
+2 d  c
+b
+3#d
+xb
+xa   d
+x   a
+x   c
+x  a
+b
+3#  b
+x d
+xa
+xc
+xd
+xf
+b
+3#h
+x   f
+2#f
+x    f
+b
+2#d
+x      ///a
+x     d
 b
 1ddff
 bXQ
@@ -15895,35 +28892,54 @@ b
 2. aba d
 3 c
 2 d
-b2# d   cxadb  ax c
+b
+2# d   c
+xadb  a
+x c
 b
 2cdd   Qa
 3#   a
 xd
 2f
-b2# fg   /a
-xdxf
 b
-2#hx      //axl
+2# fg   /a
+xd
+xf
+b
+2#h
+x      //a
+xl
 b
 2#h
 x  i
 xf g
-b2#d f   ax  dx d e
-b2# a fx fx c c
+b
+2#d f   a
+x  d
+x d e
+b
+2# a f
+x f
+x c c
 b
 2. daa
-3#    dx d  c
+3#    d
+x d  c
 x  b
 b
 
-b3# b  dx a
+b
+3# b  d
+x a
 x  d
 x   a
-x ax  d
+x a
+x  d
 b
-2#  bx      ///a
-x     db
+2#  b
+x      ///a
+x     d
+b
 1  bac
 bXQ
 bXQ
@@ -15931,26 +28947,76 @@ bXQ
 b
 2 ab  d
 3#   Qa
-x cx dx     c
-b3#a    axcxdxaxfxd
+x c
+x d
+x     c
+b
+3#a    a
+xc
+xd
+xa
+xf
+xd
 b
 2c
-3#      axdxfx d
-b3# bx ax  dx ax bx d
-b3#axcxdxf2h 
+3#      a
+xd
+xf
+x d
+b
+3# b
+x a
+x  d
+x a
+x b
+x d
+b
+3#a
+xc
+xd
+xf
+2h 
 b
 
-b3#l  axixhx  ixfx  g
-b3#  fxdx  dx   fx   ex   f
-b3#  dx   ex   fx  fx   ex   c
 b
-x   a3#cx dx    dx    cx  b
-b3# b  dx a
+3#l  a
+xi
+xh
+x  i
+xf
+x  g
+b
+3#  f
+xd
+x  d
+x   f
+x   e
+x   f
+b
+3#  d
+x   e
+x   f
+x  f
+x   e
+x   c
+b
+x   a
+3#c
+x d
+x    d
+x    c
+x  b
+b
+3# b  d
+x a
 x  d
 x      Qa
-x ax  d
+x a
+x  d
 b
-2#  bx      ///ax     Qd
+2#  b
+x      ///a
+x     Qd
 b
 Y  QbQaQc
 b
@@ -15966,53 +29032,126 @@ b
 2. aba d
 3 b
 2 a
-b2#  ffx  dx   e
-b2#  ffx     dx d
-b2 db c
+b
+2#  ff
+x  d
+x   e
+b
+2#  ff
+x     d
+x d
+b
+2 db c
 2. bb d
 3 a
 b
-2#  defx      axf
-b2# f  ex  d
-3#fxd
+2#  def
+x      a
+xf
+b
+2# f  e
+x  d
+3#f
+xd
 b
 2#c  a
 x    d
 3# d  c
 x  b
-b2#a   dx    cxc   Qa
+b
+2#a   d
+x    c
+xc   Qa
 b
 
-b2#d    dx d    //ax  b
 b
-3# b    /ax a
+2#d    d
+x d    //a
+x  b
+b
+3# b    /a
+x a
 2.  da  a
-4# ax  d
+4# a
+x  d
 b
-2#  bx     d
-x      ///ab
+2#  b
+x     d
+x      ///a
+b
 1 ab
 bbX
 2 a
 b
 2. aba d
-3# bx dx a
-b3#      ax  fx  dx   fx  dx   e
-b3#   cx  bx  dx ax bx   c
-b3#   ax    dx d  cx bx b  dx a
+3# b
+x d
+x a
+b
+3#      a
+x  f
+x  d
+x   f
+x  d
+x   e
+b
+3#   c
+x  b
+x  d
+x a
+x b
+x   c
+b
+3#   a
+x    d
+x d  c
+x b
+x b  d
+x a
 b
 
-b3#  d
-x      ax ax bx dxa
-b3#cxd
+b
+3#  d
+x      a
+x a
+x b
+x d
+xa
+b
+3#c
+xd
 2.f
 3d
-b3#c  ax   cx   ax    dx d  cx  b
-b3#dxcxa   dx   ax   cx   d
-b3#   fx dxaxcxdxf
-b3#hx   f
-2#fx    f
-b2#dx     dx   f
+b
+3#c  a
+x   c
+x   a
+x    d
+x d  c
+x  b
+b
+3#d
+xc
+xa   d
+x   a
+x   c
+x   d
+b
+3#   f
+x d
+xa
+xc
+xd
+xf
+b
+3#h
+x   f
+2#f
+x    f
+b
+2#d
+x     d
+x   f
 b
 1ddf
 bbX
@@ -16023,58 +29162,131 @@ b
 2. aba d
 3 b
 2 d
-b2# dQd  cxaQdQb  ax Qc
+b
+2# dQd  c
+xaQdQb  a
+x Qc
 b
 2cdd   a
 3#   a
 xd
 2f
-b2#      /ax fg
-3#dxf
 b
-2#hx      //ax e
+2#      /a
+x fg
+3#d
+xf
+b
+2#h
+x      //a
+x e
 b
 2#h
 x  i
 xf g
-b2#d fx  dx d e
-b2#  ffx fx c c
+b
+2#d f
+x  d
+x d e
+b
+2#  ff
+x f
+x c c
 b
 2. dda
-3#    dx d  c
+3#    d
+x d  c
 x  b
 b
 
-b3# b- dx a
-2Q  d - a
-3# ax  d
 b
-2#  bx     dx      ///a
+3# b- d
+x a
+2Q  d - a
+3# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1 ab
 bbX
 2 a
 b
 2. aba d
-3# bx dx     c
-b3#a    axcxdxaxfxd
+3# b
+x d
+x     c
 b
-3#      axcx dxdxfx d
-b3# bx ax  dx ax bx d
-b3#axcxdxfxhx e
+3#a    a
+xc
+xd
+xa
+xf
+xd
+b
+3#      a
+xc
+x d
+xd
+xf
+x d
+b
+3# b
+x a
+x  d
+x a
+x b
+x d
+b
+3#a
+xc
+xd
+xf
+xh
+x e
 b
 
-b3#   axixhx  Qix-Qfx  g
-b3#      axd fx  dx   fx   ex   f
-b3#  dx   ex   fx  fx   ex   c
 b
-3#   axcx dx    dx d  cx  b
-b3# b  dx a
+3#   a
+xi
+xh
+x  Qi
+x-Qf
+x  g
+b
+3#      a
+xd f
+x  d
+x   f
+x   e
+x   f
+b
+3#  d
+x   e
+x   f
+x  f
+x   e
+x   c
+b
+3#   a
+xc
+x d
+x    d
+x d  c
+x  b
+b
+3# b  d
+x a
 2  d   a
-3# ax  d
+3# a
+x  d
 b
-2#  bx     d
-x      ///ab
+2#  b
+x     d
+x      ///a
+b
 Y ab
 b
 B
@@ -16089,54 +29301,127 @@ b
 2. axba d&{
 3 b.
 2 #a: }
-b2#  ff  ax  #d:x   e.
-b2#  ffx     d{x d.  }
-b2 db c
+b
+2#  ff  a
+x  #d:
+x   e.
+b
+2#  ff
+x     d{
+x d.  }
+b
+2 db c
 2. #bbcd{
 3 a. }
 b
-2#  defx      axf.
-b2# f  e{x  d.}
-3#f:xd.
+2#  def
+x      a
+xf.
+b
+2# f  e{
+x  d.}
+3#f:
+xd.
 b
 2.#c  a
 3#    d
 x d  c{
 x  b.}
-b2#a   dx    ,cx-#c   a
+b
+2#a   d
+x    ,c
+x-#c   a
 b
 
-b2#d    dx d -- ///ax  b.
 b
-3# #b -- /ax a.
+2#d    d
+x d -- ///a
+x  b.
+b
+3# #b -- /a
+x a.
 2.  xd   a
-4# a:x  d.
+4# a:
+x  d.
 b
-2#  #b:x     d
-x   a.b
+2#  #b:
+x     d
+x   a.
+b
 2#  #b:
 x      ///a
 bbX
 2 a.
 b
 2. axba d&{
-3# b.x d:x a. }
-b3#      ax  f.x  ,d:x   f.x  d:x   e.
-b3#   c{x  b.x  d:x a.}x b&(:x   c.
-b3#  )ax    d.x d  c{x  b.}x #b  d{x a. }
+3# b.
+x d:
+x a. }
+b
+3#      a
+x  f.
+x  ,d:
+x   f.
+x  d:
+x   e.
+b
+3#   c{
+x  b.
+x  d:
+x a.}
+x b&(:
+x   c.
+b
+3#  )a
+x    d.
+x d  c{
+x  b.}
+x #b  d{
+x a. }
 b
 
-b3#      ax  d.
-x  fx  g.x dx f.
-b3# Qhxd.
+b
+3#      a
+x  d.
+x  f
+x  g.
+x d
+x f.
+b
+3# Qh
+xd.
 2.#f:
 3d.
-b3#c&(  ax   c.x  ) ,ax    d.x-(d  c{x-) b }
-b3#d:xc.xa   dx   a.x   cx   e.
-b3#   f&{x d.xa:xc.}xd:xf.
-b3#h:x   f
-2##f.x    f
-b2##d:x     dx   f
+b
+3#c&(  a
+x   c.
+x  ) ,a
+x    d.
+x-(d  c{
+x-) b }
+b
+3#d:
+xc.
+xa   d
+x   a.
+x   c
+x   e.
+b
+3#   f&{
+x d.
+xa:
+xc.}
+xd:
+xf.
+b
+3#h:
+x   f
+2##f.
+x    f
+b
+2##d:
+x     d
+x   f
 b
 1ddf   ///a
 bbX
@@ -16147,140 +29432,307 @@ b
 2. axba d&{
 3 b.
 2 d: }
-b2# dd  cxadb  ax ,c.
+b
+2# dd  c
+xadb  a
+x ,c.
 b
 2.#cdd   a
 3d.
 2f:
-b2#      /ax fg
-3#d:xf.
+b
+2#      /a
+x fg
+3#d:
+xf.
 b
 2#h:
 x      ///a
 xi.
 b
-2#,h:x  i.
+2#,h:
+x  i.
 xf g
 b
-2#d f   ax  ,d.x d e
-b2#  ff{x f.}x cbc
+2#d f   a
+x  ,d.
+x d e
+b
+2#  ff{
+x f.}
+x cbc
 b
 2.#cdda
-3#    dx d  c{
+3#    d
+x d  c{
 x  b }
 b
 
-b3# #b  dx a.
-2.  xd - a
-4# a:x  d.
 b
-2#  #b:x     dx      ///a
+3# #b  d
+x a.
+2.  xd - a
+4# a:
+x  d.
+b
+2#  #b:
+x     d
+x      ///a
 b
 1  ba
 bbX
 2 a.
 b
 2. axba d{
-3# b.x d:  }x     c
-b3#a -- axc.xd:xa.xf:xd.
+3# b.
+x d:  }
+x     c
 b
-3#      axc.x d:xd.xf:x d.
-b3# ,b:x a.x  dx a.x b:x d.
-b3#a:xc.xd:xf.xh:x-Qi.
+3#a -- a
+xc.
+xd:
+xa.
+xf:
+xd.
+b
+3#      a
+xc.
+x d:
+xd.
+xf:
+x d.
+b
+3# ,b:
+x a.
+x  d
+x a.
+x b:
+x d.
+b
+3#a:
+xc.
+xd:
+xf.
+xh:
+x-Qi.
 b
 
-b3#   Qaxh.x  ixf.2  ,Qg
-b3#      axd fx  ,dx   f.x   ex   f.
-b3#  d:x   e.x   fx  f.x   ex   c.
 b
-3#   axc.x d:x    dx d  c{x  b.}
-b3# #b  d{x a. }
+3#   Qa
+xh.
+x  i
+xf.
+2  ,Qg
+b
+3#      a
+xd f
+x  ,d
+x   f.
+x   e
+x   f.
+b
+3#  d:
+x   e.
+x   f
+x  f.
+x   e
+x   c.
+b
+3#   a
+xc.
+x d:
+x    d
+x d  c{
+x  b.}
+b
+3# #b  d{
+x a. }
 2.  xd   a
-4# a:x  d.
+4# a:
+x  d.
 b
-2#  #b:x     d
-x      ///ab
+2#  #b:
+x     d
+x      ///a
+b
 Y  ba
 b
 B
 
 p
-{44. Courante Gauthier sur J'avois brise mes fers - 7F8Ef9D10Bf/GB-Cfm 689, f. 50r ii}BX
+{44. Courante Gauthier sur J'avois brise mes fers - 7F8Ef9D10Bf/GB-Cfm 689, f. 50r ii}
+BX
 bX
 S3
 2 d
-b2# dffx   exdc c
-b2#cd ax bxda c
-b2#f - dx   cx   e
-b2#   f  ///axhx d e
-b2# i- hx fgxi- h
-b2# h- fxh-ixf-g
-b2#     dxddgx  f
-b2#      exfdx  g
+b
+2# dff
+x   e
+xdc c
+b
+2#cd a
+x b
+xda c
+b
+2#f - d
+x   c
+x   e
+b
+2#   f  ///a
+xh
+x d e
+b
+2# i- h
+x fg
+xi- h
+b
+2# h- f
+xh-i
+xf-g
+b
+2#     d
+xddg
+x  f
+b
+2#      e
+xfd
+x  g
 b
 
 b
 2.hd - d
-3#fxdx h
+3#f
+xd
+x h
 b
-2#a b dxc dxdd- c
-b2#f- fax d-exh -- d
-b2#      axfQhix  g
-b2#d -- dx    fx   f
+2#a b d
+xc d
+xdd- c
+b
+2#f- fa
+x d-e
+xh -- d
+b
+2#      a
+xfQhi
+x  g
+b
+2#d -- d
+x    f
+x   f
 b
 1ddf
 bbX
 2 a
-b2# affx  dx d e
-b2# adcx  bx b
-b2#   ax bax ab
+b
+2# aff
+x  d
+x d e
+b
+2# adc
+x  b
+x b
+b
+2#   a
+x ba
+x ab
 b
 
-b2#      ax  dffx  ge
-b2# d -- //axd-fxa- f
-b2#      /axf gxd f
 b
-3#      axcx   ax dx  dx b
+2#      a
+x  dff
+x  ge
 b
-2#dax     dxcb- a
-b2#    cxdd
-3#    ax     d
+2# d -- //a
+xd-f
+xa- f
 b
-2#    dxa bx  d
-b2 d fc
-3#   ex   c
+2#      /a
+xf g
+xd f
+b
+3#      a
+xc
+x   a
+x d
+x  d
+x b
+b
+2#da
+x     d
+xcb- a
+b
+2#    c
+xdd
+3#    a
+x     d
+b
+2#    d
+xa b
+x  d
+b
+2 d fc
+3#   e
+x   c
 2 b ea
 b
 
 -l "4 in"
-b2#     dx abax  d-d
-b2# ad - ax db cx bd- c
-b2# aba dx aff  ax  de
-b2#  bx     dx    c
+b
+2#     d
+x aba
+x  d-d
+b
+2# ad - a
+x db c
+x bd- c
+b
+2# aba d
+x aff  a
+x  de
+b
+2#  b
+x     d
+x    c
 b
 Y  ba
 b
 B
 
 p
-{45a. Courante par gautie - 7F8Ef10Bf/Moy 1631 f. 11v}BX
+{45a. Courante par gautie - 7F8Ef10Bf/Moy 1631 f. 11v}
+BX
 bX
 S3
 2 a
-b2# ab  dx      ///ax d a
 b
-3#  bcx  d
-2# ax  da  a
-b2#  ba dx      ///ax     d
+2# ab  d
+x      ///a
+x d a
+b
+3#  bc
+x  d
+2# a
+x  da  a
+b
+2#  ba d
+x      ///a
+x     d
 b
 1  ba
 2 a
-b2# ab  dx  bx d
+b
+2# ab  d
+x  b
+x d
 b
 2Q db c
-2@ bbcd3 a
+2@ bbcd
+3 a
 b
-2#  dx    fx      a
+2#  d
+x    f
+x      a
 b
 1  de
 2 b
@@ -16293,15 +29745,29 @@ b
 2Qa - d
 2@  bc
 3Q  d
-b2#  ffx     dxd
-b2#a  -  /ax  dxf
-b2#cdd   ax   a
-3#  b  dx  d
-b2# ax  b
-2.  da  a
-4# ax  d
 b
-2#  bx     dx      ///a
+2#  ff
+x     d
+xd
+b
+2#a  -  /a
+x  d
+xf
+b
+2#cdd   a
+x   a
+3#  b  d
+x  d
+b
+2# a
+x  b
+2.  da  a
+4# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1  ba
 bbX
@@ -16313,27 +29779,53 @@ b
 3d
 2f  a
 b
-3# a   dx cx dxa
+3# a   d
+x c
+x d
+xa
 2 cd a
 b
-2# dda  ax    cx    d
-b2   a
-2. a - d
-4#  dx a
+2# dda  a
+x    c
+x    d
 b
-2# bx      /ax    d
-b2#    acx      ax   a
-b2#    cdx      ///ax  b
-b2#   cx     ax  d
+2   a
+2. a - d
+4#  d
+x a
+b
+2# b
+x      /a
+x    d
+b
+2#    ac
+x      a
+x   a
+b
+2#    cd
+x      ///a
+x  b
+b
+2#   c
+x     a
+x  d
 b
 
-b2#  aax      a
-3#  b  dx  d
-b2# ax  b
-2.  da  a
-4# ax  d
 b
-2#  bx     dx      ///a
+2#  aa
+x      a
+3#  b  d
+x  d
+b
+2# a
+x  b
+2.  da  a
+4# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1  ba
 bbX
@@ -16343,22 +29835,63 @@ b
 3d
 2f
 b
-3# a   dx cx dxa
+3# a   d
+x c
+x d
+xa
 2 cd a
-b2# dd   ax    cx    d
-b2   a
+b
+2# dd   a
+x    c
+x    d
+b
+2   a
 2.    cd
-4#    ax    c
+4#    a
+x    c
 b
 
 b
 2    d
-3#      /ax   ax    dx    c
-b3#     cx    ax      ax    cx    dx   a
-b3#     Qdx    cx      ///ax  dx  bx  a
-b3#   c ax  ax  bx   cx  dx  b
-b3#  a   ax   ax   cx  ax  b  dx  d
-b3# ax  bx  d   ax bx ax  d
+3#      /a
+x   a
+x    d
+x    c
+b
+3#     c
+x    a
+x      a
+x    c
+x    d
+x   a
+b
+3#     Qd
+x    c
+x      ///a
+x  d
+x  b
+x  a
+b
+3#   c a
+x  a
+x  b
+x   c
+x  d
+x  b
+b
+3#  a   a
+x   a
+x   c
+x  a
+x  b  d
+x  d
+b
+3# a
+x  b
+x  d   a
+x b
+x a
+x  d
 b
 2#  Qb
 x     Qd
@@ -16369,26 +29902,39 @@ b
 B
 
 p
-{45b. Courante - Gauthier - 7F8Ef10Bf/GB-Eu Coll.2073, f. 274v-275r}BX
+{45b. Courante - Gauthier - 7F8Ef10Bf/GB-Eu Coll.2073, f. 274v-275r}
+BX
 bX
 S3
 2 a
-b2# a    ///ax  b
+b
+2# a    ///a
+x  b
 x d
 b
 2#  def
-x      a3# a
+x      a
+3# a
 x  d
-b2#  bx     d
-x      ///ab
+b
+2#  b
+x     d
+x      ///a
+b
 1  ba
 2 a
-b2# a    ///ax  bx d
+b
+2# a    ///a
+x  b
+x d
 b
 2 db c
-2. bbcd3 a
+2. bbcd
+3 a
 b
-2#  dx    fx      a
+2#  d
+x    f
+x      a
 b
 1  de
 2 b
@@ -16401,15 +29947,29 @@ b
 2a   d
 2.  bc
 3  d
-b2#  ffx     dxd
-b2#a     /ax  dxf
-b2#cdd   axd
-3#  b  dx  d
-b3# ax  b
-2.  da  a
-4# ax  d
 b
-2#  bx     dx      ///a
+2#  ff
+x     d
+xd
+b
+2#a     /a
+x  d
+xf
+b
+2#cdd   a
+xd
+3#  b  d
+x  d
+b
+3# a
+x  b
+2.  da  a
+4# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1  ba
 bbX
@@ -16421,28 +29981,54 @@ b
 3d
 2f
 b
-3# a   dx cx dxa
+3# a   d
+x c
+x d
+xa
 2 cd a
 b
-2# dd   ax    cx    d
-b2   a
-2. a   d
-4#  dx a
+2# dd   a
+x    c
+x    d
 b
-2# bx      /ax    d
-b2#    acx      ax   a
-b2#    cdx      ///ax  b
-b2#   cx     ax  d
+2   a
+2. a   d
+4#  d
+x a
+b
+2# b
+x      /a
+x    d
+b
+2#    ac
+x      a
+x   a
+b
+2#    cd
+x      ///a
+x  b
+b
+2#   c
+x     a
+x  d
 b
 
 -l "3 in"
-b2#  aax      a
-3#  b  dx  d
-b3# ax  b
-2.  d   a
-4# ax  d
 b
-2#  bx     dx      ///a
+2#  aa
+x      a
+3#  b  d
+x  d
+b
+3# a
+x  b
+2.  d   a
+4# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 Y  ba
 b
@@ -16454,21 +30040,34 @@ BX
 bX
 S3
 2 a
-b2# a   dx  bx d
+b
+2# a   d
+x  b
+x d
 b
 2#  def
-x      a3# a
+x      a
+3# a
 x  d
-b2#  bx     dx      ///a
+b
+2#  b
+x     d
+x      ///a
 b
 1 ab
 2 a
-b2# a   dx  bx d
+b
+2# a   d
+x  b
+x d
 b
 2 db c
-2. bb d3 a
+2. bb d
+3 a
 b
-2#  dx    fx      a
+2#  d
+x    f
+x      a
 b
 1  de
 2 b
@@ -16481,15 +30080,29 @@ b
 2ab  d
 2.  bc
 3  d
-b2#  ffx     dxd
-b2#a     /ax  dxf
-b2#cdd   axd
-3#  b  dx  d
-b3# ax  b
-2.  da  a
-4# ax  d
 b
-2#  bx     dx      ///a
+2#  ff
+x     d
+xd
+b
+2#a     /a
+x  d
+xf
+b
+2#cdd   a
+xd
+3#  b  d
+x  d
+b
+3# a
+x  b
+2.  da  a
+4# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1 ab
 bXQ
@@ -16498,15 +30111,54 @@ bXQ
 b
 
 b
-3# a   dx bx dx ax b  dx a
-b3#  dx  bx  a   ax  bx  dx  a
-b3#  b  dx  ax  bx  dx ax  d
-b3#  b  dx  ax  bx  dx ax b
-b3# d  cx ax b
-x dxax d
-b3# b  dx ax  d
-x  bx  ax  b
-b3#  d   ax ax  dx  ax  bx  d
+3# a   d
+x b
+x d
+x a
+x b  d
+x a
+b
+3#  d
+x  b
+x  a   a
+x  b
+x  d
+x  a
+b
+3#  b  d
+x  a
+x  b
+x  d
+x a
+x  d
+b
+3#  b  d
+x  a
+x  b
+x  d
+x a
+x b
+b
+3# d  c
+x a
+x b
+x d
+xa
+x d
+b
+3# b  d
+x a
+x  d
+x  b
+x  a
+x  b
+b
+3#  d   a
+x a
+x  d
+x  a
+x  b
+x  d
 b
 1  ba d
 2 b
@@ -16514,22 +30166,52 @@ b
 
 b
 2. bdca
-3#ax d  cxb
-b3#a   dx   ax   cx  ax  bx  d
+3#a
+x d  c
+xb
 b
-2# ab  dx      ///axd
+3#a   d
+x   a
+x   c
+x  a
+x  b
+x  d
 b
-3#a     /ax dxa
-xcxdxf
+2# ab  d
+x      ///a
+xd
+b
+3#a     /a
+x d
+xa
+xc
+xd
+xf
 b
 2cdd   a
-3# ax bx dx  b
-b3# b  dx ax  d   ax  bx  dx a
-b3#  b  dx  ax  bx  dx ax  d
+3# a
+x b
+x d
+x  b
+b
+3# b  d
+x a
+x  d   a
+x  b
+x  d
+x a
+b
+3#  b  d
+x  a
+x  b
+x  d
+x a
+x  d
 b
 
 b
-2#  bx      ///a
+2#  b
+x      ///a
 bXQ
 bXQ
 2c
@@ -16538,27 +30220,53 @@ b
 3d
 2f
 b
-3# a   dx cx dxa
+3# a   d
+x c
+x d
+xa
 2 cdca
 b
-2# dd   ax    cx    d
-b2   a
-2. a   d
-4#  dx a
+2# dd   a
+x    c
+x    d
 b
-2# bx      /ax    d
-b2#    acx      ax   a
-b2#    cdx      ///ax  b
-b2#   cx     ax  d
+2   a
+2. a   d
+4#  d
+x a
+b
+2# b
+x      /a
+x    d
+b
+2#    ac
+x      a
+x   a
+b
+2#    cd
+x      ///a
+x  b
+b
+2#   c
+x     a
+x  d
 b
 
-b2#  aax      a
-3#  b  dx  d
-b2# ax  b
-2.  d   a
-4# ax  d
 b
-2#  bx     dx      ///a
+2#  aa
+x      a
+3#  b  d
+x  d
+b
+2# a
+x  b
+2.  d   a
+4# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1  ba
 bXQ
@@ -16570,23 +30278,63 @@ b
 xf
 x  d
 b
-3# a   dx cx dxa
+3# a   d
+x c
+x d
+xa
 x cd a
 x  b
-b2# dd   ax    cx    d
-b2#   a
+b
+2# dd   a
+x    c
+x    d
+b
+2#   a
 2.    cd
-4#    ax    c
+4#    a
+x    c
 b
 
 b
 2    d
-3#      /ax   ax    dx    c
-b3#     cx    ax      ax    cx    dx   a
-b3#     dx    cx      ///ax  dx  bx  a
-b3#     ax  ax  bx   cx  dx  b
-b3#  a   ax   ax   cx  ax  bx  d
-b2 ab  d3#  d   ax bx ax  d
+3#      /a
+x   a
+x    d
+x    c
+b
+3#     c
+x    a
+x      a
+x    c
+x    d
+x   a
+b
+3#     d
+x    c
+x      ///a
+x  d
+x  b
+x  a
+b
+3#     a
+x  a
+x  b
+x   c
+x  d
+x  b
+b
+3#  a   a
+x   a
+x   c
+x  a
+x  b
+x  d
+b
+2 ab  d
+3#  d   a
+x b
+x a
+x  d
 b
 2#  b
 x     d
@@ -16596,26 +30344,39 @@ Y  ba
 b
 B
 
-{45d. Courante L'espine BEST - 7F8Ef10Bf/GB-Cfm Ms. Mus. 689, f. 50v}BX
+{45d. Courante L'espine BEST - 7F8Ef10Bf/GB-Cfm Ms. Mus. 689, f. 50v}
+BX
 bX
 S3
 2 a
-b2# aba dx  bx d a
+b
+2# aba d
+x  b
+x d a
 b
 3#  bc
 x  d
 2# a
 x  da- a
-b2#  bx     dx      ///a
+b
+2#  b
+x     d
+x      ///a
 b
 1  ba
 2 a
-b2. aba d3  b2 d
+b
+2. aba d
+3  b
+2 d
 b
 2 db c
-2. bbcd3 a
+2. bbcd
+3 a
 b
-2#  dx    fx      a
+2#  d
+x    f
+x      a
 b
 1  de
 2 b
@@ -16628,15 +30389,29 @@ b
 2ab- d
 2.  bc
 3  d
-b2#  ffx     dxd
-b2#a  -- /ax  dxf
-b2#cdd - axd
-3#  b- dx  d
-b3# ax  b
-2  da- a
-3# ax  d
 b
-2#  bx     dx      ///a
+2#  ff
+x     d
+xd
+b
+2#a  -- /a
+x  d
+xf
+b
+2#cdd - a
+xd
+3#  b- d
+x  d
+b
+3# a
+x  b
+2  da- a
+3# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1  ba
 bXQ
@@ -16645,15 +30420,50 @@ bXQ
 b
 
 b
-3# a - dx bx dx ax b- dx a
-b3#  dx  bx  a - ax  bx  dx  a
-b3#  b- dx  ax  bx  dx ax  d
-b3#  b - ///ax  ax  bx  dx ax b
-b3# d- cx ax b
-x dxax d
-b3# b- dx ax  d
-x  bx  ax  b
-b2#  dx    f
+3# a - d
+x b
+x d
+x a
+x b- d
+x a
+b
+3#  d
+x  b
+x  a - a
+x  b
+x  d
+x  a
+b
+3#  b- d
+x  a
+x  b
+x  d
+x a
+x  d
+b
+3#  b - ///a
+x  a
+x  b
+x  d
+x a
+x b
+b
+3# d- c
+x a
+x b
+x d
+xa
+x d
+b
+3# b- d
+x a
+x  d
+x  b
+x  a
+x  b
+b
+2#  d
+x    f
 x      a
 b
 1  de
@@ -16663,12 +30473,16 @@ b
 b
 2 bdca
 3# a
-x b2 d- c
-b2#a - dx  bc
+x b
+2 d- c
+b
+2#a - d
+x  bc
 x  d
 b
 2#  ff
-x     d3#d
+x     d
+3#d
 xb
 b
 2#ab- d
@@ -16677,17 +30491,24 @@ x      /a
 xd
 b
 2#cdd - a
-xd3#  b- d
+xd
+3#  b- d
 x  d
-b3# a
-x  b2  da- a3# a
+b
+3# a
+x  b
+2  da- a
+3# a
 x  d
-b2#  b
-x     dx      ///a
+b
+2#  b
+x     d
+x      ///a
 b
 
 b
-1  babXQ
+1  ba
+bXQ
 bXQ
 2c
 b
@@ -16695,27 +30516,53 @@ b
 3d
 2f
 b
-3# a - dx cx dxa
+3# a - d
+x c
+x d
+xa
 2 cdca
 b
-2# ddax    cx    d
-b2   a
-2. a   Qd
-4#  dx a
+2# dda
+x    c
+x    d
 b
-2# bx      /ax    d
-b2#    acx      ax   a
-b2#    cdx      ///ax  b
-b2#   cx     ax  d
+2   a
+2. a   Qd
+4#  d
+x a
+b
+2# b
+x      /a
+x    d
+b
+2#    ac
+x      a
+x   a
+b
+2#    cd
+x      ///a
+x  b
+b
+2#   c
+x     a
+x  d
 b
 
-b2#  aax      a
-3#  b- dx  d
-b3# ax  b
-2  da- a
-3# ax  d
 b
-2#  bx     dx      ///a
+2#  aa
+x      a
+3#  b- d
+x  d
+b
+3# a
+x  b
+2  da- a
+3# a
+x  d
+b
+2#  b
+x     d
+x      ///a
 b
 1  ba
 bXQ
@@ -16727,24 +30574,63 @@ b
 xf
 x d
 b
-3# a - dx cx dxa
+3# a - d
+x c
+x d
+xa
 x cd a
 x  b
-b2# ddax    cx    d
-b2   a
+b
+2# dda
+x    c
+x    d
+b
+2   a
 2.    cd
-4#    ax    c
+4#    a
+x    c
 b
 
 b
 2    d
-3#      /ax   ax    dx    c
-b2    ac3#      ax    cx    dx   Qa
-b3#     dx    cx      ///ax  dx  bx  a
-b3#     ax  ax  bx   cx  dx  b
-b3#  a - ax   ax   cx  ax  b- dx  d
-b3# a
-x  bx da - ax bx ax  d
+3#      /a
+x   a
+x    d
+x    c
+b
+2    ac
+3#      a
+x    c
+x    d
+x   Qa
+b
+3#     d
+x    c
+x      ///a
+x  d
+x  b
+x  a
+b
+3#     a
+x  a
+x  b
+x   c
+x  d
+x  b
+b
+3#  a - a
+x   a
+x   c
+x  a
+x  b- d
+x  d
+b
+3# a
+x  b
+x da - a
+x b
+x a
+x  d
 b
 2#  b
 x     d
@@ -16761,17 +30647,26 @@ BX
 bX
 S3
 2 a
-b2# aba dx  bx d a
+b
+2# aba d
+x  b
+x d a
 b
 3#  bc
 x  d
 2# a
 x  da- a
-b2#  bx     dx      ///a
+b
+2#  b
+x     d
+x      ///a
 b
 1  ba
 2 a
-b2# aba dx  bY d
+b
+2# aba d
+x  b
+Y d
 b
 B
 
@@ -16786,76 +30681,199 @@ b
 2. deffd
 3 e
 2 d
-b2# d - cx  da
-3# bx d
 b
-2#  e- dx    fx   f
+2# d - c
+x  da
+3# b
+x d
+b
+2#  e- d
+x    f
+x   f
 b
 1dde
 2b
 b
 1bdedb
 2      //a
-b2#      /ax edx  b
+b
+2#      /a
+x ed
+x  b
 b
 2. dd - a
-3a3#c- ax    d
+3a
+3#c- a
+x    d
 b
-2#dd- bxf- fax d e
+2#dd- b
+xf- fa
+x d e
 b
 
-b2#     dxgdx f
-b2#fh -- ax-Qgixfh
 b
-2#dx     dx   f
+2#     d
+xgd
+x f
+b
+2#fh -- a
+x-Qgi
+xfh
+b
+2#d
+x     d
+x   f
 b
 1ddf
 bbX
 2 d
 b
-3# deffdx    fx   fx ex dx     d
-b3#     cx dx  dx   ax bx d
-b3# d - dx  ex   fx  gx dex   d
-b3#   bx dx bxdx   ax    d
+3# deffd
+x    f
+x   f
+x e
+x d
+x     d
+b
+3#     c
+x d
+x  d
+x   a
+x b
+x d
+b
+3# d - d
+x  e
+x   f
+x  g
+x de
+x   d
+b
+3#   b
+x d
+x b
+xd
+x   a
+x    d
 b
 
-b3#    bx      //ax dx  exb
-4#dxb
 b
-3#      /ax ex  dx  bxbx e
-b3#      ax  dx dxaxcx    d
-b3#    bx dxdx    axf- fx   e
-b3#g -- dx  ex   fx  gx dx f
-b3#      axfx hx  ixgxf
+3#    b
+x      //a
+x d
+x  e
+xb
+4#d
+xb
 b
-2#dx     dx   f
+3#      /a
+x e
+x  d
+x  b
+xb
+x e
+b
+3#      a
+x  d
+x d
+xa
+xc
+x    d
+b
+3#    b
+x d
+xd
+x    a
+xf- f
+x   e
+b
+3#g -- d
+x  e
+x   f
+x  g
+x d
+x f
+b
+3#      a
+xf
+x h
+x  i
+xg
+xf
+b
+2#d
+x     d
+x   f
 b
 1ddf
 bbX
 2 d
 b
 
-b2#   fx dex f
-b2#   axc dx    d
-b2#    bxddx     d
-b2# dd- cx bx  ea-d
-b2#      ax  dax    d
-b2#  babx    ax     d
-b2#    dcx   ax    bd
-b2#   dax   a- //ax   b  /a
-b2#      ax  dx  e
+b
+2#   f
+x de
+x f
+b
+2#   a
+xc d
+x    d
+b
+2#    b
+xdd
+x     d
+b
+2# dd- c
+x b
+x  ea-d
+b
+2#      a
+x  da
+x    d
+b
+2#  bab
+x    a
+x     d
+b
+2#    dc
+x   a
+x    bd
+b
+2#   da
+x   a- //a
+x   b  /a
+b
+2#      a
+x  d
+x  e
 b
 
-b2# dx   fx  ge
-b2#      ax dx f
-b2# hdx   axd-e
-b2#      axf-gxdde
 b
-3#  gx  e
+2# d
+x   f
+x  ge
+b
+2#      a
+x d
+x f
+b
+2# hd
+x   a
+xd-e
+b
+2#      a
+xf-g
+xdde
+b
+3#  g
+x  e
 2.d d-  a
-4#   fx  d
+4#   f
+x  d
 b
-2#   fx     dx   f
+2#   f
+x     d
+x   f
 b
 1ddf
 bbX
@@ -16877,99 +30895,248 @@ x-Qa
 x-Qc
 x    Qd
 b
-3#    bx dx bxdxf - ax     d
-b3#     cx  dx dx bx  ex     d
-b3#      ax  dx   ax    dx    bx    a
-b3#    bx   ax  bx    bx    ax     d
-b3#     cx    ax   ax    dx     Qdx    b
-b3#   dax   bx   a- //ax  bx   b  /ax   d
+3#    b
+x d
+x b
+xd
+xf - a
+x     d
+b
+3#     c
+x  d
+x d
+x b
+x  e
+x     d
+b
+3#      a
+x  d
+x   a
+x    d
+x    b
+x    a
+b
+3#    b
+x   a
+x  b
+x    b
+x    a
+x     d
+b
+3#     c
+x    a
+x   a
+x    d
+x     Qd
+x    b
+b
+3#   da
+x   b
+x   a- //a
+x  b
+x   b  /a
+x   d
 b
 
-b3#   a  ax  dx   ex   ax  ex   f
-b3# d    axdxfx   exgx   f
-b3#      ax  dx  ex   fx dx f
-b3# h -- ax  ixgx ixlxi
-b3#gx      axfx  gxdx  e
-b3#  gx  e
-2.  d - a
-4#   fx  d
 b
-2#   fx     dx   f
+3#   a  a
+x  d
+x   e
+x   a
+x  e
+x   f
+b
+3# d    a
+xd
+xf
+x   e
+xg
+x   f
+b
+3#      a
+x  d
+x  e
+x   f
+x d
+x f
+b
+3# h -- a
+x  i
+xg
+x i
+xl
+xi
+b
+3#g
+x      a
+xf
+x  g
+xd
+x  e
+b
+3#  g
+x  e
+2.  d - a
+4#   f
+x  d
+b
+2#   f
+x     d
+x   f
 b
 2@ddf
 bbX
-3# ex dx  g
+3# e
+x d
+x  g
 b
 
 b
-2#  e- dx    fx   f
+2#  e- d
+x    f
+x   f
 b
 2. dd- c
-3# bx  e- dx b
+3# b
+x  e- d
+x b
 b
-2#  d - ax   ax    d
-b2# d- bxdxcbd-a
+2#  d - a
+x   a
+x    d
+b
+2# d- b
+xd
+xcbd-a
 b
 1.ddef-d
 b
-2#      /axdegxf
-b2# h -- ax  ixgi
-b2#fxl
-3#   axi
+2#      /a
+xdeg
+xf
+b
+2# h -- a
+x  i
+xgi
+b
+2#f
+xl
+3#   a
+xi
 b
 
 b
-2#gxfhxgi
-b2#  ixfhx  g
+2#g
+xfh
+xgi
 b
-2#      ax dxd-e
+2#  i
+xfh
+x  g
+b
+2#      a
+x d
+xd-e
 b
 3  d
-4#   fx  d
-3#   ex  gx dx   f
+4#   f
+x  d
+3#   e
+x  g
+x d
+x   f
 b
-2# ex  dx de
-b2# b - bx  ex  d-d
-b2#  ex    bx      //a
+2# e
+x  d
+x de
+b
+2# b - b
+x  e
+x  d-d
+b
+2#  e
+x    b
+x      //a
 b
 1  ed
 bbX
 2 Qd
 b
 
-b2# ded- //ax    b
-3#    ax  g
 b
-2#  e- dx    fx   f
-b2#      ax  dex  ef
-b2#      /ax bbbx  d
-b2# d -- //ax  exd
-b2#      /axdexf
-b2#c  -  ax d
+2# ded- //a
+x    b
+3#    a
+x  g
+b
+2#  e- d
+x    f
+x   f
+b
+2#      a
+x  de
+x  ef
+b
+2#      /a
+x bbb
+x  d
+b
+2# d -- //a
+x  e
+xd
+b
+2#      /a
+xde
+xf
+b
+2#c  -  a
+x d
 3 b
-4#  ex b
+4#  e
+x b
 b
-2#  ex   a
-3#  dx    d
+2#  e
+x   a
+3#  d
+x    d
 b
 
 b
-2#  b bx dx ba-a
-b2#     dx  dffx  d- c
-b2# d-ax     dx b-b
-b2#      /ax  bbdx   d
-b2#   e- ax  efx ed - /a
-b2  b
-2.  d - a
-4#   fx  d
+2#  b b
+x d
+x ba-a
 b
-2#   fx     dx   f
+2#     d
+x  dff
+x  d- c
+b
+2# d-a
+x     d
+x b-b
+b
+2#      /a
+x  bbd
+x   d
+b
+2#   e- a
+x  ef
+x ed - /a
+b
+2  b
+2.  d - a
+4#   f
+x  d
+b
+2#   f
+x     d
+x   f
 b
 Y de
 b
 B
 
-p{46b. A Dieu de Gothier - 7F8Ef9Df/RUS-SPan O No 124, ff. 74v-75v}
+p
+{46b. A Dieu de Gothier - 7F8Ef9Df/RUS-SPan O No 124, ff. 74v-75v}
 BX
 bX
 S3
@@ -16978,10 +31145,15 @@ b
 2. deffd
 3 e
 2 d
-b2# d   cx  da
-3# bx d
 b
-2#  e  dx    fx   f
+2# d   c
+x  da
+3# b
+x d
+b
+2#  e  d
+x    f
+x   f
 b
 1dde
 2b
@@ -16989,172 +31161,445 @@ b
 2#bdedb
 x      //a
 xbde
-b2#      /ax edx  b
+b
+2#      /a
+x ed
+x  b
 b
 2 dd
 3#      a
-xaxc  ax    d
+xa
+xc  a
+x    d
 b
-2#dd  bxf  Qfax d e
+2#dd  b
+xf  Qfa
+x d e
 b
 
-b2#     dxgdx f
-b2#fh    axgixfh
 b
-2#dx     dx   f
+2#     d
+xgd
+x f
+b
+2#fh    a
+xgi
+xfh
+b
+2#d
+x     d
+x   f
 b
 1ddf
 bbX
 2 d
 b
-3# deffdx    fx   fx ex dx     d
-b3#     cx dx  dx bx dx b
-b3# d   dx  ex   fx  gx dex   d
-b3#   bx dx bxdx   Qax    Qd
+3# deffd
+x    f
+x   f
+x e
+x d
+x     d
+b
+3#     c
+x d
+x  d
+x b
+x d
+x b
+b
+3# d   d
+x  e
+x   f
+x  g
+x de
+x   d
+b
+3#   b
+x d
+x b
+xd
+x   Qa
+x    Qd
 b
 
-b3#      //a
-x dx  exb
+b
+3#      //a
+x d
+x  e
+xb
 xd
 xb
 b
-3#      /ax ex  dx  bxbx e
-b3#      ax  dx dxaxcx    d
-b3#    bx dxdx    axf  fx   e
-b3#Qg    dx  ex   fx  gx dx f
-b3#      axfx hx  ixgxf
+3#      /a
+x e
+x  d
+x  b
+xb
+x e
 b
-2#dx     dx   f
+3#      a
+x  d
+x d
+xa
+xc
+x    d
+b
+3#    b
+x d
+xd
+x    a
+xf  f
+x   e
+b
+3#Qg    d
+x  e
+x   f
+x  g
+x d
+x f
+b
+3#      a
+xf
+x h
+x  i
+xg
+xf
+b
+2#d
+x     d
+x   f
 b
 1ddf
 bbX
 2 d
 b
 
-b2#   fx dex f
-b2#   axc dx    d
-b2#    bxddx     d
-b23 dd  cx bx  ea d
-b2#      ax  dax    d
-b2#  babx    ax     d
-b2#    dcx   ax    bd
-b2#   dax   a  //ax   bd
-b2#      ax  dx  e
+b
+2#   f
+x de
+x f
+b
+2#   a
+xc d
+x    d
+b
+2#    b
+xdd
+x     d
+b
+23 dd  c
+x b
+x  ea d
+b
+2#      a
+x  da
+x    d
+b
+2#  bab
+x    a
+x     d
+b
+2#    dc
+x   a
+x    bd
+b
+2#   da
+x   a  //a
+x   bd
+b
+2#      a
+x  d
+x  e
 b
 
-b2# dx   fx  ge
-b2#      ax dx f
-b2#c dx   axd e
-b2#      axf gxdde
 b
-3#  gx  e
+2# d
+x   f
+x  ge
+b
+2#      a
+x d
+x f
+b
+2#c d
+x   a
+xd e
+b
+2#      a
+xf g
+xdde
+b
+3#  g
+x  e
 2.d d   a
-4#   fx  d
+4#   f
+x  d
 b
-2#   fx     dx   f
+2#   f
+x     d
+x   f
 b
 1ddf
 bbX
 2 d
 b
-3#   fx fx  ex  gx dx f
+3#   f
+x f
+x  e
+x  g
+x d
+x f
 b
 
-b3#   ax  dx dxaxcx    db3#    bx dx bxdx    ax     d
-b3#     cx  dx dx bx  ex     d
-b3#      ax  dx   ax    dx    bx    a
-b3#    bx   ax  bx    bx    ax     d
 b
-3#     cx    ax   ax    dx     dx    b
-b3#   dax   bx   a  //ax  bx   b  /ax   d
+3#   a
+x  d
+x d
+xa
+xc
+x    d
+b
+3#    b
+x d
+x b
+xd
+x    a
+x     d
+b
+3#     c
+x  d
+x d
+x b
+x  e
+x     d
+b
+3#      a
+x  d
+x   a
+x    d
+x    b
+x    a
+b
+3#    b
+x   a
+x  b
+x    b
+x    a
+x     d
+b
+3#     c
+x    a
+x   a
+x    d
+x     d
+x    b
+b
+3#   da
+x   b
+x   a  //a
+x  b
+x   b  /a
+x   d
 b
 
-b3#   a  ax  dx   ex   ax  ex   f
-b3# dxdxfx   exgx   f
-b3#      ax  dx  ex   fx dx f
-b3# h    ax  ixgx ixfxi
-b3#gx      axfx  gxdx  e
-b3#  gx  e
+b
+3#   a  a
+x  d
+x   e
+x   a
+x  e
+x   f
+b
+3# d
+xd
+xf
+x   e
+xg
+x   f
+b
+3#      a
+x  d
+x  e
+x   f
+x d
+x f
+b
+3# h    a
+x  i
+xg
+x i
+xf
+xi
+b
+3#g
+x      a
+xf
+x  g
+xd
+x  e
+b
+3#  g
+x  e
 2.  d   Qa
-4#   fx  d
+4#   f
+x  d
 b
-2#   fx     dx   f
+2#   f
+x     d
+x   f
 b
 2@ddeffd
 bbX
-3# ex dx  g
+3# e
+x d
+x  g
 b
 
 b
-2#  e  dx    fx   f
+2#  e  d
+x    f
+x   f
 b
 2. dd  c
-3# bx  e  dx b
+3# b
+x  e  d
+x b
 b
-2#  d   ax   ax    d
-b2# d  bxdxcbd a
+2#  d   a
+x   a
+x    d
+b
+2# d  b
+xd
+xcbd a
 b
 1.ddef d
 b
-2#      /axdegxf
-b2# h    ax  ixgi
-b2f3#l  a
+2#      /a
+xdeg
+xf
+b
+2# h    a
+x  i
+xgi
+b
+2f
+3#l  a
 xi
 2g
 b
 
 b
-2#fhxgi
+2#fh
+xgi
 x  i
-b2#fhx  g
+b
+2#fh
+x  g
 x      a
-b2# dxd e
+b
+2# d
+xd e
 3#  d
 x   f
-b2#  dex  gxdd
-b2  ff
-3# ex  d2 de
-b2# b   bx  ex  d d
-b2#  ex    bx      //a
+b
+2#  de
+x  g
+xdd
+b
+2  ff
+3# e
+x  d
+2 de
+b
+2# b   b
+x  e
+x  d d
+b
+2#  e
+x    b
+x      //a
 b
 1  ed
 bbX
 2 d
 b
 
-b2. ded  //a3#    b
-x    ax  g
 b
-2#  e  dx    fx   f
-b2#      ax  dex  ef
-b2#      /ax bbbx  d
-b2# d    //ax  exd
-b2#      /axdexf
-b2c     a3# d
+2. ded  //a
+3#    b
+x    a
+x  g
+b
+2#  e  d
+x    f
+x   f
+b
+2#      a
+x  de
+x  ef
+b
+2#      /a
+x bbb
+x  d
+b
+2# d    //a
+x  e
+xd
+b
+2#      /a
+xde
+xf
+b
+2c     a
+3# d
 x b
-x  ex b
+x  e
+x b
 b
-2#  dx   a
-3#  dx    d
+2#  d
+x   a
+3#  d
+x    d
 b
 
 b
-2#  b bx dx b  a
-b2#     Qdx  effx  d  c
-b2# dx  b  dx b b
-b2#      ax  bbdx   d
-b2#   e  ax  efx ed   /a
-b2  b
-2.  d   a
-4#   fx  d
+2#  b b
+x d
+x b  a
 b
-2#   fx     dx   f
+2#     Qd
+x  eff
+x  d  c
+b
+2# d
+x  b  d
+x b b
+b
+2#      a
+x  bbd
+x   d
+b
+2#   e  a
+x  ef
+x ed   /a
+b
+2  b
+2.  d   a
+4#   f
+x  d
+b
+2#   f
+x     d
+x   f
 b
 Yddf
 b
 B
 
-p{46c. L`Adieu de Gautier - 7F8Ef9Df/CH-SO DA 111, ff. 8v-9r}
+p
+{46c. L`Adieu de Gautier - 7F8Ef9Df/CH-SO DA 111, ff. 8v-9r}
 BX
 bX
 S3
@@ -17163,10 +31608,14 @@ b
 2. deffd
 3 e
 2 d
-b2# dd  cx  da
-3# bx d
 b
-1 def d2   f
+2# dd  c
+x  da
+3# b
+x d
+b
+1 def d
+2   f
 b
 1 def
 2b
@@ -17174,101 +31623,297 @@ b
 2#bde   //a
 x    Qb
 xbde
-b2#      /ax edx  b
+b
+2#      /a
+x ed
+x  b
 b
 2. dda  a
 3#a
-xcx    d
+xc
+x    d
 b
-2#dd  bxf  Qfax d e
+2#dd  b
+xf  Qfa
+x d e
 b
 
-b2#gdx f
-b2#fh    axgixfh
 b
-2#dx     dx   f
+2#gd
+x f
+b
+2#fh    a
+xgi
+xfh
+b
+2#d
+x     d
+x   f
 b
 1ddf
 bbX
 2 d
 b
-3# def dx    fx   fx ex dx     d
-b3#     cx dx  dx bx dx b
-b3#     dx  ex   fx  gx dx   d
-b3#   bx dx bxdx    dx    b
+3# def d
+x    f
+x   f
+x e
+x d
+x     d
+b
+3#     c
+x d
+x  d
+x b
+x d
+x b
+b
+3#     d
+x  e
+x   f
+x  g
+x d
+x   d
+b
+3#   b
+x d
+x b
+xd
+x    d
+x    b
 b
 
-b3#      //a
-x dx  exb
+b
+3#      //a
+x d
+x  e
+xb
 xd
 xb
 b
-3#      /ax ex  dx  bxbx e
-b3#      ax  dx dxaxcx    d
-b3#    bx dxdx   axfx  e
-b3#Qg    dx  ex   fx  gx dx Qf
-b2f     a3# hx ixgxf
+3#      /a
+x e
+x  d
+x  b
+xb
+x e
 b
-2#dx     dx   f
+3#      a
+x  d
+x d
+xa
+xc
+x    d
+b
+3#    b
+x d
+xd
+x   a
+xf
+x  e
+b
+3#Qg    d
+x  e
+x   f
+x  g
+x d
+x Qf
+b
+2f     a
+3# h
+x i
+xg
+xf
+b
+2#d
+x     d
+x   f
 b
 1ddf
 bbX
 2  e
 b
 
-b2#   fx dex f
-b2#   axcddx    d
-b2#    bxddx     d
-b2# dQd  cx bx  ea d
-b2#      ax  dax    d
-b2#  babx    ax     d
-b2#    dcx   ax    bd
-b2#   dax   a  //ax   bd /a
-b2#   aa ax  dx  e
+b
+2#   f
+x de
+x f
+b
+2#   a
+xcdd
+x    d
+b
+2#    b
+xdd
+x     d
+b
+2# dQd  c
+x b
+x  ea d
+b
+2#      a
+x  da
+x    d
+b
+2#  bab
+x    a
+x     d
+b
+2#    dc
+x   a
+x    bd
+b
+2#   da
+x   a  //a
+x   bd /a
+b
+2#   aa a
+x  d
+x  e
 b
 
-b2# dx   fx  de
-b2#      ax dx f
-b2# h hx   axd e
-b2#      axf gxdde
 b
-3#  gx  e
+2# d
+x   f
+x  de
+b
+2#      a
+x d
+x f
+b
+2# h h
+x   a
+xd e
+b
+2#      a
+xf g
+xdde
+b
+3#  g
+x  e
 2.  d   a
-4#   fx   e
+4#   f
+x   e
 b
-2#   fx     dx   f
+2#   f
+x     d
+x   f
 b
 1ddf
 bbX
 2 de
 b
-3#   fx dx  ex  gx dx f
+3#   f
+x d
+x  e
+x  g
+x d
+x f
 b
 
-b3#      ax  dx dxaxcx    db3#    bx dx bxdxf   ax     d
-b3#     cx  dx dx bx  ex     d
-b3#      ax  dx   ax    dx    bx    a
-b3#    bx   Qax  bx    bx    ax     Qb
 b
-3#     cx    ax   ax    dx     dx    d
-b3#   d  //ax   bx   ax  bx   b  /ax   d
+3#      a
+x  d
+x d
+xa
+xc
+x    d
+b
+3#    b
+x d
+x b
+xd
+xf   a
+x     d
+b
+3#     c
+x  d
+x d
+x b
+x  e
+x     d
+b
+3#      a
+x  d
+x   a
+x    d
+x    b
+x    a
+b
+3#    b
+x   Qa
+x  b
+x    b
+x    a
+x     Qb
+b
+3#     c
+x    a
+x   a
+x    d
+x     d
+x    d
+b
+3#   d  //a
+x   b
+x   a
+x  b
+x   b  /a
+x   d
 b
 
-b3#   aa ax  dx   ex   ax  ex   Qf
-b3#      axdxfx   exgx   f
-b3#      ax  dx  ex   fx dx f
-b3# h    Qax  ixgx Qix-Qlxi
-b3#      axgxfx  gxdx  e
-b3#  gx  e
+b
+3#   aa a
+x  d
+x   e
+x   a
+x  e
+x   Qf
+b
+3#      a
+xd
+xf
+x   e
+xg
+x   f
+b
+3#      a
+x  d
+x  e
+x   f
+x d
+x f
+b
+3# h    Qa
+x  i
+xg
+x Qi
+x-Ql
+xi
+b
+3#      a
+xg
+xf
+x  g
+xd
+x  e
+b
+3#  g
+x  e
 2.  d   Qa
-4#   fx  d
+4#   f
+x  d
 b
-2#   fx     dx   f
+2#   f
+x     d
+x   f
 b
 Yddf
 b
 B
-{46d. Courante - 7F8Ef9D/D-Hs ND VI 3238, p. 89 ii}BX
+
+{46d. Courante - 7F8Ef9D/D-Hs ND VI 3238, p. 89 ii}
+BX
 bX
 S3
 2 d
@@ -17276,26 +31921,44 @@ b
 2. deffd
 3 e
 2 d
-b2# d - cx  da
-3# bx d
 b
-2#  e- dx    fx   f
+2# d - c
+x  da
+3# b
+x d
+b
+2#  e- d
+x    f
+x   f
 b
 1dde
 2b
 b
 1bde b
 2      //a
-b2#      /ax edx  b
+b
+2#      /a
+x ed
+x  b
 b
 2. dda  a
-3#axc- ax    d
+3#a
+xc- a
+x    d
 b
-2#dd- bxf  fax d e
+2#dd- b
+xf  fa
+x d e
 b
 
-b2#     dx-Qgdx f
-b2#fh -- axgQixfh
+b
+2#     d
+x-Qgd
+x f
+b
+2#fh -- a
+xgQi
+xfh
 b
 2# Qi
 x     Qd
@@ -17304,34 +31967,77 @@ b
 1ddf
 bbX
 2 d
-b2#   fx dex f
-b2#   axcd-x    d
-b2#    bxdd -x     d
-b2#  d- cx bx  ea d
-b1  da- a2    d
-b2#  babx    ax     d
+b
+2#   f
+x de
+x f
+b
+2#   a
+xcd-
+x    d
+b
+2#    b
+xdd -
+x     d
+b
+2#  d- c
+x b
+x  ea d
+b
+1  da- a
+2    d
+b
+2#  bab
+x    a
+x     d
 b
 
-b2#    dcx   ax    bd
-b2#   dax   a- //ax   b- /a
-b2#      ax  dx  e
-b2# dx   fx   e
-b2#      ax dx f
-b2# hQdx   axd e
-b2#      axf gxdde
 b
-3#  gx  e
+2#    dc
+x   a
+x    bd
+b
+2#   da
+x   a- //a
+x   b- /a
+b
+2#      a
+x  d
+x  e
+b
+2# d
+x   f
+x   e
+b
+2#      a
+x d
+x f
+b
+2# hQd
+x   a
+xd e
+b
+2#      a
+xf g
+xdde
+b
+3#  g
+x  e
 2d d - a
-3#axc
+3#a
+xc
 b
-2#dx     dx   a
+2#d
+x     d
+x   a
 b
 Ydab
 b
 B
 
 { }
-{46e. Courante - 7F8Ef9D10Bf/CZ-Pnm G.IV.18, f. 162v}BX
+{46e. Courante - 7F8Ef9D10Bf/CZ-Pnm G.IV.18, f. 162v}
+BX
 bX
 S3
 2 d
@@ -17340,10 +32046,15 @@ b
 3#     d
 x e
 2 d
-b2# d   cx  d
-3# bx d
 b
-2#  ex      ///ax     d
+2# d   c
+x  d
+3# b
+x d
+b
+2#  e
+x      ///a
+x     d
 b
 1ddef
 2b
@@ -17351,16 +32062,29 @@ b
 2#bde   //a
 x    b
 xbd
-b2# e    /ax  dx  b
+b
+2# e    /a
+x  d
+x  b
 b
 2. dda  a
-3#axcx    d
+3#a
+xc
+x    d
 b
-2#dd  bxf  fax   e
+2#dd  b
+xf  fa
+x   e
 b
 
-b2#     dxgd fx f
-b2.fh    a3gi2fh
+b
+2#     d
+xgd f
+x f
+b
+2.fh    a
+3gi
+2fh
 b
 2# i
 x      ///a
@@ -17369,93 +32093,197 @@ b
 1ddf
 bbX
 2 d
-b2#   fx dex f
-b2#   axcddx    d
-b2#    bxddx     d
-b2# dd  cx bx  e  d
 b
-2#      ax  dax    d
-b2#  babx    ax     d
+2#   f
+x de
+x f
+b
+2#   a
+xcdd
+x    d
+b
+2#    b
+xdd
+x     d
+b
+2# dd  c
+x b
+x  e  d
+b
+2#      a
+x  da
+x    d
+b
+2#  bab
+x    a
+x     d
 b
 
-b2#    dcx   ax    bd
-bx   dax   a  //ax   b  /a
-b2#   Qa  ax  d3#  e
-x  g
-b2# dx   fx  ge
-b2#  e   ax dx f
-b2# gdx    fxd e
-b2#      axf gxd e
 b
-3#  gx  e
+2#    dc
+x   a
+x    bd
+b
+x   da
+x   a  //a
+x   b  /a
+b
+2#   Qa  a
+x  d
+3#  e
+x  g
+b
+2# d
+x   f
+x  ge
+b
+2#  e   a
+x d
+x f
+b
+2# gd
+x    f
+xd e
+b
+2#      a
+xf g
+xd e
+b
+3#  g
+x  e
 x  d
 x   f
-x  dx   e
+x  d
+x   e
 b
-2#   fx      ///ax     d
+2#   f
+x      ///a
+x     d
 b
 Yddff
 b
 B
 
-{46f. Courante Transp G.M. - 7F8Ef9D10C/CZ-Pnm G.IV.18, ff. 118v-119r}BX
+{46f. Courante Transp G.M. - 7F8Ef9D10C/CZ-Pnm G.IV.18, ff. 118v-119r}
+BX
 bX
 S3
 2a
 b
 2abd a
-3#      ///axb
+3#      ///a
+xb
 2a
-b2#aff  ex  f
-3# dx f
 b
-2# bx      ///ax    a
+2#aff  e
+x  f
+3# d
+x f
+b
+2# b
+x      ///a
+x    a
 b
 1  dc
 2d
-b2#dfg   /ax    dxdfg
-b2#bd    ax ax  d
+b
+2#dfg   /a
+x    d
+xdfg
+b
+2#bd    a
+x a
+x  d
 b
 2.aa   a
-3#cxex      a
+3#c
+xe
+x      a
 b
-2#ff    /axh  h  //ax   g
-b2#   hxi     ///ax  a
+2#ff    /a
+xh  h  //a
+x   g
+b
+2#   h
+xi     ///a
+x  a
 b
 
-b2# ac  ax bdx ac
-b2#  dx      ///ax    a
+b
+2# ac  a
+x bd
+x ac
+b
+2#  d
+x      ///a
+x    a
 b
 1  dc
 bbX
 2a
-b2#  dxabxc
-b2#     axeffx      a
-b2#      /axffx    a
+b
+2#  d
+xab
+xc
+b
+2#     a
+xeff
+x      a
+b
+2#      /a
+xff
+x    a
 b
 2.aff  e
 3 d
 2 b  a
-b2#     ax accx   a
-b2#  dcdx    cx    a
+b
+2#     a
+x acc
+x   a
+b
+2#  dcd
+x    c
+x    a
 b
 
-b2. df  e
+b
+2. df  e
 3a
 2 b    ///a
-b2#  b   //ax   c  /ax   d  a
-b2   Qc ax a
-3# bx d
 b
-2#ax  dx dc
-b2# b   axaxc
-b2#Qeax   cxf g
-b2#e    axifxhi
-b2f g
+2#  b   //a
+x   c  /a
+x   d  a
+b
+2   Qc a
+x a
+3# b
+x d
+b
+2#a
+x  d
+x dc
+b
+2# b   a
+xa
+xc
+b
+2#Qea
+x   c
+xf g
+b
+2#e    a
+xif
+xhi
+b
+2f g
 2.e    a
-4# hxe
+4# h
+xe
 b
-2#fx    a
+2#f
+x    a
 x      ///a
 b
 Y  dc
@@ -17463,136 +32291,364 @@ b
 B
 
 { }
-{47a. Courante Gauthier - 7F8Ef9D10C/GB-Cfm 689, f. 72r iii}B
+{47a. Courante Gauthier - 7F8Ef9D10C/GB-Cfm 689, f. 72r iii}
+B
 b
 S3
-3# bx d
-2#ax   c
-b2 bd
-3#    ax d
+3# b
+x d
+2#a
+x   c
+b
+2 bd
+3#    a
+x d
 2a
 b
 2.aff- e
-3# dx b- ax d
+3# d
+x b- a
+x d
 b
 2 a - a
-3#   cx bxdx   c
-b3#   ax    d
-2# db cxb
+3#   c
+x b
+xd
+x   c
+b
+3#   a
+x    d
+2# db c
+xb
 b
 2#      /a
 xa b d
 x  d
 b
 2. ddd- a
-3# bx ax  d
-b
-2#  cccaxa
-3#  dx a
-b
-
-b
-2# bd   ///ax db   //ax   d
-b2#      /axabbx a
-b2#      axb dx a
-b2ab - a
-3#  cx  dx bx   c
-b3# a a- ax  d d
-2.  c ca
-4#  ax  c
-b
-2#  dx    ax      ///a
-bb
-3# bx dxax   cx  dx  c
-b3#  dx bx    ax dxaxf
-b
-
-b3#     exax  fx dx b- ax d
-b3#     ax ax   cx bxdx   c
-b3#   ax    dx    cx dx  bxb
-b3#      /axax    dx  bx   cx b
-b3#  dx   dx      ax bx ax  d
-b3#     ax  cx   cx dx  d
+3# b
 x a
-b3#      ///ax bx  dx      //ax dbx   d
+x  d
+b
+2#  ccca
+xa
+3#  d
+x a
 b
 
-b3#      /axaxbx dxaxf
 b
-3#      axbx  dx dx ax  b
-b3#     axabx  cx  dx bx   c
-b3#  a ax  d-d
+2# bd   ///a
+x db   //a
+x   d
+b
+2#      /a
+xabb
+x a
+b
+2#      a
+xb d
+x a
+b
+2ab - a
+3#  c
+x  d
+x b
+x   c
+b
+3# a a- a
+x  d d
+2.  c ca
+4#  a
+x  c
+b
+2#  d
+x    a
+x      ///a
+bb
+3# b
+x d
+xa
+x   c
+x  d
+x  c
+b
+3#  d
+x b
+x    a
+x d
+xa
+xf
+b
+
+b
+3#     e
+xa
+x  f
+x d
+x b- a
+x d
+b
+3#     a
+x a
+x   c
+x b
+xd
+x   c
+b
+3#   a
+x    d
+x    c
+x d
+x  b
+xb
+b
+3#      /a
+xa
+x    d
+x  b
+x   c
+x b
+b
+3#  d
+x   d
+x      a
+x b
+x a
+x  d
+b
+3#     a
+x  c
+x   c
+x d
+x  d
+x a
+b
+3#      ///a
+x b
+x  d
+x      //a
+x db
+x   d
+b
+
+b
+3#      /a
+xa
+xb
+x d
+xa
+xf
+b
+3#      a
+xb
+x  d
+x d
+x a
+x  b
+b
+3#     a
+xab
+x  c
+x  d
+x b
+x   c
+b
+3#  a a
+x  d-d
 2.  cc a
-4#  ax  c
+4#  a
+x  c
 b
-2#  dx    ax      ///a
-bb2#abdx dcx bd
-b2#     axdb cx   a
+2#  d
+x    a
+x      ///a
+bb
+2#abd
+x dc
+x bd
+b
+2#     a
+xdb c
+x   a
 b
 
-b2#a bcdx  dxbdd - a
+b
+2#a bcd
+x  d
+xbdd - a
 b
 2.aac- a
 3 d
 2 b
 b
 2   c
-3# ax   a
+3# a
+x   a
 2  d-d
-b2#     axd
-3#      axb
 b
-2#a     /ax      //axf  -  ///a
-b2e
-3#     ax gx f4# dx f
+2#     a
+xd
+3#      a
+xb
 b
-2#  gx i
-3# fx i
-b3# gx   h
+2#a     /a
+x      //a
+xf  -  ///a
+b
+2e
+3#     a
+x g
+x f
+4# d
+x f
+b
+2#  g
+x i
+3# f
+x i
+b
+3# g
+x   h
 2i
-3# ix    h
+3# i
+x    h
 b
 
-b3# fx  g
-2#fx g- f
+b
+3# f
+x  g
+2#f
+x g- f
 b
 1 fg- a
 2 af
 b
-2# dxa cx bd
-b2#      ///ax bdx ddd- a
+2# d
+xa c
+x bd
 b
-3# ax  d
+2#      ///a
+x bd
+x ddd- a
+b
+3# a
+x  d
 2.  ccca
-4#  ax  c
+4#  a
+x  c
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 bb
-3#ax  dx dxa-cx bdx d
-b3#     ax bxaxdx   cx   a
+3#a
+x  d
+x d
+xa-c
+x bd
+x d
+b
+3#     a
+x b
+xa
+xd
+x   c
+x   a
 b
 
-b3#      /axax  bx  dxb  -  ax b
-b3#     axax ax dx bx d
 b
-3#   cx bx ax   ax  d-dxa
-b3#     axdx bx      axbx a
-b3#      /axaxdx      //axfxi
-b3#hx     ax fx gx f
-4# dx f
+3#      /a
+xa
+x  b
+x  d
+xb  -  a
+x b
 b
-3#  gx dx  fxdx fx   h
+3#     a
+xa
+x a
+x d
+x b
+x d
+b
+3#   c
+x b
+x a
+x   a
+x  d-d
+xa
+b
+3#     a
+xd
+x b
+x      a
+xb
+x a
+b
+3#      /a
+xa
+xd
+x      //a
+xf
+xi
+b
+3#h
+x     a
+x f
+x g
+x f
+4# d
+x f
+b
+3#  g
+x d
+x  f
+xd
+x f
+x   h
 b
 
-b3# gx  ix fx  gx  fx i
 b
-3#   hx gx fx   fxf- dx d
-b3#     axex fx dx bxa
-b3# dx ax  cxax bdx    a
-b3#      ///ax bx  dx dx  bx      a
-b3# ax  d
+3# g
+x  i
+x f
+x  g
+x  f
+x i
+b
+3#   h
+x g
+x f
+x   f
+xf- d
+x d
+b
+3#     a
+xe
+x f
+x d
+x b
+xa
+b
+3# d
+x a
+x  c
+xa
+x bd
+x    a
+b
+3#      ///a
+x b
+x  d
+x d
+x  b
+x      a
+b
+3# a
+x  d
 2.  ccca
-4#  ax  c
+4#  a
+x  c
 b
 1  dca
 Y      ///a
@@ -17604,136 +32660,363 @@ B
 B
 b
 S3
-3# bx d
-2#ax   c
-b2 bd
-3#    ax d
+3# b
+x d
+2#a
+x   c
+b
+2 bd
+3#    a
+x d
 2a
 b
 2.aff  e
-3# dx b  ax d
+3# d
+x b  a
+x d
 b
 2 a   a
-3#   cx bxdx   c
-b3#   ax    d
-2# db cxb
+3#   c
+x b
+xd
+x   c
+b
+3#   a
+x    d
+2# db c
+xb
 b
 2#      /a
 xa b d
 x  d
 b
 2. dda  Qa
-3# bx ax  d
-b
-2#  cccaxa
-3#  dx a
-b
-
-b
-2# bd ax db cx   d
-b2#      /axabbx a
-b2#      axb dx a
-b2ab   a
-3#  cx  dx bx   c
-b3# a ax  d
-2.  ccca
-4#  ax  c
-b
-2#  dx    ax      //a
-bQ
-b
-3# bx dxax   cx  dx  c
-b3#  dx bx    ax dxaxf
-b
-
-b3#     ex fx  fx dx b  ax d
-b3#     ax ax   cx bxdx   c
-b3#   ax    dx    cx dx  bxb
-b3#      /axax    dx  bx   cx b
-b3#  dx   dx      Qax bx ax  d
-b3#     ax  cx   cx dx  d
+3# b
 x a
-b3#    ax bx  dx    cx dbx   d
+x  d
+b
+2#  ccca
+xa
+3#  d
+x a
 b
 
-b3#      /axax bxdxaxf
 b
-3#      axbx  dx dx ax  b
-b3#     axabx  cx  dx bx   c
-b3# a ax  d
+2# bd a
+x db c
+x   d
+b
+2#      /a
+xabb
+x a
+b
+2#      a
+xb d
+x a
+b
+2ab   a
+3#  c
+x  d
+x b
+x   c
+b
+3# a a
+x  d
 2.  ccca
-4#  ax  c
+4#  a
+x  c
 b
-2#  dx    ax      //a
+2#  d
+x    a
+x      //a
 bQ
-b2abd3#  c
-x d2 bd
-b2#     axdb cx   a
+b
+3# b
+x d
+xa
+x   c
+x  d
+x  c
+b
+3#  d
+x b
+x    a
+x d
+xa
+xf
 b
 
-b2#a bcdx  dxbdd   a
+b
+3#     e
+x f
+x  f
+x d
+x b  a
+x d
+b
+3#     a
+x a
+x   c
+x b
+xd
+x   c
+b
+3#   a
+x    d
+x    c
+x d
+x  b
+xb
+b
+3#      /a
+xa
+x    d
+x  b
+x   c
+x b
+b
+3#  d
+x   d
+x      Qa
+x b
+x a
+x  d
+b
+3#     a
+x  c
+x   c
+x d
+x  d
+x a
+b
+3#    a
+x b
+x  d
+x    c
+x db
+x   d
+b
+
+b
+3#      /a
+xa
+x b
+xd
+xa
+xf
+b
+3#      a
+xb
+x  d
+x d
+x a
+x  b
+b
+3#     a
+xab
+x  c
+x  d
+x b
+x   c
+b
+3# a a
+x  d
+2.  ccca
+4#  a
+x  c
+b
+2#  d
+x    a
+x      //a
+bQ
+b
+2abd
+3#  c
+x d
+2 bd
+b
+2#     a
+xdb c
+x   a
+b
+
+b
+2#a bcd
+x  d
+xbdd   a
 b
 2.aac  a
 3 d
 2 bd
-b3#   c
-x a2#   a
+b
+3#   c
+x a
+2#   a
 x  d d
-b2     a3#d
-x      a2b
 b
-2#a     /ax      //cxf     //a
-b2e
-3#     ax gx f4#  ix f
+2     a
+3#d
+x      a
+2b
 b
-2#  gx i
-3# fx i
-b3# gx   h
+2#a     /a
+x      //c
+xf     //a
+b
+2e
+3#     a
+x g
+x f
+4#  i
+x f
+b
+2#  g
+x i
+3# f
+x i
+b
+3# g
+x   h
 2i
-3# ix    h
+3# i
+x    h
 b
 
-b3# fx  g
-2#fx g  f
+b
+3# f
+x  g
+2#f
+x g  f
 b
 1 fg  Qa
 2 af
-b2# dxa cx bd
-b2#      //ax bdx d d  a
 b
-3# ax  d
+2# d
+xa c
+x bd
+b
+2#      //a
+x bd
+x d d  a
+b
+3# a
+x  d
 2.  ccca
-4#  ax  c
+4#  a
+x  c
 b
-2#  dx    ax      //a
+2#  d
+x    a
+x      //a
 bQ
 b
-3#ax  dx dxa cx bdx d
-b3#     ax bxaxdx   cx   a
+3#a
+x  d
+x d
+xa c
+x bd
+x d
+b
+3#     a
+x b
+xa
+xd
+x   c
+x   a
 b
 
-b3#    dxax  bx  dxb     ax b
 b
-3#     axax ax dx bx d
+3#    d
+xa
+x  b
+x  d
+xb     a
+x b
 b
-3#   cx bx ax   ax  d dxa
-b3#     axdx bxbx      ax a
-b3#    dxaxdx    cxf   axi
-b3#h    ax fx gx f
-x  ix f
+3#     a
+xa
+x a
+x d
+x b
+x d
 b
-3#  gx  ix  fx ix fx   f
+3#   c
+x b
+x a
+x   a
+x  d d
+xa
+b
+3#     a
+xd
+x b
+xb
+x      a
+x a
+b
+3#    d
+xa
+xd
+x    c
+xf   a
+xi
+b
+3#h    a
+x f
+x g
+x f
+x  i
+x f
+b
+3#  g
+x  i
+x  f
+x i
+x f
+x   f
 b
 
-b3# gx  ix fx  gx  fx i
 b
-3#   hx gx fx   fxf  dx d
-b3#     axex fx dx bxa
-b3# dx ax  cxax bdx    a
-b3#      //ax bx  dx dx bx      a
-b3# ax  d
+3# g
+x  i
+x f
+x  g
+x  f
+x i
+b
+3#   h
+x g
+x f
+x   f
+xf  d
+x d
+b
+3#     a
+xe
+x f
+x d
+x b
+xa
+b
+3# d
+x a
+x  c
+xa
+x bd
+x    a
+b
+3#      //a
+x b
+x  d
+x d
+x b
+x      a
+b
+3# a
+x  d
 2.  cc a
-4#  ax  c
+4#  a
+x  c
 b
 2#  d
 x    a
@@ -17747,226 +33030,541 @@ B
 B
 b
 S3
-2# fxf
-3#    axh
+2# f
+xf
+3#    a
+xh
 b
-2#ix   hx  f
-b2#ffgxhxedf
-b2#   hxffgx   f
-b2ff-d
-3# dx  g
+2#i
+x   h
+x  f
+b
+2#ffg
+xh
+xedf
+b
+2#   h
+xffg
+x   f
+b
+2ff-d
+3# d
+x  g
 2 df
-b2#ab-cx  dx a
-b2#     ax  dd- ax  bac
-b2#   cd-/axdxb
-b2#a-bx   dx bbc
-b2#     dx a ax   c
+b
+2#ab-c
+x  d
+x a
+b
+2#     a
+x  dd- a
+x  bac
+b
+2#   cd-/a
+xd
+xb
+b
+2#a-b
+x   d
+x bbc
+b
+2#     d
+x a a
+x   c
 b
 
-b2#    ax bdxc
-b2#da - ax bx   c
-b2# axax   a
-b2#   cdx  dx  cac
-b2#  dcax bx     d
-b2# dd  bxabd- ax-Qcdf - a
+b
+2#    a
+x bd
+xc
+b
+2#da - a
+x b
+x   c
+b
+2# a
+xa
+x   a
+b
+2#   cd
+x  d
+x  cac
+b
+2#  dca
+x b
+x     d
+b
+2# dd  b
+xabd- a
+x-Qcdf - a
 b
 1dfg   /a
 2 df - a
-b2 bd
+b
+2 bd
 2. a - a
-4#  dx a
+4#  d
+x a
 b
-2#  dx    ax      ///a
-bb2#fx f
-3#fxe
+2#  d
+x    a
+x      ///a
+bb
+2#f
+x f
+3#f
+xe
 b
 
 b
-2#fx dx fg
-b2#  fx fx d
+2#f
+x d
+x fg
 b
-2# bdx    ax QdQb c
-b2#a b-dx      /axd
-b2#  bx dx   d
-b2 b c
+2#  f
+x f
+x d
+b
+2# bd
+x    a
+x QdQb c
+b
+2#a b-d
+x      /a
+xd
+b
+2#  b
+x d
+x   d
+b
+2 b c
 2. a a d
-4#  dx a
+4#  d
+x a
 b
-2 b -x      /axd
+2 b -
+x      /a
+xd
 b
-3# bx d
-2#ax bd
-b2# dfxdxf-g
-b2# fxh-ixf-g
+3# b
+x d
+2#a
+x bd
+b
+2# df
+xd
+xf-g
+b
+2# f
+xh-i
+xf-g
 b
 
-b2#     axeffx d
-b2#abx  dx ac
 b
-2#     axaxc
-b2#ex fxfh
-b2#hk - axax d
-b2# bx  c
-3#  dx a
+2#     a
+xeff
+x d
 b
-2#     ax   cx   a
-b2a d d
+2#ab
+x  d
+x ac
+b
+2#     a
+xa
+xc
+b
+2#e
+x f
+xfh
+b
+2#hk - a
+xa
+x d
+b
+2# b
+x  c
+3#  d
+x a
+b
+2#     a
+x   c
+x   a
+b
+2a d d
 2.  c ca
-4#  ax  c
+4#  a
+x  c
 b
-2#  d-ax   cY      ///a
+2#  d-a
+x   c
+Y      ///a
 b
 B
 
 p
-{49a. Volte Gauthier - 7F8Ef10Bf/GB-Cfm 689, ff. 49v i}B
+{49a. Volte Gauthier - 7F8Ef10Bf/GB-Cfm 689, ff. 49v i}
+B
 b
 S3
-2#dxax b
-b2d
-3#   cx   d
-2  b
-b2# bdx dxafg
-b2# dx   fx  f
-b
-3#fxh
-2#ix   h
-b2#h- gx gx f
-b2#   dxffx d
-b2#     axdx a
-b
-
-b2#abx ax  d
-b2#  b- ax bx d
-b
-2#ax  dx df
-b2# fg dx      /axa
-b2# dx  bx   d
-b2 bbc- /a
-3#dxbxaxb
+2#d
+xa
+x b
 b
 2d
-3#  bx   d
+3#   c
+x   d
+2  b
+b
+2# bd
+x d
+xafg
+b
+2# d
+x   f
+x  f
+b
+3#f
+xh
+2#i
+x   h
+b
+2#h- g
+x g
+x f
+b
+2#   d
+xff
+x d
+b
+2#     a
+xd
+x a
+b
+
+b
+2#ab
+x a
+x  d
+b
+2#  b- a
+x b
+x d
+b
+2#a
+x  d
+x df
+b
+2# fg d
+x      /a
+xa
+b
+2# d
+x  b
+x   d
+b
+2 bbc- /a
+3#d
+xb
+xa
+xb
+b
+2d
+3#  b
+x   d
 2   c
 b
 
 b
-3#   dx  bx  dx ax bx d
-b3#ax b
-2. a a d
-4#  dx a
+3#   d
+x  b
+x  d
+x a
+x b
+x d
 b
-2# bx    dx      /a
+3#a
+x b
+2. a a d
+4#  d
+x a
+b
+2# b
+x    d
+x      /a
 bb
-2#f- dxh- fx g
-b2#      /axifgx    h
-b2#   hix  ix i- h
-b2# gi fxfx    d
-b2#    cxddxb
+2#f- d
+xh- f
+x g
+b
+2#      /a
+xifg
+x    h
+b
+2#   hi
+x  i
+x i- h
+b
+2# gi f
+xf
+x    d
+b
+2#    c
+xdd
+xb
 b
 
-b2a b d
-3#      /axb
+b
+2a b d
+3#      /a
+xb
 2d
-b2#      axb dx a
-b2#ab - ax   cx   a
-b2#a b-dx    cxcb- a
-b2#ddf  dx      ///axf
-b2#hx dx  g
-b2# df - ///a
-xdxab
-b2# dfxdxf-g
+b
+2#      a
+xb d
+x a
+b
+2#ab - a
+x   c
+x   a
+b
+2#a b-d
+x    c
+xcb- a
+b
+2#ddf  d
+x      ///a
+xf
+b
+2#h
+x d
+x  g
+b
+2# df - ///a
+xd
+xab
+b
+2# df
+xd
+xf-g
 b
 
-b2#h  -  ///ax  ix  g
-b2#  fxddx  d
-b2# ab - ///ax dx    c
-b2#  bcdx    cx b ea
-b2# ab - ///axd
-3#  bxa
-b3#   dx   c
-2. a a d
-4#    dx   a
 b
-2#   cx      /aY bbc
+2#h  -  ///a
+x  i
+x  g
+b
+2#  f
+xdd
+x  d
+b
+2# ab - ///a
+x d
+x    c
+b
+2#  bcd
+x    c
+x b ea
+b
+2# ab - ///a
+xd
+3#  b
+xa
+b
+3#   d
+x   c
+2. a a d
+4#    d
+x   a
+b
+2#   c
+x      /a
+Y bbc
 b
 B
 
-p{49b. Volt 4 - 8Ef/Dowland 1610, sig. S1v}B
+p
+{49b. Volt 4 - 8Ef/Dowland 1610, sig. S1v}
+B
 b
 S3
-2#dxax b
-b2d
-3#   cx   d
-2  b
-b2# bdx dxafg
-b2# dx   fx  f
+2#d
+xa
+x b
 b
-3#fxh
-2#ix   h
-b2#h  fx gx f
-b2#   dxffx d
-b2#     axdx a
+2d
+3#   c
+x   d
+2  b
+b
+2# bd
+x d
+xafg
+b
+2# d
+x   f
+x  f
+b
+3#f
+xh
+2#i
+x   h
+b
+2#h  f
+x g
+x f
+b
+2#   d
+xff
+x d
+b
+2#     a
+xd
+x a
 b
 
-b2#abx ax  d
-b2#  b  ax bx d
-b2#ax  dx df
-b2#abb dx      /axa
-b2# dx  bx   d
-b2 bbc
-3#dxbxaxb
+b
+2#ab
+x a
+x  d
+b
+2#  b  a
+x b
+x d
+b
+2#a
+x  d
+x df
+b
+2#abb d
+x      /a
+xa
+b
+2# d
+x  b
+x   d
+b
+2 bbc
+3#d
+xb
+xa
+xb
 b
 3#d
-x  bx   d
+x  b
+x   d
 x   c
 x   a
 x   c
 b
 
 b
-3#   dx  bx  dx ax bx d
-b3#ax b
+3#   d
+x  b
+x  d
+x a
+x b
+x d
+b
+3#a
+x b
 2. aba d
-4#  dx a
-b
-2# bx    dx      /a
-b
-bQ
-2#f  dxh  fx g
-b2#      /axifgx    h
-b2#   hix  ix i eh
-b2# gi fxfx    d
-b2#    cxddxb
-b
-
-b2abb d
-3#      /axb
-2d
-b2#b da
-x bx a
-b2#ab  ax   cx   a
-b2#a b dx    cxcbd a
-b2#ddfx     dxf
-b2#hx dx  g
-b2# df  d
-xdxab
-b2# dfxdxf g
-b
-
-b2#h    dx dx  g
-b2#   fxddx  d
-b2# abx     dx d  c
-b2#  bcdx    cx bd a
-b3# aba dxd
-2#  bxa
-b3# dx b
-2. aba d
-4#  dx a
+4#  d
+x a
 b
 2# b
-x    dx      /a
-bY bbc
+x    d
+x      /a
+b
+bQ
+2#f  d
+xh  f
+x g
+b
+2#      /a
+xifg
+x    h
+b
+2#   hi
+x  i
+x i eh
+b
+2# gi f
+xf
+x    d
+b
+2#    c
+xdd
+xb
+b
+
+b
+2abb d
+3#      /a
+xb
+2d
+b
+2#b da
+x b
+x a
+b
+2#ab  a
+x   c
+x   a
+b
+2#a b d
+x    c
+xcbd a
+b
+2#ddf
+x     d
+xf
+b
+2#h
+x d
+x  g
+b
+2# df  d
+xd
+xab
+b
+2# df
+xd
+xf g
+b
+
+b
+2#h    d
+x d
+x  g
+b
+2#   f
+xdd
+x  d
+b
+2# ab
+x     d
+x d  c
+b
+2#  bcd
+x    c
+x bd a
+b
+3# aba d
+xd
+2#  b
+xa
+b
+3# d
+x b
+2. aba d
+4#  d
+x a
+b
+2# b
+x    d
+x      /a
+b
+Y bbc
 b
 B
 
@@ -18223,337 +33821,731 @@ B
 B
 b
 S3
-2# dffx     dx f
-b2 dff
-3#     dx  g
+2# dff
+x     d
+x f
+b
+2 dff
+3#     d
+x  g
 2  f
-b2#  d   ax  bx  de
-b2. a a d
-4#  dx a
+b
+2#  d   a
+x  b
+x  de
+b
+2. a a d
+4#  d
+x a
 2  b
-b2# db cx  axa  c
+b
+2# db c
+x  a
+xa  c
 b
 2.c  a
-3#    dxdd  cxc
+3#    d
+xdd  c
+xc
 b
 2.a   d
-3#dxc  axf
+3#d
+xc  a
+xf
 b
-2#dx   cxf  e
+2#d
+x   c
+xf  e
 b
 
-b2#h  fx ixl
+b
+2#h  f
+x i
+xl
 b
 1l  k
 2h  f
 b
-3#f     /axhxixhxf     a
-4# ixf
+3#f     /a
+xh
+xi
+xh
+xf     a
+4# i
+xf
 b
-2# ix     dx    f
+2# i
+x     d
+x    f
 b
 1.ddff
 bb
-2#  ffx dx  de
-b2# bbcx ax   a
+2#  ff
+x d
+x  de
 b
-3#a   dx dx b  ax dxaxc
+2# bbc
+x a
+x   a
+b
+3#a   d
+x d
+x b  a
+x d
+xa
+xc
 b
 
 b
-2#dx     dx b  a
-b2. d a
+2#d
+x     d
+x b  a
+b
+2. d a
 3d
 2c     a
-b2#a    dx   ax c ca
-b2# dd   axfhxhi
+b
+2#a    d
+x   a
+x c ca
+b
+2# dd   a
+xfh
+xhi
 b
 2.i  h
 3i
 2h  f
 b
-2.f   f3h
+2.f   f
+3h
 2dd  c
-b2    d
-2.c da
-4#axc
 b
-2#dx     dx   a
+2    d
+2.c da
+4#a
+xc
+b
+2#d
+x     d
+x   a
 b
 Ydab
 b
 B
 
 p
-{51a. Volte gothier - 7F8Ef9D10C/CZ-Pnm G.IV.18, f. 10v}B
+{51a. Volte gothier - 7F8Ef9D10C/CZ-Pnm G.IV.18, f. 10v}
+B
 b
 S3
-3#   dx   c
-2#   ax  d
-b2#  b   /ax  dx   d  a
-b2    f
+3#   d
+x   c
+2#   a
+x  d
+b
+2#  b   /a
+x  d
+x   d  a
+b
+2    f
 2.   ca
-4#   ax   c
+4#   a
+x   c
 b
-2#   ax      ax   a
+2#   a
+x      a
+x   a
 b
-3#  bx  dx  bx   dx   cx   a
+3#  b
+x  d
+x  b
+x   d
+x   c
+x   a
 b
-2#  bcdx      /ax  d
+2#  bcd
+x      /a
+x  d
 b
 2.  ea
-3#  dx  bx   c
+3#  d
+x  b
+x   c
 b
-2#  ddx     bx  dd
-b2#     ax  bcx c
+2#  dd
+x     b
+x  dd
+b
+2#     a
+x  bc
+x c
 b
 
-b2# ddax      ax      /a
-b2#      //ax  dx  b
-b2#      ///ax gx f f
-b2 d d
+b
+2# dda
+x      a
+x      /a
+b
+2#      //a
+x  d
+x  b
+b
+2#      ///a
+x g
+x f f
+b
+2 d d
 2. c ca
-4# ax c
+4# a
+x c
 b
-2# dx   ax      a
+2# d
+x   a
+x      a
 bb
-3#  dx   fx  dx  ex  gx  d
+3#  d
+x   f
+x  d
+x  e
+x  g
+x  d
 b
-2# dex   fx   d
-b2  bc
-3#   dx   cx   ax   c
+2# de
+x   f
+x   d
 b
-2# bddx   cx d a
+2  bc
+3#   d
+x   c
+x   a
+x   c
+b
+2# bdd
+x   c
+x d a
 b
 
-b2# f  ex  dx   f
+b
+2# f  e
+x  d
+x   f
 b
 2# Qd Qe
 x    Qf
 x    Qd
-b2# d  cx  bx   d
-b2# b cx    dx    c
-b2# b  ax   Qdx   Qc
-b2# d ax    bx    a
-b2#   a dx    dx    b
-b2#      ///ax   ax    Qd
-b2    c
+b
+2# d  c
+x  b
+x   d
+b
+2# b c
+x    d
+x    c
+b
+2# b  a
+x   Qd
+x   Qc
+b
+2# d a
+x    b
+x    a
+b
+2#   a d
+x    d
+x    b
+b
+2#      ///a
+x   a
+x    Qd
+b
+2    c
 2.   c  ///a
-4#   ax   c
+4#   a
+x   c
 b
 1   a
 Y      a
 b
 B
 
-{ }{51b. Volte Gothier sine quinta - 7F8Ef9D10C/GB-Eu Coll.2073, f. 272v}B
+{ }
+{51b. Volte Gothier sine quinta - 7F8Ef9D10C/GB-Eu Coll.2073, f. 272v}
+B
 b
 S3
-3#   dx   c
-2#   ax  d
-b2#  b   /ax  dx   d  a
-b2    f
+3#   d
+x   c
+2#   a
+x  d
+b
+2#  b   /a
+x  d
+x   d  a
+b
+2    f
 2.   ca
-4#   ax   c
+4#   a
+x   c
 b
-2#   ax      ax   a
+2#   a
+x      a
+x   a
 b
-3#  bx  dx  bx   dx   cx   a
+3#  b
+x  d
+x  b
+x   d
+x   c
+x   a
 b
-2#  bcdx      /ax  d
+2#  bcd
+x      /a
+x  d
 b
 2.  ea
-3#  dx  bx   c
+3#  d
+x  b
+x   c
 b
-2#  ddx     bx  dd
-b2#     ax  bcx c
+2#  dd
+x     b
+x  dd
+b
+2#     a
+x  bc
+x c
 b
 
-b2# ddax      ax      /a
-b2#      //ax  dx  b
-b2#      ///ax gdx f f
-b2 d d
+b
+2# dda
+x      a
+x      /a
+b
+2#      //a
+x  d
+x  b
+b
+2#      ///a
+x gd
+x f f
+b
+2 d d
 2. c ca
-4# ax c
+4# a
+x c
 b
-2# dx   ax      a
+2# d
+x   a
+x      a
 bb
-3#  dx   fx  dx  ex  gx  d
+3#  d
+x   f
+x  d
+x  e
+x  g
+x  d
 b
-2# dex   fx   d
-b2  bc
-3#   dx   cx   ax   c
+2# de
+x   f
+x   d
 b
-2# bddx   cx d a
+2  bc
+3#   d
+x   c
+x   a
+x   c
+b
+2# bdd
+x   c
+x d a
 b
 
-b2# f  ex  dx   f
+b
+2# f  e
+x  d
+x   f
 b
 2# d e
 x    f
 x    d
-b2# d  cx  bx   d
-b2# b cx    dx    c
-b2# b  ax   dx   c
-b2# d ax    bx    a
-b2#   a dx    dx    b
-b2#      ///ax   ax    Qd
-b2    c
+b
+2# d  c
+x  b
+x   d
+b
+2# b c
+x    d
+x    c
+b
+2# b  a
+x   d
+x   c
+b
+2# d a
+x    b
+x    a
+b
+2#   a d
+x    d
+x    b
+b
+2#      ///a
+x   a
+x    Qd
+b
+2    c
 2.   c  ///a
-4#   ax   c
+4#   a
+x   c
 b
 1   a
 Y      Qa
 b
 B
 
-{52a. Volte Gothier - 7F8Ef9D10Bf/CZ-Pnm G.IV.18, ff. 68v-69r}B
+{52a. Volte Gothier - 7F8Ef9D10Bf/CZ-Pnm G.IV.18, ff. 68v-69r}
+B
 b
 S3
-2#  bx   cx  de
-b2# affx     d
-3  gx  f
+2#  b
+x   c
+x  de
+b
+2# aff
+x     d
+3  g
+x  f
 b
 2.  d   a
-3# ax  b  ax  d
+3# a
+x  b  a
+x  d
 b
 1  a c
 2      //a
 b
 2. a
-3# cx ex a
+3# c
+x e
+x a
 b
-2#afx     axd
-b2#      //ax a
-4#  dx  bx  ax  b
+2#af
+x     a
+xd
 b
-2#   cx bx a a
+2#      //a
+x a
+4#  d
+x  b
+x  a
+x  b
+b
+2#   c
+x b
+x a a
 b
 
-b2#    dxabx  d
+b
+2#    d
+xab
+x  d
 b
 1 db   //a
 2 b    /a
-b2 a
-3#  dx      ax ax  d
 b
-2#  bx     dx dd  c
+2 a
+3#  d
+x      a
+x a
+x  d
+b
+2#  b
+x     d
+x dd  c
 b
 1adb  a
 2 c
-b2#c     ax   a
-3#dxf
+b
+2#c     a
+x   a
+3#d
+xf
 b
 2h  f
 2.f   f
-4# ixf
+4# i
+xf
 b
 2 i
 1      ///a
 bb
 
 bb
-2# ab  dx    ax    c
-b2#  bccax axa
-b2#      //ax db c
-3# b  dx a
+2# ab  d
+x    a
+x    c
+b
+2#  bcca
+x a
+xa
+b
+2#      //a
+x db c
+3# b  d
+x a
 b
 2  da
-3#      ax  bx  ax   a
-b3# ax bx d  cx  bx b  ax  a
+3#      a
+x  b
+x  a
+x   a
 b
-2# ab  dxaxce   c
-b2#df   ax      axf g   /a
+3# a
+x b
+x d  c
+x  b
+x b  a
+x  a
+b
+2# ab  d
+xa
+xce   c
+b
+2#df   a
+x      a
+xf g   /a
 b
 2.h     //a
 3 e
 2 f
 b
 
-b2#     dxf    cx e
-b2#d    ax fx  f
-b2# bx   c
-3#  bx  d
 b
-2# ax   cx   a
-b2#a b dx  d
-3#cxa
+2#     d
+xf    c
+x e
 b
-2# e    //ax  fx  d
-b2a b
+2#d    a
+x f
+x  f
+b
+2# b
+x   c
+3#  b
+x  d
+b
+2# a
+x   c
+x   a
+b
+2#a b d
+x  d
+3#c
+xa
+b
+2# e    //a
+x  f
+x  d
+b
+2a b
 2. e    //a
-4# cx e
+4# c
+x e
 b
-2# fx     ax   c
+2# f
+x     a
+x   c
 bb
-3#     dx ax  bx   ax  a cx  b
+3#     d
+x a
+x  b
+x   a
+x  a c
+x  b
 b
 
-b3#     ax  bx   cx ax  bxa
-b3#      //ax dx    cx  bx b  dx a
-b3#  dx   ax      ax  bx  ax   a
-b3# ax bx d  cx  bx b  ax  a
-b3#     dx axax  bxc    cx e
-b3#d    ax fx  fx      axh     /axf
-b3#hx      //ax hx ix ex f
+b
+3#     a
+x  b
+x   c
+x a
+x  b
+xa
+b
+3#      //a
+x d
+x    c
+x  b
+x b  d
+x a
+b
+3#  d
+x   a
+x      a
+x  b
+x  a
+x   a
+b
+3# a
+x b
+x d  c
+x  b
+x b  a
+x  a
+b
+3#     d
+x a
+xa
+x  b
+xc    c
+x e
+b
+3#d    a
+x f
+x  f
+x      a
+xh     /a
+xf
+b
+3#h
+x      //a
+x h
+x i
+x e
+x f
 b
 
-b3#cx     dx     cxfx cx e
-b3#     axdx fx  fx  dx  f
-b3# bx   cx ax bx  bx  d
-b3# ax      //ax  dx   bx    cx  b
-b3#   cx bx ax  axa   dxc
-b3#      //ax ex  fx  dx  bxa
-b3#  ax   c2.  a   //a
-4#   cx  a
 b
-2#   cx     a
+3#c
+x     d
+x     c
+xf
+x c
+x e
+b
+3#     a
+xd
+x f
+x  f
+x  d
+x  f
+b
+3# b
+x   c
+x a
+x b
+x  b
+x  d
+b
+3# a
+x      //a
+x  d
+x   b
+x    c
+x  b
+b
+3#   c
+x b
+x a
+x  a
+xa   d
+xc
+b
+3#      //a
+x e
+x  f
+x  d
+x  b
+xa
+b
+3#  a
+x   c
+2.  a   //a
+4#   c
+x  a
+b
+2#   c
+x     a
 x    c
 b
 Yaacc
 b
 B
 
-{ }{52b. Volte - 7F8Ef9D10Bf/GB-Eu Coll.2073, ff. 270v-271r}B
+{ }
+{52b. Volte - 7F8Ef9D10Bf/GB-Eu Coll.2073, ff. 270v-271r}
+B
 b
 S3
-2#  bx   cx  de
-b2# affx     d
-3#  gx  f
+2#  b
+x   c
+x  de
+b
+2# aff
+x     d
+3#  g
+x  f
 b
 2.  d   a
-3# ax  b  ax  d
+3# a
+x  b  a
+x  d
 b
 1  a c
 2      //a
 b
 2. a
-3# cx ex a
+3# c
+x e
+x a
 b
-2#afx     axd
-b2#      //ax a
-4#  dx  bx  ax  b
+2#af
+x     a
+xd
 b
-2#   cx bx a a
+2#      //a
+x a
+4#  d
+x  b
+x  a
+x  b
+b
+2#   c
+x b
+x a a
 b
 
-b2#    dxabx  d
+b
+2#    d
+xab
+x  d
 b
 1 db   //a
 2 b    /a
-b2 a
-3#  dx      ax ax  d
 b
-2#  bx     dx dd  c
+2 a
+3#  d
+x      a
+x a
+x  d
+b
+2#  b
+x     d
+x dd  c
 b
 1aQdQb  a
 2 c
-b2#c b   ax   a
-3#dxf
+b
+2#c b   a
+x   a
+3#d
+xf
 b
 2h  f
 2.f   f
-4# ixf
+4# i
+xf
 b
 2# i
 x      ///a
@@ -18562,105 +34554,267 @@ x a
 b
 
 b
-2# ab  dx    ax  abc
-b2#  bccax axa
-b2#      //ax db c
-3# b  dx a
+2# ab  d
+x    a
+x  abc
+b
+2#  bcca
+x a
+xa
+b
+2#      //a
+x db c
+3# b  d
+x a
 b
 2  dd
-3#      ax  bx  ax   a
-b3# ax bx d  cx  bx b  ax  a
+3#      a
+x  b
+x  a
+x   a
 b
-2# ab  dxaxce   c
-b2#df   ax      axf g   /a
+3# a
+x b
+x d  c
+x  b
+x b  a
+x  a
+b
+2# ab  d
+xa
+xce   c
+b
+2#df   a
+x      a
+xf g   /a
 b
 2.h     //a
 3 e
 2 f
 b
 
-b2#     dxf    cx e
-b2#d    ax fx  f
-b2# bx   c
-3#  bx  d
 b
-2# ax   cx   a
-b2#a b dx  d
-3#cxa
+2#     d
+xf    c
+x e
 b
-2# e    //ax  fx  d
-b2a b
+2#d    a
+x f
+x  f
+b
+2# b
+x   c
+3#  b
+x  d
+b
+2# a
+x   c
+x   a
+b
+2#a b d
+x  d
+3#c
+xa
+b
+2# e    //a
+x  f
+x  d
+b
+2a b
 2. e    //a
-4# cx e
+4# c
+x e
 b
-2# fx     ax   c
+2# f
+x     a
+x   c
 b
 bQ
-3#     dx ax  bx   ax  a cx  b
+3#     d
+x a
+x  b
+x   a
+x  a c
+x  b
 b
 
-b3#     ax  bx   cx ax  bxa
-b3#      //ax dx    cx  bx b  dx a
-b3#  dx   ax      ax  bx  ax   a
-b3# ax bx d  cx  bx b  ax  a
-b3#     dx axax  bxc    cx e
-b3#d    ax fx  fx      axh     /axf
-b3#hx      //ax hx ix ex f
+b
+3#     a
+x  b
+x   c
+x a
+x  b
+xa
+b
+3#      //a
+x d
+x    c
+x  b
+x b  d
+x a
+b
+3#  d
+x   a
+x      a
+x  b
+x  a
+x   a
+b
+3# a
+x b
+x d  c
+x  b
+x b  a
+x  a
+b
+3#     d
+x a
+xa
+x  b
+xc    c
+x e
+b
+3#d    a
+x f
+x  f
+x      a
+xh     /a
+xf
+b
+3#h
+x      //a
+x h
+x i
+x e
+x f
 b
 
-b3#cx     dx     cxfx cx e
-b3#     axdx fx  fx  dx  f
-b3# bx   cx ax bx  bx  d
-b3# ax      //ax  dx   bx    cx  b
-b3#   cx bx ax  axa   dxc
-b3#      //ax ex  fx  dx  bxa
-b3#  ax   c2.  a   //a
-4#   cx  a
 b
-2#   cx     a
+3#c
+x     d
+x     c
+xf
+x c
+x e
+b
+3#     a
+xd
+x f
+x  f
+x  d
+x  f
+b
+3# b
+x   c
+x a
+x b
+x  b
+x  d
+b
+3# a
+x      //a
+x  d
+x   b
+x    c
+x  b
+b
+3#   c
+x b
+x a
+x  a
+xa   d
+xc
+b
+3#      //a
+x e
+x  f
+x  d
+x  b
+xa
+b
+3#  a
+x   c
+2.  a   //a
+4#   c
+x  a
+b
+2#   c
+x     a
 x    c
 b
 Yaac
 b
 B
 
-{ }{52c. Corante - 7F8Ef9D/RUS-SPan O No 124, f. 68v}B
+{ }
+{52c. Corante - 7F8Ef9D/RUS-SPan O No 124, f. 68v}
+B
 b
 S3
-2#  bx   cx  de
-b2 aff3#     d
-x  g2  f
+2#  b
+x   c
+x  de
+b
+2 aff
+3#     d
+x  g
+2  f
 b
 2.  da  a
-3# ax  bx  d
+3# a
+x  b
+x  d
 b
 1  a c
 2      //a
 b
 2. a
-3# cx ex a
+3# c
+x e
+x a
 b
-2#afx     axd
-b2 a    //a3#  dx  bx  ax  b
+2#af
+x     a
+xd
 b
-2#   cx bx a a
+2 a    //a
+3#  d
+x  b
+x  a
+x  b
+b
+2#   c
+x b
+x a a
 b
 
-b2#    dxabbx  d
+b
+2#    d
+xabb
+x  d
 b
 2#      //a
 x dd
 x bd   /a
-b2 a
-3#  dx      ax ax  d
 b
-2#  bx     dx dd  c
+2 a
+3#  d
+x      a
+x a
+x  d
+b
+2#  b
+x     d
+x dd  c
 b
 2#     a
 xadb
 x c
-b2cdd   a3#   a
-xd2f  a
+b
+2cdd   a
+3#   a
+xd
+2f  a
 b
 2h  f
 2.f   f
@@ -18672,39 +34826,80 @@ xddff
 bb
 
 bb
-2. ab  d3    a2  abc
-b2#  bc ax axa
-b2#      //ax db
-3# b    /ax a
+2. ab  d
+3    a
+2  abc
+b
+2#  bc a
+x a
+xa
+b
+2#      //a
+x db
+3# b    /a
+x a
 b
 2  d
-3#      ax  bx  ax   a
-b3# ax bx d  cx  bx b  ax  a
+3#      a
+x  b
+x  a
+x   a
 b
-2# ab  dxaxce   c
-b3#df   ax      axf     /a
+3# a
+x b
+x d  c
+x  b
+x b  a
+x  a
+b
+2# ab  d
+xa
+xce   c
+b
+3#df   a
+x      a
+xf     /a
 b
 2.h     //a
 3 e
 2a
 b
 
-b2#     dxf    cx e
-b2#df
-x     ax  f
-b2# bx   c
-3#  bx  d
 b
-2# ax   cx   a
-b2#a   dx  d
-3#cxa
+2#     d
+xf    c
+x e
 b
-2# e    //ax  fx  d
-b2a b
+2#df
+x     a
+x  f
+b
+2# b
+x   c
+3#  b
+x  d
+b
+2# a
+x   c
+x   a
+b
+2#a   d
+x  d
+3#c
+xa
+b
+2# e    //a
+x  f
+x  d
+b
+2a b
 2.  a   //a
-4#   cx  a
+4#   c
+x  a
 b
-2#   Qcx     aYaaccca
+2#   Qc
+x     a
+Yaaccca
 b
 B
 
@@ -18718,10 +34913,18 @@ b
 1ab  d
 2 d  c
 b
-3# b  ax ax bx dxaxb
+3# b  a
+x a
+x b
+x d
+xa
+xb
 b
 2da c
-3#axbxdxb
+3#a
+xb
+xd
+xb
 b
 1abb d
 2f
@@ -18729,56 +34932,107 @@ b
 2.ffg  f
 3h
 2i
-b2#hx fxf
-b2#d  cxbxab
+b
+2#h
+x f
+xf
+b
+2#d  c
+xb
+xab
 b
 2.bddQa
 3d
 2a - d
 b
 
-b2# d   dxax b  a
+b
+2# d   d
+xa
+x b  a
 b
 2     b
 2. a - d
 4#  d
 x a
 b
-2# bx    dx      /a
+2# b
+x    d
+x      /a
 b
 1 bb
 bXQ
 bXQ
 2a
 b
-3#a   dx dxaxbxax d
-b3# bx    ax bx dxaxb
-b3#dx   cxaxbxdxb
+3#a   d
+x d
+xa
+xb
+xa
+x d
 b
-2#ab  dx      /axf
+3# b
+x    a
+x b
+x d
+xa
+xb
+b
+3#d
+x   c
+xa
+xb
+xd
+xb
+b
+2#ab  d
+x      /a
+xf
 b
 
 b
 2.ffg  f
 3h
 2i
-b2#hx fxf
+b
+2#h
+x f
+xf
 b
 2.da c
 3b
 2a   d
 b
 3# d Qa
-xaxbxax dx b
-b3# a - dx  bx  dx ax b  ax d
-b3#ax b
-2. d   d
-4#ax d
+xa
+xb
+xa
+x d
+x b
 b
-2# bx    dx      /a
-b1Q bb
+3# a - d
+x  b
+x  d
+x a
+x b  a
+x d
+b
+3#a
+x b
+2. d   d
+4#a
+x d
+b
+2# b
+x    d
+x      /a
+b
+1Q bb
 bXQ
-bXQ3#ax d
+bXQ
+3#a
+x d
 b
 
 b
@@ -18786,55 +35040,106 @@ b
 3# a
 x b
 2  d
-b2 d  c
+b
+2 d  c
 3# b
 x d
 2 a   d
 b
 2.a - d
-4# dxa
+4# d
+xa
 2 b  a
-b2#b  ax axa - d
-b2# d   dx     bx     a
-b2#d  cx bxb  a
-b2a  -  /a
-3# dx bx a    ax b
-b3# dx b
+b
+2#b  a
+x a
+xa - d
+b
+2# d   d
+x     b
+x     a
+b
+2#d  c
+x b
+xb  a
+b
+2a  -  /a
+3# d
+x b
+x a    a
+x b
+b
+3# d
+x b
 2. a - a
-4#  dx a
+4#  d
+x a
 b
 
 b
-2#  dx    ax      ///a
-b2  dc
+2#  d
+x    a
+x      ///a
+b
+2  dc
 bXQ
 bXQ
-3#axbxax d
+3#a
+xb
+xa
+x d
 b
 2 bd a
-3# ax b
+3# a
+x b
 2  d
-b2 da c
-3# bx d2 a   d
+b
+2 da c
+3# b
+x d
+2 a   d
 b
 2.a - d
-4# dxa
+4# d
+xa
 2 b
 b
-3#bx      axdxb
+3#b
+x      a
+xd
+xb
 2a  -  /a
-b2# d   dx     bx     a
 b
-3#d  cxbxaxbxdxb
+2# d   d
+x     b
+x     a
+b
+3#d  c
+xb
+xa
+xb
+xd
+xb
 b
 
 -l "4 in"
-b3#ax      /ax dx bx a    ax b
-b3# dx b
-2. a - Qa
-4#  dx a
 b
-2#  dx    ax      ///a
+3#a
+x      /a
+x d
+x b
+x a    a
+x b
+b
+3# d
+x b
+2. a - Qa
+4#  d
+x a
+b
+2#  d
+x    a
+x      ///a
 b
 Y  dca
 b
@@ -18847,9 +35152,14 @@ BX
 bX
 S3
 2      ///a
-b1 bdc2      a
-b1 ddd2      ///a
-b1 bdc
+b
+1 bdc
+2      a
+b
+1 ddd
+2      ///a
+b
+1 bdc
 2     a
 b
 1 acc
@@ -18860,77 +35170,143 @@ b
 b
 1 dda
 2      ///a
-b2 bdc2. a   a
+b
+2 bdc
+2. a   a
 4#  d
 x a
 b
-2#  dx    ax      ///a
+2#  d
+x    a
+x      ///a
 b
 
 b
 1.  dc
-bb2# bx  dx   d
-b2# dx      a
-3# ax  d
-b
-2# b  ax  dc3# d
-x b
-b2# a   ax  Qb3#d
-xb
-b2#a     /ax bxf
-b2. ddd  a3#ax b  ax d
-b
-2# a   ax bdx ac
-b
-
-b2  dca1      ///a
 bb
-2#ax bx d
-b2b3#  dx d2a
-b2# bdx  bx  Qdd
+2# b
+x  d
+x   d
 b
-2#ad   ax b cxd
-b2#      /axdfg dxf
-b2#      axbdd3# bx d
+2# d
+x      a
+3# a
+x  d
 b
-2#adc  ax bdx acc
+2# b  a
+x  dc
+3# d
+x b
+b
+2# a   a
+x  Qb
+3#d
+xb
+b
+2#a     /a
+x b
+xf
+b
+2. ddd  a
+3#a
+x b  a
+x d
+b
+2# a   a
+x bd
+x ac
 b
 
 b
-2#  dx    ax      ///a
+2  dca
+1      ///a
+bb
+2#a
+x b
+x d
+b
+2b
+3#  d
+x d
+2a
+b
+2# bd
+x  b
+x  Qdd
+b
+2#ad   a
+x b c
+xd
+b
+2#      /a
+xdfg d
+xf
+b
+2#      a
+xbdd
+3# b
+x d
+b
+2#adc  a
+x bd
+x acc
+b
+
+b
+2#  d
+x    a
+x      ///a
 bb
 2.a
-3# bx dxa
-b3#bx  dx d
+3# b
+x d
+xa
+b
+3#b
+x  d
+x d
 xa
 x  c
 x d
-b3#  dx b
+b
+3#  d
+x b
 x  b
-x   dx  d
+x   d
+x  d
 x d
 b
-3#     ax dxa
+3#     a
+x d
+xa
 x   c
 x b
 xd
-b3#      /axdx    d
+b
+3#      /a
+xd
+x    d
 x f
 x  g
 x f
 b
 3#      a
 x  g
-x  ixfxh
+x  i
+xf
+xh
 xf
 b
-3#f     axex f
+3#f     a
+xe
+x f
 xi
 xh    a
 xh
 b
 
-b2#f
+b
+2#f
 x    a
 x      ///a
 bb
@@ -18940,90 +35316,242 @@ b
 2      a
 1bdda
 b
-2#    axabd
-3#fx  d
+2#    a
+xabd
+3#f
+x  d
 b
-2#     axdx      a
-b2#      /axifxh
-b2#      axfgx  i
+2#     a
+xd
+x      a
 b
-3#hxf
+2#      /a
+xif
+xh
+b
+2#      a
+xfg
+x  i
+b
+3#h
+xf
 2.ea   a
-4#cxe
+4#c
+xe
 b
-2#fx    ax      ///a
+2#f
+x    a
+x      ///a
 bb
 
-bb2#    a
-x    cx   cd
-b2#   df ax  dx d
-b2#      ///ax bdca
-3#   cx   a
+bb
+2#    a
+x    c
+x   cd
 b
-2# ad  ax  bcx b
+2#   df a
+x  d
+x d
+b
+2#      ///a
+x bdca
+3#   c
+x   a
+b
+2# ad  a
+x  bc
+x b
 b
 2.  bdd /a
-3#    dx   cx  d
+3#    d
+x   c
+x  d
 b
 2.      a
-3# b dx ax  d
+3# b d
+x a
+x  d
 b
-2#     ax  dcax  c c
-b2#  dx    ax      ///a
+2#     a
+x  dca
+x  c c
+b
+2#  d
+x    a
+x      ///a
 bb
 
 bb
-3#    ax    cx    dx   ax   cx    d
-b3#      ax   dx    ax  dx ax  d
-b3#      ///ax  dx   dx bx   cx   a
-b3#     Qax  dx ax   cx  bx b
-b3#      /ax   dx    dx  bx   cx  d
-b3#      ax   dx  dx bx ax  d
-b3#     ax  cx   ax    dx  dx  c Qc
+3#    a
+x    c
+x    d
+x   a
+x   c
+x    d
 b
-2#  dx    ax      ///a
+3#      a
+x   d
+x    a
+x  d
+x a
+x  d
+b
+3#      ///a
+x  d
+x   d
+x b
+x   c
+x   a
+b
+3#     Qa
+x  d
+x a
+x   c
+x  b
+x b
+b
+3#      /a
+x   d
+x    d
+x  b
+x   c
+x  d
+b
+3#      a
+x   d
+x  d
+x b
+x a
+x  d
+b
+3#     a
+x  c
+x   a
+x    d
+x  d
+x  c Qc
+b
+2#  d
+x    a
+x      ///a
 bb
 
-bb2#fxhx i
-b2#ix     ax      a
-b2#ai    /axfg    a
-3#fxh
-b
-2#e    ax fx d
-b2#      ///axffgxdd    //a
-b2#      /axabbxbdd   a
-b2# bx a   ax   c
-b2#  dx    ax      ///a
 bb
-4#fxdxbxa
+2#f
+xh
+x i
+b
+2#i
+x     a
+x      a
+b
+2#ai    /a
+xfg    a
+3#f
+xh
+b
+2#e    a
+x f
+x d
+b
+2#      ///a
+xffg
+xdd    //a
+b
+2#      /a
+xabb
+xbdd   a
+b
+2# b
+x a   a
+x   c
+b
+2#  d
+x    a
+x      ///a
+bb
+4#f
+xd
+xb
+xa
 4# Qd
-x-Qaxbx  d4#ax  bx   dxa
+x-Qa
+xb
+x  d
+4#a
+x  b
+x   d
+xa
 b
 
-b4# dx b
+b
+4# d
+x b
 x Qa
-x Qb4# dx bx dx b4# ax bx  dx d
+x Qb
+4# d
+x b
+x d
+x b
+4# a
+x b
+x  d
+x d
 b
-3#     ax  dx bx  cx  dx a
+3#     a
+x  d
+x b
+x  c
+x  d
+x a
 b
-4#   cx   ax    dx    c4#    dx    cx    ax    c4#    dx   ax   cx    d
+4#   c
+x   a
+x    d
+x    c
+4#    d
+x    c
+x    a
+x    c
+4#    d
+x   a
+x   c
+x    d
 b
-3#   dx    ax   cx     dx     bx  d
-b3#   ax a
+3#   d
+x    a
+x   c
+x     d
+x     b
+x  d
+b
+3#   a
+x a
 x  cc a
-4#    dx    cx    dx    cx    ax    c
+4#    d
+x    c
+x    d
+x    c
+x    a
+x    c
 b
 2    a
 Y      ///a
 b
 B
 
-{54b. Sarabanda de Gaultier - 7F8Ef10C/CZ-Pnm XIII.B.237, ff. 12r-12v}B
+{54b. Sarabanda de Gaultier - 7F8Ef10C/CZ-Pnm XIII.B.237, ff. 12r-12v}
+B
 b
 S3
-2Q      ///a1Q bQdQc
-b2Q      a1Q dQdd
-b2Q      ///a1Q bQdQcQ
+2Q      ///a
+1Q bQdQc
+b
+2Q      a
+1Q dQdd
+b
+2Q      ///a
+1Q bQdQcQ
 b
 2Q     Qa
 1Q abc
@@ -19034,74 +35562,182 @@ b
 2      a
 1bdd
 b
-2#     ax bdx a
+2#     a
+x bd
+x a
 b
-2#    Qax  dcx      ///a
+2#    Qa
+x  dc
+x      ///a
 bb
 
-bb2#ax bx d
-b2#bx  d
-3# dcxa
+bb
+2#a
+x b
+x d
 b
-2# bdx  bx  dd
-b2#ad   ax b cxd
-b2#      /ax-Qdfg dxf
-b2#      axbdd3# bx d
+2#b
+x  d
+3# dc
+xa
 b
-2#adc  ax bdx a c
-b2#  d
-x    ax      ///a
+2# bd
+x  b
+x  dd
+b
+2#ad   a
+x b c
+xd
+b
+2#      /a
+x-Qdfg d
+xf
+b
+2#      a
+xbdd
+3# b
+x d
+b
+2#adc  a
+x bd
+x a c
+b
+2#  d
+x    a
+x      ///a
 b
 
 b
 2  d
-3#ax bx dxa
-b3#bx  dx dxax  cx d
-b3#  dx bx  bx   dx  dx d
+3#a
+x b
+x d
+xa
 b
-3#      ax dxax   Qcx bxd
-b3#      /axdx    dx fx  gx f
-b3#      ax  Qgx-Qixfx     axf
+3#b
+x  d
+x d
+xa
+x  c
+x d
+b
+3#  d
+x b
+x  b
+x   d
+x  d
+x d
+b
+3#      a
+x d
+xa
+x   Qc
+x b
+xd
+b
+3#      /a
+xd
+x    d
+x f
+x  g
+x f
+b
+3#      a
+x  Qg
+x-Qi
+xf
+x     a
+xf
 b
 3#f    a
 x    a
 x fQ
-x  gQxiQxhQ
+x  gQ
+xiQ
+xhQ
 b
-2#fcx    ax      ///a
+2#fc
+x    a
+x      ///a
 bb
 
 bb
-2#    ax    cx   cd
-b2#   df ax  dx d
-b2#      ///ax bd
-3#   cx   a
+2#    a
+x    c
+x   cd
 b
-2# ad  ax  bcx b
-b2#  bdd /ax   QcQdx  d
+2#   df a
+x  d
+x d
+b
+2#      ///a
+x bd
+3#   c
+x   a
+b
+2# ad  a
+x  bc
+x b
+b
+2#  bdd /a
+x   QcQd
+x  d
 b
 2.      a
-3# b dx ax  d
+3# b d
+x a
+x  d
 b
-2#     ax  dcdx  cac
-b2  dca
+2#     a
+x  dcd
+x  cac
+b
+2  dca
 1      ///a
 bb
 
 bb
-3#    ax    cx    dx   a
-x   Qcx    d
-b3#      a
-x   dx   ax  dx dx  d
+3#    a
+x    c
+x    d
+x   a
+x   Qc
+x    d
+b
+3#      a
+x   d
+x   a
+x  d
+x d
+x  d
 b
 3#      ///a
-x  Qdx   dx bx   cx   a
-b3#     ax  dx ax   cx  bx b
+x  Qd
+x   d
+x b
+x   c
+x   a
 b
-3#      /ax   dx    dx  b
-x   cx  d
+3#     a
+x  d
+x a
+x   c
+x  b
+x b
 b
-3#      ax   dx  dx bx ax  d
+3#      /a
+x   d
+x    d
+x  b
+x   c
+x  d
+b
+3#      a
+x   d
+x  d
+x b
+x a
+x  d
 b
 3#     Qa
 x   Qc
@@ -19109,7 +35745,8 @@ x   Qa
 x    Qd
 x  Qd
 x  Qc Qc
-b2Q  QdQcQa
+b
+2Q  QdQcQa
 Y      ///a
 b
 B
@@ -19120,9 +35757,14 @@ BX
 bX
 S3
 2      ///a
-b1 bdc2      a
-b1 ddd2      ///a
-b1 bdc
+b
+1 bdc
+2      a
+b
+1 ddd
+2      ///a
+b
+1 bdc
 2     a
 b
 1 acc
@@ -19133,46 +35775,95 @@ b
 b
 1 ddd
 2      ///a
-b2# bdcx a
+b
+2# bdc
+x a
 3.     a
 4 a.
 b
-2#  d ax      ///a
-x    abQ
-bQ
-
-bQ
-bQ
-2. bdc3#     dx     bx     a
-b2#      a
-x dda3    dx    c
-b
-2#    ax bdc3#     d
-x     c
-b2#     ax accx      a
-b2#      /axabbx a.
-b2#      ax ddx  f.
-b
-2 bd2. ac  a
-4#  dx a.
-b2#  d ax      ///a
+2#  d a
+x      ///a
 x    a
 bQ
 bQ
 
 bQ
 bQ
-1abd{3# dxa.}
-b2#bdda
-x      a3#ax d.
+2. bdc
+3#     d
+x     b
+x     a
 b
-3#ax    ax   c{x d.x bx d.}
+2#      a
+x dda
+3    d
+x    c
 b
-2#     ax acx      a
-b2#      /axafxf.
-b2#      axbddx b.
-b2#aac  ax  d dx  c c
-b2#  dcax      ///ax    a
+2#    a
+x bdc
+3#     d
+x     c
+b
+2#     a
+x acc
+x      a
+b
+2#      /a
+xabb
+x a.
+b
+2#      a
+x dd
+x  f.
+b
+2 bd
+2. ac  a
+4#  d
+x a.
+b
+2#  d a
+x      ///a
+x    a
+bQ
+bQ
+
+bQ
+bQ
+1abd{
+3# d
+xa.}
+b
+2#bdda
+x      a
+3#a
+x d.
+b
+3#a
+x    a
+x   c{
+x d.
+x b
+x d.}
+b
+2#     a
+x ac
+x      a
+b
+2#      /a
+xaf
+xf.
+b
+2#      a
+xbdd
+x b.
+b
+2#aac  a
+x  d d
+x  c c
+b
+2#  dca
+x      ///a
+x    a
 bQ
 bQ
 
@@ -19187,34 +35878,102 @@ b
 2.ffgh
 3h.
 2f
-b2#     axhf gx      a
-b2#      /axifxh.
-b2#      axfgixh.
-b2     a
-3# fxf.xex d.
-b2#f   ax      ///a
+b
+2#     a
+xhf g
+x      a
+b
+2#      /a
+xif
+xh.
+b
+2#      a
+xfgi
+xh.
+b
+2     a
+3# f
+xf.
+xe
+x d.
+b
+2#f   a
+x      ///a
 bXQ
-bXQ3#  dx a.x bx d.
+bXQ
+3#  d
+x a.
+x b
+x d.
 b
 
-b3#ax    ax bx a.x  dx  b.
-b3#      axb.x dxa.xbx d.
-b3#ax    ax bx a.x  dx b.
-b3# ax     ax  cx  d.x ax   c.
-b3#ax      /axdxb.xaxd.
-b3#b     ax   c.x   dx  b.x  dx a.
-b3# bx d.xax     ax  dx  c.
+b
+3#a
+x    a
+x b
+x a.
+x  d
+x  b.
+b
+3#      a
+xb.
+x d
+xa.
+xb
+x d.
+b
+3#a
+x    a
+x b
+x a.
+x  d
+x b.
+b
+3# a
+x     a
+x  c
+x  d.
+x a
+x   c.
+b
+3#a
+x      /a
+xd
+xb.
+xa
+xd.
+b
+3#b     a
+x   c.
+x   d
+x  b.
+x  d
+x a.
+b
+3# b
+x d.
+xa
+x     a
+x  d
+x  c.
 b
 1  dca
 Y      ///a
 b
 B
 
-p{54d. Courante a la Princesse - 7F8Ef9C/D-B Hove-1, ff. 29v-30r}B
-bS3
-1 bdc2      //a
-b1 ddd2      a
-b1 bdc
+p
+{54d. Courante a la Princesse - 7F8Ef9C/D-B Hove-1, ff. 29v-30r}
+B
+b
+S3
+1 bdc
+2      //a
+b
+1 ddd
+2      a
+b
+1 bdc
 2      //a
 b
 1 abc
@@ -19225,101 +35984,200 @@ b
 b
 1 ddd
 2      a
-b2 bdc1 acc a
 b
-1  dca2      //abQX
-bQX
-
-bQX
-bQX
-2# bx  dx   d
-b2# dx      a
-3# ax  d.
+2 bdc
+1 acc a
 b
-2# b  ax  d.3# d
-x b.
-b2# a   ax  b.3#d     a
-xb.
-b2#a     /ax bxf.
-b2# dda  axa.3# b  ax d.
-b
-2# a   ax bdx ac
-b1  dca2      //a
+1  dca
+2      //a
 bQX
 bQX
 
 bQX
 bQX
-1abb2      /a
+2# b
+x  d
+x   d
 b
-1bdd
-2      a
-b1abd2f   a
-b1dff  a2      /a
-b
-1dfg2      a
-b1bdd2a   a
-b2f2.ea   a4#cxe.
-b
-2#fx    a
-bXQ
-bXQ
-
-bQX
-bQX2a
+2# d
+x      a
+3# a
+x  d.
 b
 2# b  a
 x  d.
-3#fxd.
-b2#b     ax d.3#d  a
+3# d
+x b.
+b
+2# a   a
+x  b.
+3#d     a
 xb.
 b
-2#a   ax b
+2#a     /a
+x b
 xf.
 b
-1dff  a2a  -  /a
-b3#a   dxb.xd
+2# dda  a
+xa.
+3# b  a
+x d.
+b
+2# a   a
+x bd
+x ac
+b
+1  dca
+2      //a
+bQX
+bQX
+
+bQX
+bQX
+1abb
+2      /a
+b
+1bdd
+2      a
+b
+1abd
+2f   a
+b
+1dff  a
+2      /a
+b
+1dfg
+2      a
+b
+1bdd
+2a   a
+b
+2f
+2.ea   a
+4#c
+xe.
+b
+2#f
+x    a
+bXQ
+bXQ
+
+bQX
+bQX
+2a
+b
+2# b  a
+x  d.
+3#f
+xd.
+b
+2#b     a
+x d.
+3#d  a
+xb.
+b
+2#a   a
+x b
+xf.
+b
+1dff  a
+2a  -  /a
+b
+3#a   d
+xb.
+xd
 xf.
 2b  a
 b
 2b  -  a
 3#a
-xb.2a -- a
+xb.
+2a -- a
 b
-2f3#e -- axf.
+2f
+3#e -- a
+xf.
 xh
 xe
 b
 
-b2#f   a
+b
+2#f   a
 x      //a
 x    a
-bb2#   Qa
-x   Qcx  QcQd
-b2#   dfx  d.x d
-b2#      //ax bdd
-3#   cx   a
+bb
+2#   Qa
+x   Qc
+x  QcQd
 b
-2# ad  ax  bcx b.
+2#   df
+x  d.
+x d
+b
+2#      //a
+x bdd
+3#   c
+x   a
+b
+2# ad  a
+x  bc
+x b.
 b
 2#  bdd /a
-x   cdx  d.
+x   cd
+x  d.
 b
 2#      a
-x b d3# ax  d.
+x b d
+3# a
+x  d.
 b
-2#     ax  dcdx  cac
-b2#  dx    ax      //a
+2#     a
+x  dcd
+x  cac
+b
+2#  d
+x    a
+x      //a
 bQ
 bQ
 
 bQ
 bQ
-3#    ax    cx    dx   ax   cx    d
-b3#      ax   dx    ax   cx   dx  b.
-b3#      //ax  dx   dx bx   cx   a
-b3#      ax  d.x ax   cx  bx b.
-b3#      /ax   dx    dx  bx   cx  d.
+3#    a
+x    c
+x    d
+x   a
+x   c
+x    d
+b
+3#      a
+x   d
+x    a
+x   c
+x   d
+x  b.
+b
+3#      //a
+x  d
+x   d
+x b
+x   c
+x   a
+b
+3#      a
+x  d.
+x a
+x   c
+x  b
+x b.
+b
+3#      /a
+x   d
+x    d
+x  b
+x   c
+x  d.
 b
 3#      Qa
 x   Qd
@@ -19327,219 +36185,528 @@ x  Qd
 x Qb
 x Qa
 x  Qd
-b3#     ax   cx   ax    dx  d.x  c c
 b
-1  dcaY      //a
+3#     a
+x   c
+x   a
+x    d
+x  d.
+x  c c
+b
+1  dca
+Y      //a
 b
 B
 
 p
 {55a. Ballet Lepin - 7F8E10C AABB8/CZ-Pnm IV.G.18, ff. 130v-131r}
 B
-bSc2.  dca
-3#  d3# acc ax cx dxa
 b
-2# cdcax      ///a2 cdc
-3#  dx a
-b3# c   cx e
-2a    e2#a   ax e  c
-b2#aac  a
-x   c2aac3# d
-xab
+Sc
+2.  dca
+3#  d
+3# acc a
+x c
+x d
+xa
+b
+2# cdca
+x      ///a
+2 cdc
+3#  d
+x a
+b
+3# c   c
+x e
+2a    e
+2#a   a
+x e  c
+b
+2#aac  a
+x   c
+2aac
+3# d
+xa
+b
 2cdd   a
-3#   ax   c
+3#   a
+x   c
 2   e
-3#a cx d
+3#a c
+x d
 b
 2 cdca
-3#     ax      a
+3#     a
+x      a
 2      /a
-3# ax  d
+3# a
+x  d
 b
 
-b3#  c  ax   cx  d ex a3# c ax d
+b
+3#  c  a
+x   c
+x  d e
+x a
+3# c a
+x d
 x a   a
 x c
-b2#  dcax      ///a2  dc
+b
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
 3#  a
 x  c
 bX
-3#  dx     cx  cx  d3# ax     ex  dx a
-b
-3# c    ///ax     e
-x    a
-x    c3#    e
-x  cx  d
+3#  d
+x     c
+x  c
+x  d
+3# a
+x     e
+x  d
 x a
-b3# c    ///ax  dxax     e3#     cxa
+b
+3# c    ///a
+x     e
+x    a
+x    c
+3#    e
+x  c
+x  d
+x a
+b
+3# c    ///a
+x  d
+xa
+x     e
+3#     c
+xa
 x c
 x e
 b
 
 b
-3#aac  ax     ex    ax    c3#     ax cx dxa
-b3#cdd   ax    ex   ax   c3#   excxa cx d
-b3# c  ax     cx     ax      a3#      /ax cx ax  d
-b3#  c  ax   cx  d   /ax a3# c    ax dx a   ax c
+3#aac  a
+x     e
+x    a
+x    c
+3#     a
+x c
+x d
+xa
+b
+3#cdd   a
+x    e
+x   a
+x   c
+3#   e
+xc
+xa c
+x d
+b
+3# c  a
+x     c
+x     a
+x      a
+3#      /a
+x c
+x a
+x  d
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+x a   a
+x c
 bX
-2#  dcax      ///a
+2#  dca
+x      ///a
 2  dc
 bQ
 bQ
 3# a
-x cb
+x c
+b
 
 b
 1 da c
 2 c  a
-3# ax  d
+3# a
+x  d
 b
-2# ac  ax   c2 ac
-3#  dx a
-b3# c    ///ax  dxcx     e3#     cxax c
+2# ac  a
+x   c
+2 ac
+3#  d
+x a
+b
+3# c    ///a
+x  d
+xc
+x     e
+3#     c
+xa
+x c
 x e
-b2#aac  ax   c3#cdd   a
+b
+2#aac  a
+x   c
+3#cdd   a
 xe
 2f
 b
 2. d  c
-3c3#a   excx d  c
+3c
+3#a   e
+xc
+x d  c
 xa
-b2. c    ///a
-3 c3# a   ex cx  d  cx a
-b3#  c  ax   cx  d ex a3# c ax dx a   ax c
+b
+2. c    ///a
+3 c
+3# a   e
+x c
+x  d  c
+x a
+b
+3#  c  a
+x   c
+x  d e
+x a
+3# c a
+x d
+x a   a
+x c
 b
 
 b
-2#  dcax      ///a2  dc
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
-3# ax c
+3# a
+x c
 bX
-3# d  cx  cx  dx a3# c    ///ax  ax  cx  d
+3# d  c
+x  c
+x  d
+x a
+3# c    ///a
+x  a
+x  c
+x  d
 b
-3# ax     ax     ex    a3#    cx  cx  dx a
-b3# c    ///ax  dxax     e3#     cx cx ex  d
+3# a
+x     a
+x     e
+x    a
+3#    c
+x  c
+x  d
+x a
+b
+3# c    ///a
+x  d
+xa
+x     e
+3#     c
+x c
+x e
+x  d
 b
 
 b
-3#aac  ax cx dxa3#cdd   axexfxh
+3#aac  a
+x c
+x d
+xa
+3#cdd   a
+xe
+xf
+xh
 b
-3# d  cxaxc  axe3#a   excx d  cxa
-b3# c    ///ax dxax c3# a   ex cx  d  cx a
-b3#  c  axaxc     /axe3#f     ax cx ax     a
+3# d  c
+xa
+xc  a
+xe
+3#a   e
+xc
+x d  c
+xa
 b
-2#  dcax      ///aY  dc
+3# c    ///a
+x d
+xa
+x c
+3# a   e
+x c
+x  d  c
+x a
+b
+3#  c  a
+xa
+xc     /a
+xe
+3#f     a
+x c
+x a
+x     a
+b
+2#  dca
+x      ///a
+Y  dc
 b
 B
 
-p{55b. Ballet - 7F8E10C AA8BB9/D-B N 479, ff. 48v-49r}
+p
+{55b. Ballet - 7F8E10C AA8BB9/D-B N 479, ff. 48v-49r}
 BX
 bX
 Sc
 2   c
-b2  d a
+b
+2  d a
 3#      ///a
-x  d.x a   ax c.x dxa.
+x  d.
+x a   a
+x c.
+x d
+xa.
 b
 2# cd a:
-x   c2      ///a
-3#  d:x a.
-b3# c   c&{x e  }
-2a    e2#a:  ax e  c
-b2#aacc a&{x   c2aac
+x   c
+2      ///a
+3#  d:
+x a.
+b
+3# c   c&{
+x e  }
+2a    e
+2#a:  a
+x e  c
+b
+2#aacc a&{
+x   c
+2aac
 3# d:}
-xab
+xa
+b
 2cdd   a
-3#   ax   c
+3#   a
+x   c
 2   e:
-3#a c:x d.
+3#a c:
+x d.
 b
 2 cd a:
-3#     ax      a
+3#     a
+x      a
 2      /a
-3# a:   ax  d
+3# a:   a
+x  d
 b
 
-b3#  c  ax   c2  d e3# a:ax  d
+b
+3#  c  a
+x   c
+2  d e
+3# a:a
+x  d
 2  cc:
-bX2#  d a
-x   c2      ///a
+bX
+2#  d a
+x   c
+2      ///a
 bQ
-bQ3#  a
+bQ
+3#  a
 x  c
 b
-3#  dx    ax  c.
-x  d3# a:x     a&{x   cx d. }
-b3# c  ax  d.
+3#  d
+x    a
+x  c.
+x  d
+3# a:
+x     a&{
+x   c
+x d. }
+b
+3# c  a
+x  d.
 x c
-x d3#a:
-x   ax    e
+x d
+3#a:
+x   a
+x    e
 x    c
-b3# c  ax  dxax     e3#     c&{xa
+b
+3# c  a
+x  d
+xa
+x     e
+3#     c&{
+xa
 x e
 xc  }
 b
 
 b
-3#a:x    ax     ex     c3#     axa
-x cxdb
-3#c:x   ax   ax   c3#   ex   axa c:x d
-b3# cd a:x     c:x     a:x      a3#      /ax cx a:   ax  d
-b3#  c  ax   cx  d   /ax a3# c    ax dx a   ax c
+3#a:
+x    a
+x     e
+x     c
+3#     a
+xa
+x c
+xd
+b
+3#c:
+x   a
+x   a
+x   c
+3#   e
+x   a
+xa c:
+x d
+b
+3# cd a:
+x     c:
+x     a:
+x      a
+3#      /a
+x c
+x a:   a
+x  d
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+x a   a
+x c
 bX
-2#  d ax   c
+2#  d a
+x   c
 2      ///a
-bQbQ
+bQ
+bQ
 3# a:
-x cb
+x c
+b
 
 b
 2 da c&{
 3#  c
 x d }
 2 cd   /a
-3# a:   ax  d
+3# a:   a
+x  d
 b
-2 ac  a3#   c&+x  d.
-3# ax  c.
+2 ac  a
+3#   c&+
+x  d.
+3# a
+x  c.
 xa
 x d.
 b
-3# c  ax d.xax  c.3#  a:xax e {
+3# c  a
+x d.
+xa
+x  c.
+3#  a:
+xa
+x e {
 xc.}
-b0af   a
+b
+0af   a
 b
 2cdda
-3#      axa3#c
+3#      a
+xa
+3#c
 xe
 2f:
 b
 2. da c
-3c3#a   e{xc   }x d  c{
+3c
+3#a   e{
+xc   }
+x d  c{
 xa   }
-b2 cd a:
-3#      ///ax c3# a   e{x c   }x  d  c{
+b
+2 cd a:
+3#      ///a
+x c
+3# a   e{
+x c   }
+x  d  c{
 x a   }
 b
 
-b3#  c  ax   cx  d   /ax a3# c    ax dx a   ax c
-bX
-2#  d ax   c2      ///a
-bQ
-bQ
-3# a:x c
 b
-3# dx    cx  cx d3# c:x    ax  ax c.
-b3# a:x  cx   c&+x  d3# a:x     cx     e
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+x a   a
+x c
+bX
+2#  d a
+x   c
+2      ///a
+bQ
+bQ
+3# a:
+x c
+b
+3# d
+x    c
+x  c
+x d
+3# c:
+x    a
+x  a
+x c.
+b
+3# a:
+x  c
+x   c&+
+x  d
+3# a:
+x     c
+x     e
 x     a
-b3# c   cx exa    exe3#c:  axax e  c
+b
+3# c   c
+x e
+xa    e
+xe
+3#c:  a
+xa
+x e  c
 xc
 b
 
-b2aacc a3#   cx  d3# a:x  cx d
+b
+2aacc a
+3#   c
+x  d
+3# a:
+x  c
+x d
 xa
 b
 3#c  a
@@ -19550,89 +36717,209 @@ xe
 x  d
 x a
 x c
-b2. da c3a   e3#c  ax axa   ex d  cb3# c  ax  dx    ax    c3#    ex cx a:ax  d
-b3#  c  ax   cx  d   /ax a3# c    ax dx a   ax c
 b
-2#  d:ax   cY      ///a
+2. da c
+3a   e
+3#c  a
+x a
+xa   e
+x d  c
+b
+3# c  a
+x  d
+x    a
+x    c
+3#    e
+x c
+x a:a
+x  d
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+x a   a
+x c
+b
+2#  d:a
+x   c
+Y      ///a
 b
 B
 
-p{55c. Ballet - 7F8E9C AABB8/D-LEm II.6.15, pp. 310-311}
+p
+{55c. Ballet - 7F8E9C AABB8/D-LEm II.6.15, pp. 310-311}
 B
 b
-Sc2#  dca
-x  d3# a   ax cx dxa
+Sc
+2#  dca
+x  d
+3# a   a
+x c
+x d
+xa
 b
-2# cdcax      ///a2a
-3#  dx a
-b3# ca  cx e
-2Qaa   e3#cc  a
-xa2 e
-b2#aacc ax    Qc
-2aacc3# d
-xab
+2# cdca
+x      ///a
+2a
+3#  d
+x a
+b
+3# ca  c
+x e
+2Qaa   e
+3#cc  a
+xa
+2 e
+b
+2#aacc a
+x    Qc
+2aacc
+3# d
+xa
+b
 2Qcdd   Qa
-3#   ax   c
+3#   a
+x   c
 3#  a
 xc
-xaaccx d
+xaacc
+x d
 b
 3# cdca
-x     cx     Qa
+x     c
+x     Qa
 x      Qa
 3#      /a
 x c
-x ax  d
+x a
+x  d
 b
 
-b3#  c  ax   cx  d   /ax a3# c    Qax d
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    Qa
+x d
 2Q a   a
-b2#  dcax      ///a
-bbX2Q  dc
+b
+2#  dca
+x      ///a
+bbX
+2Q  dc
 3#  a
 x  Qc
 bb
-3#  dx     cx  cx  d3# ax     ex  dx a
-b3# c  ax     e
-x    a
-x    c3#    e
-x  cx  d
+3#  d
+x     c
+x  c
+x  d
+3# a
+x     e
+x  d
 x a
-b2Q c  a3#ax     e3#     cxa
+b
+3# c  a
+x     e
+x    a
+x    c
+3#    e
+x  c
+x  d
+x a
+b
+2Q c  a
+3#a
+x     e
+3#     c
+xa
 x c
 x e
 b
 
 b
-3#a    ax     ex    ax    c3#     ax cx dxa
+3#a    a
+x     e
+x    a
+x    c
+3#     a
+x c
+x d
+xa
 b
-3#c     Qax   ex   ax   c3#  axcxa cx d
-b3# cd ax     cx     ax      Qa3#      /ax cx ax  d
-b3#  c  ax   cx  d   /ax a3# c    Qax dx a   ax c
+3#c     Qa
+x   e
+x   a
+x   c
+3#  a
+xc
+xa c
+x d
+b
+3# cd a
+x     c
+x     a
+x      Qa
+3#      /a
+x c
+x a
+x  d
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    Qa
+x d
+x a   a
+x c
 bQ
-2#  dcax      ///a
+2#  dca
+x      ///a
 2Q  dc
 bbX
 3# a
-x cb
+x c
+b
 
 b
 2 da c
 3#a
 x d
 2 cdca
-3# ax  d
+3# a
+x  d
 b
-2# a   ax    c2aa c
-3#  dx a
-b3# c   cx exaa   exe3#cc  axax e  c
+2# a   a
+x    c
+2aa c
+3#  d
+x a
+b
+3# c   c
+x e
+xaa   e
+xe
+3#cc  a
 xa
-b2#aac  axa3#c  a
+x e  c
+xa
+b
+2#aac  a
+xa
+3#c  a
 xe
 2f a
 b
 2. da c
-3c3#a   excx da c
+3c
+3#a   e
+xc
+x da c
 xa
 b
 2 cdca
@@ -19657,31 +36944,75 @@ b
 2#  dca
 x      ///a
 2  dca
-bbX3# ax c
-b3# da cx  c
-x  d
-x a3# c  ax  a
+bbX
+3# a
+x c
+b
+3# da c
 x  c
 x  d
-b3# accx     ax     ex    a
+x a
+3# c  a
+x  a
+x  c
+x  d
+b
+3# acc
+x     a
+x     e
+x    a
 3#    c
 x  c
 x  d
 x a
 b
 3. c   c
-4 a3.aa   e
+4 a
+3.aa   e
 4e
-3.c   a4a
-3.aa  c4 e
+3.c   a
+4a
+3.aa  c
+4 e
 b
 
-b3#ax cx dxa3#c  axe2f a
-b3# da cxaxc  axe3#a   excx da cxa
-b3# c  ax  dxax c3# a   ex cx  d  cx a
-b3#  c  ax   cxc     /axe3#f     Qax c2ea   a
 b
-1fcd aY      ///a
+3#a
+x c
+x d
+xa
+3#c  a
+xe
+2f a
+b
+3# da c
+xa
+xc  a
+xe
+3#a   e
+xc
+x da c
+xa
+b
+3# c  a
+x  d
+xa
+x c
+3# a   e
+x c
+x  d  c
+x a
+b
+3#  c  a
+x   c
+xc     /a
+xe
+3#f     Qa
+x c
+2ea   a
+b
+1fcd a
+Y      ///a
 b
 B
 
@@ -19691,361 +37022,884 @@ BX
 bX
 Sc
 2   c
-b2  d a
-3#      ///ax  d3# a - ax cx dxa
 b
-2# cdx    a2      ///a
-3#ax d
-b3# c  ax d
-2a -- Qe2#a   ax e- c
-b2#aacx   c2     a
-3# dxa
+2  d a
+3#      ///a
+x  d
+3# a - a
+x c
+x d
+xa
+b
+2# cd
+x    a
+2      ///a
+3#a
+x d
+b
+3# c  a
+x d
+2a -- Qe
+2#a   a
+x e- c
+b
+2#aac
+x   c
+2     a
+3# d
+xa
 b
 2c  -  a
-3#   ax   c
+3#   a
+x   c
 2   e
-3#a cx d
+3#a c
+x d
 b
 2 cd a
-3#     ax      a
+3#     a
+x      a
 2 Qc -- /a
-3# a    Qax  d
+3# a    Qa
+x  d
 b
 
-b3#  cc ax   cx  d - /ax a3# c    ax d
+b
+3#  cc a
+x   c
+x  d - /a
+x a
+3# c    a
+x d
 2 a - a
-b2#  d ax      ///a1Q   c
+b
+2#  d a
+x      ///a
+1Q   c
 bb
-3#  d ax   cx  ax  c3#  dx cx a - axa
-b3# c  ax d
-2 c2  d
-3#ax d
-b3# c  ax dxa -- Qexe3#c - axa
+3#  d a
+x   c
+x  a
+x  c
+3#  d
+x c
+x a - a
+xa
+b
+3# c  a
+x d
+2 c
+2  d
+3#a
+x d
+b
+3# c  a
+x d
+xa -- Qe
+xe
+3#c - a
+xa
 2c - c
 b
 
 b
-3#a -- ax    cx    ex   b3#   cx dx dxa
+3#a -- a
+x    c
+x    e
+x   b
+3#   c
+x d
+x d
+xa
 b
-3#c --- ax   ax   ax   c3#   e  axaxax d
-b3# c  ax     ax     ax      a3#      /ax cx cx a
-b3#  dx      ax      ax      /a3#      //ax dxa cx d
+3#c --- a
+x   a
+x   a
+x   c
+3#   e  a
+xa
+xa
+x d
 b
-2# cdx    a2      ///a
+3# c  a
+x     a
+x     a
+x      a
+3#      /a
+x c
+x c
+x a
+b
+3#  d
+x      a
+x      a
+x      /a
+3#      //a
+x d
+xa c
+x d
+b
+2# cd
+x    a
+2      ///a
 bbX
-3# ax c
+3# a
+x c
 b
 
 b
 2 d  c
-3#ax d
+3#a
+x d
 2 cd a
-3# ax  d
+3# a
+x  d
 b
-2# acx   c2     a
-3#  dx a
+2# ac
+x   c
+2     a
+3#  d
+x a
 b
-3# c  ax exa -- exe3#c - axa2c - c
-b2#a    ax    c1   c
+3# c  a
+x e
+xa -- e
+xe
+3#c - a
+xa
+2c - c
+b
+2#a    a
+x    c
+1   c
 b
 2c --- a
-3# dxa3#cxd
+3# d
+xa
+3#c
+xd
 2f - a
-b2 d- c
-3#axc3#dxcxax d
+b
+2 d- c
+3#a
+xc
+3#d
+xc
+xa
+x d
 b
 
 -l "4 in"
-b2 c  a
-3#      ///ax      //a3#      /ax cx a -- ax  d
 b
-3#  cc ax   cx  d   /ax a3# c    ax d
+2 c  a
+3#      ///a
+x      //a
+3#      /a
+x c
+x a -- a
+x  d
+b
+3#  cc a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
 2 a - a
-b2#  dx    a
+b
+2#  d
+x    a
 Y      ///a
 b
 B
 
-p{55e. Balletto del Espina - 7F8E10C AABB8/D-Mbs 21646, ff. 74v-75r}B
+p
+{55e. Balletto del Espina - 7F8E10C AABB8/D-Mbs 21646, ff. 74v-75r}
+B
 b
-Sc2#  dca
-x  d3# acc ax cx dxa
+Sc
+2#  dca
+x  d
+3# acc a
+x c
+x d
+xa
 b
-2# cd ax      ///a2 cd
-3#  dx a
-b3# c   cx e
-2a    e2#a   ax e  c
-b2#aacc ax   c
-2aac3# d
-xab
+2# cd a
+x      ///a
+2 cd
+3#  d
+x a
+b
+3# c   c
+x e
+2a    e
+2#a   a
+x e  c
+b
+2#aacc a
+x   c
+2aac
+3# d
+xa
+b
 2cdd   a
-3#   ax   c
+3#   a
+x   c
 2   e
-3#a cx d
+3#a c
+x d
 b
 2 cd a
-3#     ax      a
+3#     a
+x      a
 2      /a
-3# a    ax  d
+3# a    a
+x  d
 b
 
-b3#  cc ax   cx  d ex a3# c ax d
+b
+3#  cc a
+x   c
+x  d e
+x a
+3# c a
+x d
 x acc a
 x c
-bX2#  dcax      ///a2  dc
+bX
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
 3#  a
 x  c
 b
-3#  dx     cx  cx  d3# ax     ex  dx a
-b3# cd ax     e
-x    a
-x    c3#    e
-x  cx  d
+3#  d
+x     c
+x  c
+x  d
+3# a
+x     e
+x  d
 x a
-b3# cd   ///ax  dxax     e3#     cxa
+b
+3# cd a
+x     e
+x    a
+x    c
+3#    e
+x  c
+x  d
+x a
+b
+3# cd   ///a
+x  d
+xa
+x     e
+3#     c
+xa
 x c
 x e
 b
 
 b
-3#aacc ax     ex    ax    c3#     ax cx dxa
+3#aacc a
+x     e
+x    a
+x    c
+3#     a
+x c
+x d
+xa
 b
-3#cdd   ax    ax   ax   c3#   excxa cx d
-b3# cd ax     cx     ax      a3#      /ax cx Qax  d
-b3#  cc ax   cx  d   /ax a3# c    ax dx acc ax c
+3#cdd   a
+x    a
+x   a
+x   c
+3#   e
+xc
+xa c
+x d
+b
+3# cd a
+x     c
+x     a
+x      a
+3#      /a
+x c
+x Qa
+x  d
+b
+3#  cc a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+x acc a
+x c
 bX
-2#  dcax      ///a
+2#  dca
+x      ///a
 2   dc
 bQ
 bQ
 3# a
-x cb
+x c
+b
 
 b
 2# dc c
 x cd a
 3# a   e
-x cx  d  c
+x c
+x  d  c
 x a
 b
-2#  cc ax   c2 ac
-3#  dx a
+2#  cc a
+x   c
+2 ac
+3#  d
+x a
 b
-3# c   cx e2a    a2#a   ax e  c
-b2# fx     a2cdd   a
+3# c   c
+x e
+2a    a
+2#a   a
+x e  c
+b
+2# f
+x     a
+2cdd   a
 3#e
 xf
 b
 2. da c
-3c3#axcx d
+3c
+3#a
+xc
+x d
 xa
-b2. cd a
-3 c3# a   ex cx  d  cx a
+b
+2. cd a
+3 c
+3# a   e
+x c
+x  d  c
+x a
 b
 
-b3#  cc ax   cx  dex a3# c ax dx acc ax c
-bX
-2#  dcax      ///a2  dc
-bQ
-bQ
-3# ax c
 b
-3# d  cx  cx  dx a3# cd   ///ax  ax  cx  d
+3#  cc a
+x   c
+x  de
+x a
+3# c a
+x d
+x acc a
+x c
+bX
+2#  dca
+x      ///a
+2  dc
+bQ
+bQ
+3# a
+x c
+b
+3# d  c
+x  c
+x  d
+x a
+3# cd   ///a
+x  a
+x  c
+x  d
 b
 3# ac
-x     ax     ex    a3#    cx  cx  dx a
-b3# cd   ///ax exa   exc3# e  cxa
+x     a
+x     e
+x    a
+3#    c
+x  c
+x  d
+x a
+b
+3# cd   ///a
+x e
+xa   e
+xc
+3# e  c
+xa
 xc
 xe
 b
 
-b3#aacc ax cx dxa3#cdd   axexfxh
-b3# d  cxaxc  axe3#a   excx d  cxa.
-b3# cd ax dxax c3# a   ex cx  d  cx a
-b3#  cc axaxc     /axe3#f     ax cx ax     a
 b
-2#  dcax      ///aY  dc
+3#aacc a
+x c
+x d
+xa
+3#cdd   a
+xe
+xf
+xh
 b
-Bp{55f. Palletto del Espina - 7F8E10C AABB8/D-Mbs 21646, f. 90v}
+3# d  c
+xa
+xc  a
+xe
+3#a   e
+xc
+x d  c
+xa.
+b
+3# cd a
+x d
+xa
+x c
+3# a   e
+x c
+x  d  c
+x a
+b
+3#  cc a
+xa
+xc     /a
+xe
+3#f     a
+x c
+x a
+x     a
+b
+2#  dca
+x      ///a
+Y  dc
+b
+B
+
+p
+{55f. Palletto del Espina - 7F8E10C AABB8/D-Mbs 21646, f. 90v}
 B
 b
-Sc2#  dca
-x  d3# acc ax cx dxa
+Sc
+2#  dca
+x  d
+3# acc a
+x c
+x d
+xa
 b
-2# cd ax      ///a2 cd
-3#  dx a
-b3# c   cx e
-2a    e2#a   ax e  c
-b2#aacc ax   c
-2aac3# d
-xab
+2# cd a
+x      ///a
+2 cd
+3#  d
+x a
+b
+3# c   c
+x e
+2a    e
+2#a   a
+x e  c
+b
+2#aacc a
+x   c
+2aac
+3# d
+xa
+b
 2cdd   a
-3#   ax   c
+3#   a
+x   c
 2   e
-3#a cx d
+3#a c
+x d
 b
 2 cd a
-3#     ax      a
+3#     a
+x      a
 2      /a
-3# a    ax  d
+3# a    a
+x  d
 b
 
-b3#  cc ax   cx  d ex a3# c ax d
+b
+3#  cc a
+x   c
+x  d e
+x a
+3# c a
+x d
 x acc a
 x c
-bX2#  dcax      ///a2  dc
+bX
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
 3#  a
 x  c
 b
-3#  dx     cx  cx  d3# ax     ex  dx a
-b3# cd ax     e
-x    a
-x    c3#    e
-x  cx  d
+3#  d
+x     c
+x  c
+x  d
+3# a
+x     e
+x  d
 x a
-b3# cd   ///ax  dxax     e3#     cxa
+b
+3# cd a
+x     e
+x    a
+x    c
+3#    e
+x  c
+x  d
+x a
+b
+3# cd   ///a
+x  d
+xa
+x     e
+3#     c
+xa
 x c
 x e
 b
 
 b
-3#aacc ax     ex    ax    c3#     ax cx dxa
+3#aacc a
+x     e
+x    a
+x    c
+3#     a
+x c
+x d
+xa
 b
-3#cdd   ax    ax   ax   c3#   excxa cx d
-b3# cd ax     cx     ax      a3#      /ax cx Qax  d
-b3#  cc ax   cx  d   /ax a3# c    ax dx acc ax c
+3#cdd   a
+x    a
+x   a
+x   c
+3#   e
+xc
+xa c
+x d
+b
+3# cd a
+x     c
+x     a
+x      a
+3#      /a
+x c
+x Qa
+x  d
+b
+3#  cc a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+x acc a
+x c
 bX
-2#  dcax      ///a
+2#  dca
+x      ///a
 2  dc
 bQ
 bQ
 3# a
-x cb
+x c
+b
 
 b
 2# dc c
 x cd a
 3# a   e
-x cx  d  c
+x c
+x  d  c
 x a
 b
-2#  cc ax   c2 ac
-3#  dx a
+2#  cc a
+x   c
+2 ac
+3#  d
+x a
 b
-3# c   cx e2a    e2#a   ax e  c
-b2# fx     a2cdd   a
+3# c   c
+x e
+2a    e
+2#a   a
+x e  c
+b
+2# f
+x     a
+2cdd   a
 3#e
 xf
 b
 2. da c
-3c3#axcx d
+3c
+3#a
+xc
+x d
 xa
-b2. cd a
-3 c3# a   ex cx  d  cx a
+b
+2. cd a
+3 c
+3# a   e
+x c
+x  d  c
+x a
 b
 
-b3#  cc ax   cx  dex a3# c ax dx acc ax c
 b
-2#  dcax      ///a2  dc
+3#  cc a
+x   c
+x  de
+x a
+3# c a
+x d
+x acc a
+x c
+b
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
-3# ax c
+3# a
+x c
 bX
-3# d  cx  cx  dx a3# cd   ///ax  ax  cx  d
+3# d  c
+x  c
+x  d
+x a
+3# cd   ///a
+x  a
+x  c
+x  d
 b
 3# ac
-x     ax     ex    a3#    cx  cx  dx a
-b3# cd   ///ax exa    exc3# e  cxa
+x     a
+x     e
+x    a
+3#    c
+x  c
+x  d
+x a
+b
+3# cd   ///a
+x e
+xa    e
+xc
+3# e  c
+xa
 xc
 xe
 b
 
-b3#aacc ax cx dxa3#cdd   axexfxh
 b
-3# d  cxaxc  axe3#a   excx d  cxa
-b3# cd ax dxax c3# a   ex cx  d  cx a
-b3#  cc axaxc     /axe3#fx c    ax ax     a
+3#aacc a
+x c
+x d
+xa
+3#cdd   a
+xe
+xf
+xh
 b
-2#  dcax      ///aY  dc
+3# d  c
+xa
+xc  a
+xe
+3#a   e
+xc
+x d  c
+xa
+b
+3# cd a
+x d
+xa
+x c
+3# a   e
+x c
+x  d  c
+x a
+b
+3#  cc a
+xa
+xc     /a
+xe
+3#f
+x c    a
+x a
+x     a
+b
+2#  dca
+x      ///a
+Y  dc
 b
 B
 
 p
-{55g. Ballet - 7F8E9C AB8/GB-Cu Nn.6.36, f. 27r ii}B
-b
-Sc
-2.  dca
-3  d3# acc ax cx dxa
-b
-2# cdx      //a2 cd
-3#  dx a
-b3# c  ax e
-2a -- e2#a   ax e  c
-b
-2#aac  ax   c2aac
-3# dxa
-b
-2Qcdd   a
-3#   ax   c
-2   e
-3#a cx d
-b
-2 cd a
-3#     ax      a
-2      /a
-3# a -- ax  d
-b
-
-b3#  c  ax   cx  d   /ax a3# c -- ax d
-x a - ax c
-b
-2#  dcax      //a2  dc
-bbX
-3# ax c
-b1 da c2 cd   /a
-3# a -- ax  d
-b2# ax     a2 acc
-3#  dx a
-b3# c  ax exa - exc3# e  c&{xaxcxe  }
-b
-
-b2#aac  ax   c3#cdd - axe2f
-bQ2. da c3a
-3#c  axcxa- cx d
-bQ
-2. cd   //a3 c3# a   ex cx  d  cx a
-bQ3#  c  ax   cx  a - /ax  c3#  d   ax a2  cc a
-bQ2  dcaY      //a
-b
-B
-
-p{55h. Ballet de Lepin - 7F8E10C AABB8/GB-Eu Coll.2073, ff. 34v-35v}
+{55g. Ballet - 7F8E9C AB8/GB-Cu Nn.6.36, f. 27r ii}
 B
 b
 Sc
 2.  dca
 3  d
-3# acc ax cx dxa
+3# acc a
+x c
+x d
+xa
+b
+2# cd
+x      //a
+2 cd
+3#  d
+x a
+b
+3# c  a
+x e
+2a -- e
+2#a   a
+x e  c
+b
+2#aac  a
+x   c
+2aac
+3# d
+xa
+b
+2Qcdd   a
+3#   a
+x   c
+2   e
+3#a c
+x d
+b
+2 cd a
+3#     a
+x      a
+2      /a
+3# a -- a
+x  d
+b
+
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c -- a
+x d
+x a - a
+x c
+b
+2#  dca
+x      //a
+2  dc
+bbX
+3# a
+x c
+b
+1 da c
+2 cd   /a
+3# a -- a
+x  d
+b
+2# a
+x     a
+2 acc
+3#  d
+x a
+b
+3# c  a
+x e
+xa - e
+xc
+3# e  c&{
+xa
+xc
+xe  }
+b
+
+b
+2#aac  a
+x   c
+3#cdd - a
+xe
+2f
+bQ
+2. da c
+3a
+3#c  a
+xc
+xa- c
+x d
+bQ
+2. cd   //a
+3 c
+3# a   e
+x c
+x  d  c
+x a
+bQ
+3#  c  a
+x   c
+x  a - /a
+x  c
+3#  d   a
+x a
+2  cc a
+bQ
+2  dca
+Y      //a
+b
+B
+
+p
+{55h. Ballet de Lepin - 7F8E10C AABB8/GB-Eu Coll.2073, ff. 34v-35v}
+B
+b
+Sc
+2.  dca
+3  d
+3# acc a
+x c
+x d
+xa
 b
 2# cdca
 x      ///a
 2 cdc
-3#  dx a
-b3# c   cx e
-2a    e2#a   ax e  c
-b2#aac  a
+3#  d
+x a
+b
+3# c   c
+x e
+2a    e
+2#a   a
+x e  c
+b
+2#aac  a
 x   c
-2aac3# d
+2aac
+3# d
 xa
 b
 2cdd   a
-3#   ax   c
+3#   a
+x   c
 2   e
-3#a cx d
+3#a c
+x d
 b
 2 cdca
 3#     a
@@ -20056,213 +37910,536 @@ x  d
 b
 
 b
-3#  c  ax   cx  d ex a3# c ax dx a   a
+3#  c  a
+x   c
+x  d e
+x a
+3# c a
+x d
+x a   a
 x c
 b
-2#  dcax      ///a2  dc
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
-3#  ax  c
-bX3#  dx     cx  cx  d3# ax     ex  dx a
-b3# cd   ///ax     ex    ax    c3#    ex  cx  dx a
-b3# cd   ///ax  dxax     e3#     cxax cx e
+3#  a
+x  c
+bX
+3#  d
+x     c
+x  c
+x  d
+3# a
+x     e
+x  d
+x a
+b
+3# cd   ///a
+x     e
+x    a
+x    c
+3#    e
+x  c
+x  d
+x a
+b
+3# cd   ///a
+x  d
+xa
+x     e
+3#     c
+xa
+x c
+x e
 b
 
-b3#aac  ax     ex    a
-x    c3#     ax cx dxa
-b3#cdd   a
-x    a
-x   ax   c3#  axcxa cx d
 b
-3# cd ax     cx     ax      a
-3#      /ax cx ax  d
-b3#  c  ax   cx  d   /ax a3# c    ax dx a   a
+3#aac  a
+x     e
+x    a
+x    c
+3#     a
+x c
+x d
+xa
+b
+3#cdd   a
+x    a
+x   a
+x   c
+3#  a
+xc
+xa c
+x d
+b
+3# cd a
+x     c
+x     a
+x      a
+3#      /a
+x c
+x a
+x  d
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+x a   a
 x c
 bX
-2#  dcax      ///a2  dc
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
-3# ax c
+3# a
+x c
 b
 
 b
 1 da c
 2 cd a
-3# ax  d
-b2# ac  ax   c2 ac
-3#ax d
-b3# c    ///ax  dxcx     e3#     c
-xax cx e
+3# a
+x  d
+b
+2# ac  a
+x   c
+2 ac
+3#a
+x d
+b
+3# c    ///a
+x  d
+xc
+x     e
+3#     c
+xa
+x c
+x e
 b
 2#aac  a
-x   c3#c     a
+x   c
+3#c     a
 xe
 2f
-b2. d  c
-3c3#a   excx d  cxa
-bx
+b
+2. d  c
+3c
+3#a   e
+xc
+x d  c
+xa
+b
+x
 2. cd   ///a
-3 c3# a   ex cx  d  cx a
+3 c
+3# a   e
+x c
+x  d  c
+x a
 b
 
-b3#  c  ax   cx  d e
-x a3# c ax dx a   a
-x cbX
-2#  dcax      ///a2  dc
+b
+3#  c  a
+x   c
+x  d e
+x a
+3# c a
+x d
+x a   a
+x c
+bX
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
-3# ax c
-b3# d  cx  cx  dx a3# cd   ///ax  ax  cx  d
+3# a
+x c
+b
+3# d  c
+x  c
+x  d
+x a
+3# cd   ///a
+x  a
+x  c
+x  d
 b
 3# a
-x     ax     ex    a3#    cx  cx  dx a
-b3# cd   ///ax  dxa
-x     e3#     cx cx e
+x     a
+x     e
+x    a
+3#    c
+x  c
+x  d
+x a
+b
+3# cd   ///a
+x  d
+xa
+x     e
+3#     c
+x c
+x e
 x  d
 b
 
-b3#aac  ax cx dxa3#c     axexfxh
-b3# d  cxa
-xc  axe3#a   excx d  cxa
-b3# cd   ///ax dxax c3# a   ex cx  d  cx a
-b3#  c  axaxc     /axe3#f     ax c
+b
+3#aac  a
+x c
+x d
+xa
+3#c     a
+xe
+xf
+xh
+b
+3# d  c
+xa
+xc  a
+xe
+3#a   e
+xc
+x d  c
+xa
+b
+3# cd   ///a
+x d
+xa
+x c
+3# a   e
+x c
+x  d  c
+x a
+b
+3#  c  a
+xa
+xc     /a
+xe
+3#f     a
+x c
 x a
 x     a
 b
 2#  dca
 x      ///a
-Y  dcb
+Y  dc
+b
 B
 
 p
 {55i. Untitled - 7F8E9D10C AABB8/PL-Kj Mus.40153, ff. 34v-35v}
 B
 b
-Sc2  dca
+Sc
+2  dca
 3#      ///a
-x  d.3# xa - ax c.x dxa.
+x  d.
+3# xa - a
+x c.
+x d
+xa.
 b
-2# cdcax      ///a2 cdc
-3#  dx a.
-b3# \1c  ax \4e
-2a -- \3e2#a - ax ea c
-b2#aac  a
-x   c2aac3# d
-xa.b
+2# cdca
+x      ///a
+2 cdc
+3#  d
+x a.
+b
+3# \1c  a
+x \4e
+2a -- \3e
+2#a - a
+x ea c
+b
+2#aac  a
+x   c
+2aac
+3# d
+xa.
+b
 2cdd   a
-3#   ax   c.
+3#   a
+x   c.
 2   e
-3#a cx \4d.
+3#a c
+x \4d.
 b
 2 cd
-3#     ax      a
+3#     a
+x      a
 2      /a
-3# xax  d.
+3# xa
+x  d.
 b
 
-b3#  c  ax   cx  d   /ax a3# \2c -- ax \4d.
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# \2c -- a
+x \4d.
 2 xa   a
-b2#  \4dcax      ///a2  dc
+b
+2#  \4dca
+x      ///a
+2  dc
 bb
 3#  a
 x  c
 bX
-3#  d  cx  a.x  cx  d.3# a - ax  c.x  dx a.
-b3# c  ax     e.
+3#  d  c
+x  a.
+x  c
+x  d.
+3# a - a
+x  c.
+x  d
+x a.
+b
+3# c  a
+x     e.
 x    a
-x    \1c.3#    e
-x  \1cx  d
+x    \1c.
+3#    e
+x  \1c
+x  d
 x a
-b3# c  ax  dxax     e3#     cxa
+b
+3# c  a
+x  d
+xa
+x     e
+3#     c
+xa
 x \1c
 x e
 b
 
 b
-3#a -- ax     ex    ax    \1c3#     ax c.x dxa.
-b3#c  -  ax    e.x   ax   c.3#   ex-\2c.xa \1cx \4d.
-b3# cdx     cx     ax      a3#      /ax c.x ax  d.
-b3#  c- ax   c.x  d - /ax a.3# c -- ax d.x xa - ax  \4d.
+3#a -- a
+x     e
+x    a
+x    \1c
+3#     a
+x c.
+x d
+xa.
+b
+3#c  -  a
+x    e.
+x   a
+x   c.
+3#   e
+x-\2c.
+xa \1c
+x \4d.
+b
+3# cd
+x     c
+x     a
+x      a
+3#      /a
+x c.
+x a
+x  d.
+b
+3#  c- a
+x   c.
+x  d - /a
+x a.
+3# c -- a
+x d.
+x xa - a
+x  \4d.
 bX
-2#  dcax      ///a
+2#  dca
+x      ///a
 2  dc
 bQ
 bQ
 3# a
-x cb
+x c
+b
 
 b
 2# da c
 x  c
 2 cd - /a
-3# xa -- ax  d.
+3# xa -- a
+x  d.
 b
-2# ac  ax   c2 ac
-3#  dx a.
-b3# \1c  ax e.2Qa -- e2#a - ax ea c
-b2#aac  ax   c3#c  -  a
+2# ac  a
+x   c
+2 ac
+3#  d
+x a.
+b
+3# \1c  a
+x e.
+2Qa -- e
+2#a - a
+x ea c
+b
+2#aac  a
+x   c
+3#c  -  a
 xe.
 2f
 b
 2. \4da   //a
-3c.3#a  -  /ax-\2cx d    //a
+3c.
+3#a  -  /a
+x-\2c
+x d    //a
 xa.
-b2 xc  a
+b
+2 xc  a
 3#      ///a
-x c.3# a - ax c.x  d  cx a.
+x c.
+3# a - a
+x c.
+x  d  c
+x a.
 b
 
-b3#  c  ax   c.x  d   /ax a.3# c -- ax d.x xa - ax  d.
 b
-2#  dcax      ///a2  dc
+3#  c  a
+x   c.
+x  d   /a
+x a.
+3# c -- a
+x d.
+x xa - a
+x  d.
+b
+2#  dca
+x      ///a
+2  dc
 bbX
 3# a
 x c.
 b
-3# d  cx  c.x  dx a.3# c -- ///ax  a.x  cx  d
+3# d  c
+x  c.
+x  d
+x a.
+3# c -- ///a
+x  a.
+x  c
+x  d
 b
-3# acx     ax     ex    a3#    cx  cx  dx a
-b3# \1c -- ///ax exaxc3# e  cxax-\1cx-\4e
+3# ac
+x     a
+x     e
+x    a
+3#    c
+x  c
+x  d
+x a
+b
+3# \1c -- ///a
+x e
+xa
+xc
+3# e  c
+xa
+x-\1c
+x-\4e
 b
 
-b3#a -- ax \1cx dxa3#\1c  -  axexfxh
-bQ3# \4d    //axaxcxd3#a  -  /ax\2cx d    //axa.
-b3# c  ax  d.x      ///ax \2c.3# a - ax c.x  d  cx a.
-b3#  c  axa.x-\1c  -  /ax-\3e3#\4f  -  ax c.x a - ax  d.
 b
-2#  dcax      ///aY  dc
+3#a -- a
+x \1c
+x d
+xa
+3#\1c  -  a
+xe
+xf
+xh
+bQ
+3# \4d    //a
+xa
+xc
+xd
+3#a  -  /a
+x\2c
+x d    //a
+xa.
+b
+3# c  a
+x  d.
+x      ///a
+x \2c.
+3# a - a
+x c.
+x  d  c
+x a.
+b
+3#  c  a
+xa.
+x-\1c  -  /a
+x-\3e
+3#\4f  -  a
+x c.
+x a - a
+x  d.
+b
+2#  dca
+x      ///a
+Y  dc
 b
 B
 
 p
-{55j. Ballet - 7F8E10C AABB8/RUS-Span O No 124, ff. 44v-45r}BX
+{55j. Ballet - 7F8E10C AABB8/RUS-Span O No 124, ff. 44v-45r}
+BX
 bX
 Sc
 2   c
 b
 2#  dca
 x      ///a
-3# a   ax cx dxa
+3# a   a
+x c
+x d
+xa
 b
 2# cdca
 x      ///a
 2af
-3#  dx a
-b3# c   cx e
-xa    exe3#c   a
-xaxaacc
+3#  d
+x a
+b
+3# c   c
+x e
+xa    e
+xe
+3#c   a
+xa
+xaacc
 x e
 b
-1aac  a3# a
+1aac  a
+3# a
 x c
 x d
 xa
 b
 2cdd   a
-3#   ax   c
+3#   a
+x   c
 3#  a
 xc
-xa cx d
+xa c
+x d
 b
 3# c  a
 x     c
@@ -20275,162 +38452,486 @@ x  d
 b
 
 b
-3#  c  ax   cx  d   /ax a3# c    ax d2 a   a
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+2 a   a
 b
-2#  d ax      ///a2  d
+2#  d a
+x      ///a
+2  d
 bbX
-3#  ax  c
-b3#  dx     cx  cx  d3# ax     ex  dx a
-b3# c  ax     ex    ax    c3#    ex  cx  dx a
-b3# c  ax  dxax     e3#c    cx ax cx e
+3#  a
+x  c
+b
+3#  d
+x     c
+x  c
+x  d
+3# a
+x     e
+x  d
+x a
+b
+3# c  a
+x     e
+x    a
+x    c
+3#    e
+x  c
+x  d
+x a
+b
+3# c  a
+x  d
+xa
+x     e
+3#c    c
+x a
+x c
+x e
 b
 
-b3#a    ax     ex    a
-x    c3#     ax cx dxa
-b2cdd   a
-3#   ax   c3#  axcxa cx d
 b
-3# c  ax     cx     ax      a
-3#      /ax cx ax  d
-b3#  c  ax   cx  d   /ax a3# c    ax d2 a   a
+3#a    a
+x     e
+x    a
+x    c
+3#     a
+x c
+x d
+xa
 b
-2#  d ax      ///a2  d
+2cdd   a
+3#   a
+x   c
+3#  a
+xc
+xa c
+x d
+b
+3# c  a
+x     c
+x     a
+x      a
+3#      /a
+x c
+x a
+x  d
+b
+3#  c  a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+2 a   a
+b
+2#  d a
+x      ///a
+2  d
 bbX
-3# ax c
+3# a
+x c
 b
 
 b
 2# da c
 xa c
 2 cdca
-3# ax  d
-b2# ac  ax   c2a
-3#  dx a
-b3# c   cx exa    exe3#c  a
-xax caa cx e
+3# a
+x  d
 b
-1aac  a3#a
-xcxe
+2# ac  a
+x   c
+2a
+3#  d
+x a
+b
+3# c   c
+x e
+xa    e
+xe
+3#c  a
+xa
+x caa c
+x e
+b
+1aac  a
+3#a
+xc
+xe
 xf
-b2. da c
-3c3#a   excx d  cxa
+b
+2. da c
+3c
+3#a   e
+xc
+x d  c
+xa
 b
 2 cdca
 3#      ///a
-x c3# a   ex cx  d  cx a
+x c
+3# a   e
+x c
+x  d  c
+x a
 b
 
-b3#  c  ax   cx      /a
-x  d3# a    ax c2 a   ab
-2#  d ax      ///a2  d
+b
+3#  c  a
+x   c
+x      /a
+x  d
+3# a    a
+x c
+2 a   a
+b
+2#  d a
+x      ///a
+2  d
 bbX
-3# ax c
-b3# d  cx  cxax d3# c  ax    cx    ex   a
-b2aac  a3#     ex    a3#    cx  cx  dx  a
-b3# c   cx exa    e
-xe3#c   a
-xaxaa  cx e
+3# a
+x c
+b
+3# d  c
+x  c
+xa
+x d
+3# c  a
+x    c
+x    e
+x   a
+b
+2aac  a
+3#     e
+x    a
+3#    c
+x  c
+x  d
+x  a
+b
+3# c   c
+x e
+xa    e
+xe
+3#c   a
+xa
+xaa  c
+x e
 b
 
-b3#a    ax cx dxa3#c  axexf axh
-b3# da cxa
-xc  axe3#a   excx da cxa
-b3# c  ax  dxax c3# a   ex cx  da cx a
-b3#  c  ax   cxc     /axe3#f     a
-x c2ea   a
 b
-Y  dcab
+3#a    a
+x c
+x d
+xa
+3#c  a
+xe
+xf a
+xh
+b
+3# da c
+xa
+xc  a
+xe
+3#a   e
+xc
+x da c
+xa
+b
+3# c  a
+x  d
+xa
+x c
+3# a   e
+x c
+x  da c
+x a
+b
+3#  c  a
+x   c
+xc     /a
+xe
+3#f     a
+x c
+2ea   a
+b
+Y  dca
+b
 B
 
-p{55k. Ballet Lespin - 7F8E9D10C AABB8/S-S 253, ff. 110v-111v}B
+p
+{55k. Ballet Lespin - 7F8E9D10C AABB8/S-S 253, ff. 110v-111v}
+B
 b
 Sc
 2.  dca
-3  d3# acc ax cx dxa
+3  d
+3# acc a
+x c
+x d
+xa
 b
-2# cd ax      ///a2 cd
-3#  dx a
-b3# c   cx e
-xa    ax     e2#a   ax e  c
+2# cd a
+x      ///a
+2 cd
+3#  d
+x a
 b
-2#aacc ax   c2aac
-3# Qdxa
+3# c   c
+x e
+xa    a
+x     e
+2#a   a
+x e  c
+b
+2#aacc a
+x   c
+2aac
+3# Qd
+xa
 b
 2cdd
-3#   ax   c
+3#   a
+x   c
 2   e
-3#a cx d
+3#a c
+x d
 b
 2 cd a
-3#     ax      a
+3#     a
+x      a
 2      /a
-3# ax  d
+3# a
+x  d
 b
 
-b3#  cc ax   cx  d ex a3# c a
-x Qdx acc ax c
 b
-2#  dcax      ///a2  dc
+3#  cc a
+x   c
+x  d e
+x a
+3# c a
+x Qd
+x acc a
+x c
+b
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
-3#  ax  c
-bX3#  dx     cx  cx  d3# ax     ex  dx a
-b3# cd ax     ex    ax    c3#    ex  cx  dx a
-b3# cd   ///ax  dxax     e3#     cxax cx e
-b
-
-b3#aac  Qax     Qex    Qa
-x    Qc3#     Qax cx dxa
-b3#cdd   Qax    Qex   Qax   Qc3#   Qe
-xcxa cx d
-b
-3# cd Qax     Qcx     Qax      a
-3#      /ax cx ax  d
-b3#  cc ax   cx  Qd   /ax a3# Qc    Qax dx acc ax c
+3#  a
+x  c
 bX
-2#  dcax      ///a2  dc
+3#  d
+x     c
+x  c
+x  d
+3# a
+x     e
+x  d
+x a
+b
+3# cd a
+x     e
+x    a
+x    c
+3#    e
+x  c
+x  d
+x a
+b
+3# cd   ///a
+x  d
+xa
+x     e
+3#     c
+xa
+x c
+x e
+b
+
+b
+3#aac  Qa
+x     Qe
+x    Qa
+x    Qc
+3#     Qa
+x c
+x d
+xa
+b
+3#cdd   Qa
+x    Qe
+x   Qa
+x   Qc
+3#   Qe
+xc
+xa c
+x d
+b
+3# cd Qa
+x     Qc
+x     Qa
+x      a
+3#      /a
+x c
+x a
+x  d
+b
+3#  cc a
+x   c
+x  Qd   /a
+x a
+3# Qc    Qa
+x d
+x acc a
+x c
+bX
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
-3# ax c
+3# a
+x c
 b
 
 b
 1 da c
 2 cd a
-3# ax  d
-b2# acc ax   c2 ac
-3#  dx a
-b3# cd   ///ax Qdxax     e3#     cxax cx e
+3# a
+x  d
 b
-2#aacc ax   c
-3#cddQaxe
+2# acc a
+x   c
+2 ac
+3#  d
+x a
+b
+3# cd   ///a
+x Qd
+xa
+x     e
+3#     c
+xa
+x c
+x e
+b
+2#aacc a
+x   c
+3#cddQa
+xe
 2f
-b2 d  Qc
-3#cxa3#    excx Qd  Qcxa
+b
+2 d  Qc
+3#c
+xa
+3#    e
+xc
+x Qd  Qc
+xa
 b
 2 cd a
-3# cx a-3#     ex cx  d- cx a
+3# c
+x a-
+3#     e
+x c
+x  d- c
+x a
 b
 
-b3#  cc ax   cx  d   /ax a3# c    ax dx acc ax c
+b
+3#  cc a
+x   c
+x  d   /a
+x a
+3# c    a
+x d
+x acc a
+x c
 bX
-2#  dcax      ///a2  dc
+2#  dca
+x      ///a
+2  dc
 bQ
 bQ
-3# ax c
-b3# d  cx  dx ax c3#      ///ax  ax  cx  d
+3# a
+x c
 b
-3# acx     ax     ex    a3#    cx  cx  dx a
-b3# cd   ///ax exa    exc3# Qe  cxaxcxe
+3# d  c
+x  d
+x a
+x c
+3#      ///a
+x  a
+x  c
+x  d
+b
+3# ac
+x     a
+x     e
+x    a
+3#    c
+x  c
+x  d
+x a
+b
+3# cd   ///a
+x e
+xa    e
+xc
+3# Qe  c
+xa
+xc
+xe
 b
 
-b3#aacc ax cx dxa3#cdd   axexfxh
-b3# d- cxa
-xc- axe3#a   excx d  cxa
-b3# cd ax dxax c3# a   ex cx  d- cx a
-b3#  cc axaxc     /axe3#fx cx ax     a
+b
+3#aacc a
+x c
+x d
+xa
+3#cdd   a
+xe
+xf
+xh
+b
+3# d- c
+xa
+xc- a
+xe
+3#a   e
+xc
+x d  c
+xa
+b
+3# cd a
+x d
+xa
+x c
+3# a   e
+x c
+x  d- c
+x a
+b
+3#  cc a
+xa
+xc     /a
+xe
+3#f
+x c
+x a
+x     a
 bQ
-2#  dcax      ///a
+2#  dca
+x      ///a
 Y  dc
 b
 B
@@ -20442,47 +38943,81 @@ b1
 Sc
 2. dff  ///a
 3 b
-3# a   dx  b2a b d
-b2 dff3#axc3#d  cx    d2f  e
-b2h  f
-3#i     //axh3#f     /ax ixf     ax h
+3# a   d
+x  b
+2a b d
+b
+2 dff
+3#a
+xc
+3#d  c
+x    d
+2f  e
+b
+2h  f
+3#i     //a
+xh
+3#f     /a
+x i
+xf     a
+x h
 b
 2 i    ///a
-3#fxd
+3#f
+xd
 2cdd   a
-3#ax d
-b3# c   ax  d
+3#a
+x d
+b
+3# c   a
+x  d
 2 dd  c
 3#a    d
-xcxa   ax d
+xc
+xa   a
+x d
 b
 
 b
 2 dda  a
 3#    a
-x    c2 bb d
-3#     ax     c
+x    c
+2 bb d
+3#     a
+x     c
 b
 2 ab  d
-3#  dx   f3#  de  ax  fx  dx   e
+3#  d
+x   f
+3#  de  a
+x  f
+x  d
+x   e
 b
-2#   fx      ///a
+2#   f
+x      ///a
 2  ba
 bbX
 3.  a
 4  b
 b
-2#  dx      /a2      //a
+2#  d
+x      /a
+2      //a
 3.  bc
 4  d
 b
-2#  ffx      ///a2      /a
+2#  ff
+x      ///a
+2      /a
 3.  de
 4  f
 b
 
 b
-2#  gx    a2      a
+2#  g
+x    a
+2      a
 3. a
 4 b
 b
@@ -20490,67 +39025,202 @@ b
 x      //a
 2. f    /a
 3 d
-b3#a   dxcxd  cxa3#c  ax d
+b
+3#a   d
+xc
+xd  c
+xa
+3#c  a
+x d
 2d  Qc
-b2#f  ex-Qh  Qf3#f   fx ixfhx i
-b2# ix      ///a3Q  ba
+b
+2#f  e
+x-Qh  Qf
+3#f   f
+x i
+xfh
+x i
+b
+2# i
+x      ///a
+3Q  ba
 b2X
 bX
-4#   cx  a4#  bx  dx ax b
+4#   c
+x  a
+4#  b
+x  d
+x a
+x b
 b
 
 b
 2. dff  ///a
-3 b3# a   dx  bx    dxa b
-b3#      ///ax dffxaxc3#d  cx    dxf  ex    f
-b3h  f
-4#fxh4#i     //axhxfx i4#f     /ax ix hx f4# h    ax ixfx h
+3 b
+3# a   d
+x  b
+x    d
+xa b
+b
+3#      ///a
+x dff
+xa
+xc
+3#d  c
+x    d
+xf  e
+x    f
+b
+3h  f
+4#f
+xh
+4#i     //a
+xh
+xf
+x i
+4#f     /a
+x i
+x h
+x f
+4# h    a
+x i
+xf
+x h
 b
 2 i    ///a
-3#fxd
+3#f
+xd
 3cdd   a
-4#axc4#dxcxax d
+4#a
+xc
+4#d
+xc
+xa
+x d
 b
 
-b4# c   ax  dx ax c4# d   cx ax cx d4#a    dx dx cx a4# c  ax dxax c
 b
-3# dx      ax    ax    c3# b  dx      /ax     ax     c
+4# c   a
+x  d
+x a
+x c
+4# d   c
+x a
+x c
+x d
+4#a    d
+x d
+x c
+x a
+4# c  a
+x d
+xa
+x c
+b
+3# d
+x      a
+x    a
+x    c
+3# b  d
+x      /a
+x     a
+x     c
 b
 3 ab  d
-4#  dx a4# bx ax  dx  b4#  a   ax   cx  ax  b4#  ax  bx  dx a
+4#  d
+x a
+4# b
+x a
+x  d
+x  b
+4#  a   a
+x   c
+x  a
+x  b
+4#  a
+x  b
+x  d
+x a
 b
 
-b1      ///a3  ba
+b
+1      ///a
+3  ba
 bbX
-4#   ax   c4#  ax  bx  dx a
+4#   a
+x   c
+4#  a
+x  b
+x  d
+x a
 b
-2#  dx      /a3Q      //a
-4#   cx  a4#  bx  dx ax b
+2#  d
+x      /a
+3Q      //a
+4#   c
+x  a
+4#  b
+x  d
+x a
+x b
 b
-2# afx      ///a3Q      /a
-4#  dx  b4#  ax  bx  dx a
+2# af
+x      ///a
+3Q      /a
+4#  d
+x  b
+4#  a
+x  b
+x  d
+x a
 b
-2# bx    a3Q      a
-4#   cx  a4#  bx  dx ax b
+2# b
+x    a
+3Q      a
+4#   c
+x  a
+4#  b
+x  d
+x a
+x b
 b
 
 b
 2 d  c
-3#      //ax f
+3#      //a
+x f
 2. f    /a
 3 d
 b
-4#f   dx dxaxc4#a  cxcxdxa3#c  ax d
+4#f   d
+x d
+xa
+xc
+4#a  c
+xc
+xd
+xa
+3#c  a
+x d
 2d  c
-b2#f  exh  f
-3#f   fx ixfx i
+b
+2#f  e
+xh  f
+3#f   f
+x i
+xf
+x i
 b
 1. i    ///a
 2  ba
 b3
 b
 2. dff  ///a
-3 d3# f    /ax ix h    ax i
+3 d
+3# f    /a
+x i
+x h    a
+x i
 b
 1. i    ///a
 2 l
@@ -20559,64 +39229,116 @@ b
 b
 1. l  k
 2 i
-b2# hfx h2# f   fx  i
+b
+2# hf
+x h
+2# f   f
+x  i
 b
 1.  i   a
 2  g
 b
 1.  g   /a
 2  f
-b2  f   ///a3#  dx   f3#  de  ax  fx  dx   e
+b
+2  f   ///a
+3#  d
+x   f
+3#  de  a
+x  f
+x  d
+x   e
 b
 1   f
-3#      ///ax  ba
+3#      ///a
+x  ba
 bbX
-4#  ax  bx  dx  d
+4#  a
+x  b
+x  d
+x  d
 b
 
 b
-2#  d&+x      /a2      //a
-4#  cx  dx  fx  f
+2#  d&+
+x      /a
+2      //a
+4#  c
+x  d
+x  f
+x  f
 b
-2#  fx      ///a2      /a
-4#  dx  fx  gx  g
+2#  f
+x      ///a
+2      /a
+4#  d
+x  f
+x  g
+x  g
 b
-2#  g&+x    a2      a
-4# ax bx dx d
+2#  g&+
+x    a
+2      a
+4# a
+x b
+x d
+x d
 b
 2 d&+
-3#      //ax f
-2# f    /ax d
+3#      //a
+x f
+2# f    /a
+x d
 b
-3#a   dxcxd  cxa3#c  ax d
+3#a   d
+xc
+xd  c
+xa
+3#c  a
+x d
 2d  c
 b
 
-b2f  e
+b
+2f  e
 3.l   f
 4i
 3.h  f
 4h
-3#f   fx i
+3#f   f
+x i
 b
-2# ix      ///a
+2# i
+x      ///a
 1  ba
 b4
 b
 2. dff  ///a
-3 b3# abxdx b cx d e
+3 b
+3# ab
+xd
+x b c
+x d e
 b
-2#  ffx      ///a
+2#  ff
+x      ///a
 1  g   /a
 b
 2.  i   //a
-3 f3#      /ax hx      axf
+3 f
+3#      /a
+x h
+x      a
+xf
 b
 
 b
 2 i    ///a
-4# hx i
-3 f2#  i   ax      /a
+4# h
+x i
+3 f
+2#  i   a
+x      /a
 b
 1.h     //a
 2 i   a
@@ -20624,57 +39346,119 @@ b
 1.i     /a
 2h
 b
-3# h    ax i2Q     d2 ab3#  d   ax   f
+3# h    a
+x i
+2Q     d
+2 ab
+3#  d   a
+x   f
 b
 1   f  ///a
 2.  ba
 bbX
-4#  ax  b
+4#  a
+x  b
 b
-3#  dx      ax      /ax      a3#      //ax  ax  bx  d
+3#  d
+x      a
+x      /a
+x      a
+3#      //a
+x  a
+x  b
+x  d
 b
 
-b3#  fx      ///ax     ax      a3#      /ax   fx  dx  f
 b
-3#  gx    a
-x      //ax      /a3#      ax  dx ax b
-b3# dx      //ax     ax      a3      /a
+3#  f
+x      ///a
+x     a
+x      a
+3#      /a
+x   f
+x  d
+x  f
+b
+3#  g
+x    a
+x      //a
+x      /a
+3#      a
+x  d
+x a
+x b
+b
+3# d
+x      //a
+x     a
+x      a
+3      /a
 2Q f
 3 h
 b
-3#      //ax ix      /axf
+3#      //a
+x i
+x      /a
+xf
 1 h    a
 b
 1.  i
 2     a
 b
 2.      //a
-3l3#ixhxf     /ax i
+3l
+3#i
+xh
+xf     /a
+x i
 b
 1. i    ///a
 Y  ba
 b
 B
 
-p{56b. Untitled - 7F8Ef9D10C11Bf/US-RO V186S, p. 41}B
+p
+{56b. Untitled - 7F8Ef9D10C11Bf/US-RO V186S, p. 41}
+B
 b
 Sc
 2. dff  4
 3 b
-3# a&,   dx  b2Qa b d
-b2 dff  43#axc3#d  cx    d2f  e
-b2h  f
-3#i     //axh3#f     /ax ixf     ax h
+3# a&,   d
+x  b
+2Qa b d
+b
+2 dff  4
+3#a
+xc
+3#d  c
+x    d
+2f  e
+b
+2h  f
+3#i     //a
+xh
+3#f     /a
+x i
+xf     a
+x h
 b
 2 i    4
-3#fxd
+3#f
+xd
 3#c     a
-x ax     d
+x a
+x     d
 x d
-b3# c  ax  d
+b
+3# c  a
+x  d
 x d    a
 xa
-3#c  ax d3.a   a5 d
+3#c  a
+x d
+3.a   a
+5 d
 xa
 b
 
@@ -20682,30 +39466,44 @@ b
 3# d
 x      a
 x    a
-x    c3#    d
+x    c
+3#    d
 x b
-x     ax     c
+x     a
+x     c
 b
 3#     d
 x a
-x  dx   f3#  da  ax  fx  dx   e
+x  d
+x   f
+3#  da  a
+x  f
+x  d
+x   e
 b
-2#   fx      4
+2#   f
+x      4
 1 aba
 bb
 3#  a
 x  b
-2  xd2#      /ax      //a
+2  xd
+2#      /a
+x      //a
 b
 3#  b
 x  d
-2  f&+2#      ///ax      /a
+2  f&+
+2#      ///a
+x      /a
 b
 
 b
 3#  d
 x  f
-2  g&+2#    ax      a
+2  g&+
+2#    a
+x      a
 b
 3# a
 x b
@@ -20714,108 +39512,201 @@ x b
 xa
 x f&+    /a
 x d  c
-b3#a   dxcxd    axf
-3#c  ax d
+b
+3#a   d
+xc
+xd    a
+xf
+3#c  a
+x d
 2Qd  Qc
-b2#f  ex-Qh  Qf3#f     axhxf
+b
+2#f  e
+x-Qh  Qf
+3#f     a
+xh
+xf
 x h
-b2# i&+x      4Y aba
+b
+2# i&+
+x      4
+Y aba
 b
 B
 
-p{56c. Untitled -7F8Ef9D10C11Bf/RUS-SPan O No 124, ff. 71v-72r}B
+p
+{56c. Untitled -7F8Ef9D10C11Bf/RUS-SPan O No 124, ff. 71v-72r}
+B
 b
 Sc
 2. dff
 3 b
-3# a   dx  b2abb d
-b2 dff3#axc2#d  cxfd a
-b2h  f
-3#i     //axh3#f     /ax ixf     ax i
+3# a   d
+x  b
+2abb d
+b
+2 dff
+3#a
+xc
+2#d  c
+xfd a
+b
+2h  f
+3#i     //a
+xh
+3#f     /a
+x i
+xf     a
+x i
 b
 2 i    4
-3#fxd
+3#f
+xd
 2cd a
-3#ax d
-b2# c   ax d   c
-3#a    dxcxa   ax d
+3#a
+x d
+b
+2# c   a
+x d   c
+3#a    d
+xc
+xa   a
+x d
 b
 
 b
 2 daa
-3#    ax    c
+3#    a
+x    c
 2 bbcd
-3#     ax     c
+3#     a
+x     c
 b
 2 aba d
-3#  dx   f3#  dex  fx  dx   e
+3#  d
+x   f
+3#  de
+x  f
+x  d
+x   e
 b
-2#   fx      4
+2#   f
+x      4
 2  ba
 bbXX
 3#  a
 x  b
 b
-2#  dx      a2      /a
+2#  d
+x      a
+2      /a
 3#  bc
 x  d
 b
-2#  ffx      /a2      //a
+2#  ff
+x      /a
+2      //a
 3#  de
 x  f
 b
 
 b
-2#  g ax      //a2      ///a
+2#  g a
+x      //a
+2      ///a
 3# a f
 x b
 b
-2 d  c3#      //a
+2 d  c
+3#      //a
 x f
 2# f    /a
 x d  c
-b3#a   dxcxd  cxf3#c     ax d
+b
+3#a   d
+xc
+xd  c
+xf
+3#c     a
+x d
 2d  c
-b2f  e
+b
+2f  e
 3#l
 xi
-3#h  fxi
+3#h  f
+xi
 2f   f
-b2# i
-x     d2ddff
+b
+2# i
+x     d
+2ddff
 bbX
-4#  ax  bx  dx  d
+4#  a
+x  b
+x  d
+x  d
 b
 
 b
-2#  dx      a2      /a
-4#  bx  dx  fx  f
+2#  d
+x      a
+2      /a
+4#  b
+x  d
+x  f
+x  f
 b
-2#  fx      /a2      //a
-4#  dx  fx  gx  g
+2#  f
+x      /a
+2      //a
+4#  d
+x  f
+x  g
+x  g
 b
-2#  gx      //a2      ///a
-4# ax bx dx d
+2#  g
+x      //a
+2      ///a
+4# a
+x b
+x d
+x d
 b
 2 d
 3#      //a
 x f
-2# f    /ax d  c
+2# f    /a
+x d  c
 b
-3#a   dx dxaxc3#a  cxcxdxa
+3#a   d
+x d
+xa
+xc
+3#a  c
+xc
+xd
+xa
 b
 
 -l "4 in"
-b2#c  ax d
-2#dxf  e
 b
-3# dx bx a   dx a
+2#c  a
+x d
+2#d
+xf  e
+b
+3# d
+x b
+x a   d
+x a
 2.  d   a
 3   f
 b
 2   f
 Y      4
-bB
+b
+B
 
 p
 {56d. Balletto - Variatio - 7F8Ef9D10Bf/S-B PB fil 172, ff. 40v-41r}
@@ -20824,47 +39715,81 @@ b
 Sc
 2. dff  ///a
 3 b
-3# a - dx  b2a b d
-b2 d&+f&+f  ///a3#axc3#d  cx    d2Qf  e
-b2Qh  f
-3#i     //axh3#f  -  /ax ixf     ax i
+3# a - d
+x  b
+2a b d
+b
+2 d&+f&+f  ///a
+3#a
+xc
+3#d  c
+x    d
+2Qf  e
+b
+2Qh  f
+3#i     //a
+xh
+3#f  -  /a
+x i
+xf     a
+x i
 b
 2 i -- ///a
-3#fxd
+3#f
+xd
 2cdd - a
-3#ax d
-b3# c   ax  d
+3#a
+x d
+b
+3# c   a
+x  d
 2 dd  c
 3#a -- d
-xcxa   ax d
+xc
+xa   a
+x d
 b
 
 b
 2 dda  a
 3#    Qa
-x    Qc2 bb d
-3#     ax     c
+x    Qc
+2 bb d
+3#     a
+x     c
 b
 2 ab  d
-3#  dx   f3#  de  ax  fx  dx   e
+3#  d
+x   f
+3#  de  a
+x  f
+x  d
+x   e
 b
-2#   fx      ///a
+2#   f
+x      ///a
 2  ba
 bbX
 3#  a
 x  b
 b
-2#  dx      /a2      //a
+2#  d
+x      /a
+2      //a
 3#  bc
 x  d
 b
-2#  ffx      ///a2      /a
+2#  ff
+x      ///a
+2      /a
 3#  de
 x  f
 b
 
 b
-2#  gx    a2      a
+2#  g
+x    a
+2      a
 3# a
 x b
 b
@@ -20872,18 +39797,36 @@ b
 x      //a
 2.Q f    /a
 3 d
-b3#a   dxcxdxa3#c  ax d
+b
+3#a   d
+xc
+xd
+xa
+3#c  a
+x d
 2d  c
-b2#f  exh  f3#f   fx ixfx h
-b2# i
-x      ///a1Q  ba
+b
+2#f  e
+xh  f
+3#f   f
+x i
+xf
+x h
+b
+2# i
+x      ///a
+1Q  ba
 b
 B
 
 B
 b
 2. dff  ///a
-3 d3# f -- /ax ix h    ax i
+3 d
+3# f -- /a
+x i
+x h    a
+x i
 b
 1. i    ///a
 3#
@@ -20892,7 +39835,10 @@ b
 1@ l  k
 3# i
 x h -- a
-b2Q h1 f - a2  i
+b
+2Q h
+1 f - a
+2  i
 b
 1.  i
 2  g
@@ -20901,36 +39847,71 @@ b
 b
 1.  g   /a
 2  f
-b2  f   ///a3#  dx   f3#  de  ax  fx  dx   e
+b
+2  f   ///a
+3#  d
+x   f
+3#  de  a
+x  f
+x  d
+x   e
 b
 2#   f
-x      ///a2  ba
+x      ///a
+2  ba
 bbX
-4#  ax  bx  dx  d
+4#  a
+x  b
+x  d
+x  d
 b
-2#  dx      /a2      //a
-4#  bx  dx  fx  f
+2#  d
+x      /a
+2      //a
+4#  b
+x  d
+x  f
+x  f
 b
-2#  fx      ///a2      /a
-4#  dx  fx  gx  g
+2#  f
+x      ///a
+2      /a
+4#  d
+x  f
+x  g
+x  g
 b
 
 b
-2#  gx    a2      a
-4# ax bx dx d
+2#  g
+x    a
+2      a
+4# a
+x b
+x d
+x d
 b
 2 d
-3#      //ax f
-2. f -- /a3 f
+3#      //a
+x f
+2. f -- /a
+3 f
 b
-3#a   dxcxdxa3#c- ax d
+3#a   d
+xc
+xd
+xa
+3#c- a
+x d
 2Qd  c
-b2Qf  e
+b
+2Qf  e
 3#l
 xi
 3#h  f
 xh
-xf - fx i
+xf - f
+x i
 b
 2# i
 x      ///a
@@ -21234,14 +40215,20 @@ b
 B
 
 p
-{58. Sarabanden 1 - 7F8Ef9D10C/RUS-SPan O No 124, ff. 13v-14v}BX
+{58. Sarabanden 1 - 7F8Ef9D10C/RUS-SPan O No 124, ff. 13v-14v}
+BX
 bX
 S3
 2      ///a
-b1 bdc2      a
-b2# dda
-xax      ///a
-b1 bdc
+b
+1 bdc
+2      a
+b
+2# dda
+xa
+x      ///a
+b
+1 bdc
 2     a
 b
 2 b
@@ -21255,7 +40242,8 @@ bT
 3 d
 2. bdc
 3 b
-b2# a
+b
+2# a
 x     a
 x   c
 b
@@ -21268,34 +40256,65 @@ b
 b
 1 bdc
 2      //a
-b2#  dx  bx   d
-b2#a     /ax    d
+b
+2#  d
+x  b
+x   d
+b
+2#a     /a
+x    d
 x   c
 b
 1a b
 2 dd   a
-b2. da3a2     a
-b3# b  ax a2# bdx a   a
 b
-2#  dx      ///a
-xab
+2. da
+3a
+2     a
+b
+3# b  a
+x a
+2# bd
+x a   a
+b
+2#  d
+x      ///a
+xa
+b
 2#    a
 x bdc
 x      ///a
 b
 
-b2# bdc
-xax      ///a
 b
-2# dbxdx      /a
-b2#    dxa  cxd b
-b2#      ax dddaxa
+2# bdc
+xa
+x      ///a
+b
+2# db
+xd
+x      /a
+b
+2#    d
+xa  c
+xd b
+b
+2#      a
+x ddda
+xa
 b
 2.   c a
-3# dx b  ax a
-b2# bdx a   ax   c
+3# d
+x b  a
+x a
 b
-2#  dx    ax      ///a
+2# bd
+x a   a
+x   c
+b
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bXQ
@@ -21303,155 +40322,355 @@ bXQ
 2  d
 b
 
-b2#    ax    cx   cd
-b2#  bx   dfx     f
-b2#a   dx d   dx    f
-b2#     axf gxd
-b2#      ax-Qfgxh
-b2#i     /ax  gxa
-b2#f     ax g
-3#hxf
+b
+2#    a
+x    c
+x   cd
+b
+2#  b
+x   df
+x     f
+b
+2#a   d
+x d   d
+x    f
+b
+2#     a
+xf g
+xd
+b
+2#      a
+x-Qfg
+xh
+b
+2#i     /a
+x  g
+xa
+b
+2#f     a
+x g
+3#h
+xf
 b
 1e    a
 2 f
-b2# dxa g
-3#  fx  d
+b
+2# d
+xa g
+3#  f
+x  d
 b
 
 b
-2# dcx bdx    a
-b2#ax  b cx d d
-b2# bbcdx      /axd
-b2#      axb  ax  d
+2# dc
+x bd
+x    a
+b
+2#a
+x  b c
+x d d
+b
+2# bbcd
+x      /a
+xd
+b
+2#      a
+xb  a
+x  d
 b
 2.a c  a
-3# dx b cx a
-b2# bdx a   ax   c
-b2#  dx    ax      ///a
+3# d
+x b c
+x a
+b
+2# bd
+x a   a
+x   c
+b
+2#  d
+x    a
+x      ///a
 b
 1  dc
 bbX
-3#  gx d
+3#  g
+x d
 b
 
 b
-2# fx     fx d   Qe
-b2 b  a
-3# dx bx a   ax b
+2# f
+x     f
+x d   Qe
+b
+2 b  a
+3# d
+x b
+x a   a
+x b
 b
 2.  dddb
 3 a
 2 bbc a
-b2#  d   ax dx  b
-b2a     /a
-3#    Qdxcxdx   Qc
+b
+2#  d   a
+x d
+x  b
+b
+2a     /a
+3#    Qd
+xc
+xd
+x   Qc
 b
 2f   a
 2.e    a
-4#cxe
+4#c
+xe
 b
 2f
-3#    axh
+3#    a
+xh
 2i
 b
-2#h    ex fxf   a
+2#h    e
+x f
+xf   a
 b
 
-b2#dx     ax f
 b
-3#f   aQxd
-2#c   cx  f
-b2# fx     ax   c
+2#d
+x     a
+x f
+b
+3#f   aQ
+xd
+2#c   c
+x  f
+b
+2# f
+x     a
+x   c
 b
 1aac
 bXQ
 bXQ
-3#  gx d
+3#  g
+x d
 b
-2# fx     f
-3# d   exa
-b3# b  ax  dx ax bx a   ax b
-b3#  d  bx    cx    ax    cx  b  ax    d
-b3#      ax  bx  dx ax bx d
+2# f
+x     f
+3# d   e
+xa
+b
+3# b  a
+x  d
+x a
+x b
+x a   a
+x b
+b
+3#  d  b
+x    c
+x    a
+x    c
+x  b  a
+x    d
+b
+3#      a
+x  b
+x  d
+x a
+x b
+x d
 b
 
 b
 2.a     /a
-3#cxd   dx    b
+3#c
+xd   d
+x    b
 b
 2f   a
 2.e    a
-4#cxe
+4#c
+xe
 b
 2f
-3#    axhxixf
-b3#Qh    ex fx ax  ix  g Qaxf
-b3#  f  axdx  gxaxfx    a
-b3#    cxdx      ///axdxcx  f
+3#    a
+xh
+xi
+xf
 b
-2# fx     ax   c
+3#Qh    e
+x f
+x a
+x  i
+x  g Qa
+xf
+b
+3#  f  a
+xd
+x  g
+xa
+xf
+x    a
+b
+3#    c
+xd
+x      ///a
+xd
+xc
+x  f
+b
+2# f
+x     a
+x   c
 b
 2.aac
 bXQ
 bXQ
-3#axcxe
+3#a
+xc
+xe
 b
 
 b
-2#f   ax   hxffg
-b2 i   a
-3#f     axhxfxh
+2#f   a
+x   h
+xffg
+b
+2 i   a
+3#f     a
+xh
+xf
+xh
 b
 2.i     /a
-3#fxdx g
+3#f
+xd
+x g
 b
-2# f  dx d   dx  f
-b2 b  a
-3#  dx ax bx d
+2# f  d
+x d   d
+x  f
 b
-2#a   dxf     Qdx d
+2 b  a
+3#  d
+x a
+x b
+x d
+b
+2#a   d
+xf     Qd
+x d
 b
 2.e    a
-3#fxexc
+3#f
+xe
+xc
 b
-2# fx    d
-3# d ax b
+2# f
+x    d
+3# d a
+x b
 b
 
 b
 2 a c
-3#     ax  dx  cx d
+3#     a
+x  d
+x  c
+x d
 b
 2 bd
-3#     ax bx ax   c
+3#     a
+x b
+x a
+x   c
 b
-2#  dx    a
+2#  d
+x    a
 x      ///a
 b
 2.  dc
 bXQ
 bXQ
-3#axcxe
-b3#f   ax   hx  gx  Qix fx h
-b3# i   ax  fx  gx ixf     aQxh
+3#a
+xc
+xe
+b
+3#f   a
+x   h
+x  g
+x  Qi
+x f
+x h
+b
+3# i   a
+x  f
+x  g
+x i
+xf     aQ
+xh
 b
 2.i     /a
-3#fxdx g
-b3# f  dxdx gx fx d   dx f
+3#f
+xd
+x g
+b
+3# f  d
+xd
+x g
+x f
+x d   d
+x f
 b
 
-b3# b  ax   cx  dx ax bx d
-b3#ax     dx     bx     a
-x      Qaxf
-b3#e    axfxhxfxe
-xc
-b3#a  Qcx  ax  cx dx  dx b
-b3#   cx bx ax   ax    dx  d
-b3#    cx    a
-2. Qa  c
-4#  ax  c
 b
-2#  dx    ax      ///a
+3# b  a
+x   c
+x  d
+x a
+x b
+x d
+b
+3#a
+x     d
+x     b
+x     a
+x      Qa
+xf
+b
+3#e    a
+xf
+xh
+xf
+xe
+xc
+b
+3#a  Qc
+x  a
+x  c
+x d
+x  d
+x b
+b
+3#   c
+x b
+x a
+x   a
+x    d
+x  d
+b
+3#    c
+x    a
+2. Qa  c
+4#  a
+x  c
+b
+2#  d
+x    a
+x      ///a
 b
 Y  dc
 b

--- a/LN-LZ153/LN153.tab
+++ b/LN-LZ153/LN153.tab
@@ -291,53 +291,167 @@ B
 B
 b
 Sc
-3#fxc.x dx  d.3#  ax   a.x    ax     c.
-b4#      a
-xf.xcxd.4#axc.x d
-xa.4# cx d.x ax c.4#  dx a.x  b
+3#f
+xc.
+x d
 x  d.
-bQ4#  ax  b.x   cx  a.4#   ax   c.x    e
-x   a.4#    cx    e.x    ax    c.4#     dx    a.5#     c
-x     d.x     a
+3#  a
+x   a.
+x    a
+x     c.
+b
+4#      a
+xf.
+xc
+xd.
+4#a
+xc.
+x d
+xa.
+4# c
+x d.
+x a
+x c.
+4#  d
+x a.
+x  b
+x  d.
+bQ
+4#  a
+x  b.
+x   c
+x  a.
+4#   a
+x   c.
+x    e
+x   a.
+4#    c
+x    e.
+x    a
+x    c.
+4#     d
+x    a.
+5#     c
+x     d.
+x     a
 x     c.
 b
 
 b
 3#      a
 xadd a
-x cx a.3# cx d.xax c.
+x c
+x a.
+3# c
+x d.
+xa
+x c.
 b
-2#cdd   ax-Qa    a2# dd  cx     db
-2#acd ax    c2#    ex    a
-b2 da c
-3# ax c.3# dxa.xcxd.
+2#cdd   a
+x-Qa    a
+2# dd  c
+x     d
+b
+2#acd a
+x    c
+2#    e
+x    a
+b
+2 da c
+3# a
+x c.
+3# d
+xa.
+xc
+xd.
 b
 2fcd a
-3#  dx a.3# cx d.xaxc.
+3#  d
+x a.
+3# c
+x d.
+xa
+xc.
 bQ
 
 bQ
 2d    a
-3#   cx  a.3#  bx  d.x ax c.
+3#   c
+x  a.
+3#  b
+x  d.
+x a
+x c.
 bQ
-2 da c3#  ax  c.3#  dx a.x cx d.bQ
-3#a   ax d.x cx a.3#  dx  b.x  ax   c.bQ
-3#   axa.xcxd.3#f   axd.xcxa.bQ
+2 da c
+3#  a
+x  c.
+3#  d
+x a.
+x c
+x d.
+bQ
+3#a   a
+x d.
+x c
+x a.
+3#  d
+x  b.
+x  a
+x   c.
+bQ
+3#   a
+xa.
+xc
+xd.
+3#f   a
+xd.
+xc
+xa.
+bQ
 
 bQ
-3# d  cx c.
-x ax  d.3#  ccxa.x cx d.
+3# d  c
+x c.
+x a
+x  d.
+3#  cc
+xa.
+x c
+x d.
 bQ
-3#a   ax d.x cx a.3#  dx  b.x  ax   c.bQ
-3#   ax    d.x    cx    a.
+3#a   a
+x d.
+x c
+x a.
+3#  d
+x  b.
+x  a
+x   c.
+bQ
+3#   a
+x    d.
+x    c
+x    a.
 2 ab  d
-3#     cx     a.
+3#     c
+x     a.
 bQ
-2#cdd   ax     a2#     cx      abQ
+2#cdd   a
+x     a
+2#     c
+x      a
+bQ
 2add a
-3# cx a.3# cx d.xax c.
+3# c
+x a.
+3# c
+x d.
+xa
+x c.
 b
-Y daa  ab
+Y daa  a
+b
 B
 
 { }
@@ -496,87 +610,175 @@ B
 B
 b
 Sc
-3#afx e.x fxc.
-3#ex f.xcxa.
-bQ3#cxa.xcxe.
-3#cxhixghxhi
+3#af
+x e.
+x f
+xc.
+3#e
+x f.
+xc
+xa.
 bQ
-3# hx f.
+3#c
+xa.
+xc
+xe.
+3#c
+xhi
+xgh
+xhi
+bQ
+3# h
+x f.
 2gh
 3ha
-4#f.xe4#c.xax d.x c
+4#f.
+xe
+4#c.
+xa
+x d.
+x c
 bQ
-3# a.x    cx    ex   b3#   cx dxaxcbQ
-3#dx     ax     dx    a3#cef cxh.xexg.
+3# a.
+x    c
+x    e
+x   b
+3#   c
+x d
+xa
+xc
+bQ
+3#d
+x     a
+x     d
+x    a
+3#cef c
+xh.
+xe
+xg.
 bQ
 
-bQ3# hx Qe.x ax c.
-3# eQax    cx   ax   cbQ
-3#   ex ax dxa3#cx     d
-x     Qcx     a
+bQ
+3# h
+x Qe.
+x a
+x c.
+3# eQa
+x    c
+x   a
+x   c
+bQ
+3#   e
+x a
+x d
+xa
+3#c
+x     d
+x     Qc
+x     a
 bQ
 1cce  c
 2cef c
 bbX
-3#cxe
+3#c
+xe
 bQ
-2#fx   e
-2Qacd3#hxk
+2#f
+x   e
+2Qacd
+3#h
+xk
 bQ
-2#lx   k2fhi
-3#  dx a
+2#l
+x   k
+2fhi
+3#  d
+x a
 bQ
-2# bx    a2 abc
-3#afxc
+2# b
+x    a
+2 abc
+3#af
+xc
 bQ
 
 bQ
-2#dxabQd2cef
-3#   cx  a
-bQ2#abb dxhaa  h
-3#fxe.xcxa.
+2#d
+xabQd
+2cef
+3#   c
+x  a
+bQ
+2#abb d
+xhaa  h
+3#f
+xe.
+xc
+xa.
 bQ
 2@ ea   a
 3  d
-2# ax     a
+2# a
+x     a
 bQ
 2#cef c
-xafg a1cef a
-b1@aac  a
+xafg a
+1cef a
+b
+1@aac  a
 bbX
-3#cxe.
+3#c
+xe.
 bQ
 2f  e c
-3#exc.
+3#e
+xc.
 2acd a
-3#hxk
+3#h
+xk
 bQ
 2l  k h
 3#k
 x-Qh
 2fhi f
-3#fxh.
+3#f
+xh.
 bQ
 
 bQ
 2i  h f
-3#hxf.
+3#h
+xf.
 2dfg d
-3#afxc.
+3#af
+xc.
 bQ
-2Qda c a3#cxa.
+2Qda c a
+3#c
+xa.
 2cef c
-3#afxc.
+3#af
+xc.
 bQ
 2afg
-3#   cx  a3#  b.x     a
+3#   c
+x  a
+3#  b.
+x     a
 2  dcd
 bQ
 2cef Qc
-3#axc
-3#dx     cx     dx    a
+3#a
+xc
+3#d
+x     c
+x     d
+x    a
 bQ
-2#cef cxafg a2#he   hx  a
+2#cef c
+xafg a
+2#he   h
+x  a
 bQ
 Yeff  a
 b
@@ -1335,56 +1537,113 @@ bQ
 1.ddef
 2f.
 1ddef
-bQ1  dd1  bb1 b.
 bQ
-1bde b2#   dx e.2# dx b.
+1  dd
+1  bb
+1 b.
+bQ
+1bde b
+2#   d
+x e.
+2# d
+x b.
 b
 1    b
-1bde1g  f
-bQ1fdd f1f
-2#   bxd.
-bQ2#    dxd.1d da1c.
-bQ1daba d2#   ax  d.2#  b
-x  a.b
+1bde
+1g  f
+bQ
+1fdd f
+1f
+2#   b
+xd.
+bQ
+2#    d
+xd.
+1d da
+1c.
+bQ
+1daba d
+2#   a
+x  d.
+2#  b
+x  a.
+b
 0dab  d
-bbX1 dddf
+bbX
+1 dddf
 bQ
 
 bQ
 1. dddf
 2 dd
 1    d
-bQ1bde b1b e  b1  d
 bQ
-1bde b2#   dx e.2# dx b.
+1bde b
+1b e  b
+1  d
+bQ
+1bde b
+2#   d
+x e.
+2# d
+x b.
 bQ
 1    b
-1bde1g  f
+1bde
+1g  f
 bQ
 1fdd f
 1f.
 1g  f
-bQ1f  e1ff d1dd b
-bQ1cdd   a
-2#   axd.2#cxa.
-bQ1cdd   a1   a
-bbX1gd f
+bQ
+1f  e
+1ff d
+1dd b
+bQ
+1cdd   a
+2#   a
+xd.
+2#c
+xa.
+bQ
+1cdd   a
+1   a
+bbX
+1gd f
 bQ
 
-bQ1f  d1d  b1b  a
-bQ1 Qe  d1 d  b1 d   d
-bQ1bbd  b
-2#   dx  e.2#  dx  b.
 bQ
-2#bbd  bx     a
+1f  d
+1d  b
+1b  a
+bQ
+1 Qe  d
+1 d  b
+1 d   d
+bQ
+1bbd  b
+2#   d
+x  e.
+2#  d
+x  b.
+bQ
+2#bbd  b
+x     a
 2#     b
 x     d
 2#    a
-x    cbQ
+x    c
+bQ
 2#abb d
 x    a
-1 d  b1     d
-bQ1add a3# cx a.x cx d.
+1 d  b
+1     d
+bQ
+1add a
+3# c
+x a.
+x c
+x d.
 1 cdca
 bQ
 1cdd   a
@@ -2046,12 +2305,16 @@ S3
 2 b  Qd
 b
 1 a   Qd
-2  d Qa2#  c  Qax   c
-3#axc
+2  d Qa
+2#  c  Qa
+x   c
+3#a
+xc
 b
 2.d  Qc
 3c  Qa
-2a   Qd2 d   Qd
+2a   Qd
+2 d   Qd
 1 b  Qa
 b
 1. a   Qa
@@ -2087,7 +2350,13 @@ bb
 2.a   Qd
 3 d
 2 b
-b2# a   Qdx  bx b  Qa2# a   Qax  bx b   Qb
+b
+2# a   Qd
+x  b
+x b  Qa
+2# a   Qa
+x  b
+x b   Qb
 b
 1 a   Qa
 2  d Qd
@@ -2136,7 +2405,8 @@ b
 b
 1.a    Qa
 1     Qa
-3#Qax-Qc
+3#Qa
+x-Qc
 b
 2.d  Qc
 3c
@@ -2173,9 +2443,15 @@ b
 b
 1 a+ba d
 2  +dca
-b2#  #c  ax   c.x    a
-b2#     ex     a
-3#a:xc.
+b
+2#  #c  a
+x   c.
+x    a
+b
+2#     e
+x     a
+3#a:
+xc.
 b
 2.+da c
 3c  a
@@ -2187,7 +2463,8 @@ b
 1@ a#cc a
 bQ
 1Q   Qc
-3#a:xc.
+3#a:
+xc.
 b
 2.+da c&{
 3c.
@@ -2209,18 +2486,32 @@ b
 2.  #aa  a
 3  c.
 2  d:
-b2  d ca
+b
+2  d ca
 1  #c.
 b
 1.  +dca
-bb1.aa +c a
-b2#    c{x db }x #b  d
-b2#     d{x aba }x  +d a
-b2#  #c  ax   c.x    a
+bb
+1.aa +c a
+b
+2#    c{
+x db }
+x #b  d
+b
+2#     d{
+x aba }
+x  +d a
+b
+2#  #c  a
+x   c.
+x    a
 b
 
-b2#     ex     a
-3#a:xc.
+b
+2#     e
+x     a
+3#a:
+xc.
 b
 2.+da c
 3c  a
@@ -2232,27 +2523,40 @@ b
 1@ a#cc a
 bQ
 1Q
-3#a:xc.
+3#a:
+xc.
 b
 2   c&{
-3#d:xc.
+3#d:
+xc.
 2a:}
-b2f:
-3#    dx    c.
+b
+2f:
+3#    d
+x    c.
 2    a
-b2     b&{
-3# b:x a.
+b
+2     b&{
+3# b:
+x a.
 2  d }
-b2     a
-3#   cx   a.
+b
+2     a
+3#   c
+x   a.
 2    d
-b2      a
-3#  a:x  c.
+b
+2      a
+3#  a:
+x  c.
 2  d:
 b
 
 b
-3#     ax  a.x  c:x  d.
+3#     a
+x  a.
+x  c:
+x  d.
 2  #c:
 b
 1.  +dca
@@ -2268,7 +2572,10 @@ b
 b
 1 a#cc a
 2  da b
-b2#  #c  ax   c.xab  d
+b
+2#  #c  a
+x   c.
+xab  d
 b
 2. db c{
 3a.  }
@@ -2300,7 +2607,8 @@ b
 2. #cd a
 3 d.
 2a:
-b2aaa c{
+b
+2aaa c{
 1 e. }
 b
 1.aa +c a
@@ -2314,13 +2622,30 @@ bQ
 b
 
 b
-3# d - d&{x b.x d:xa.  }
+3# d - d&{
+x b.
+x d:
+xa.  }
 2 #b  a
-b2# acx     ax  da b
-b2#  #c  ax   c.xab  d
 b
-3# d  c&{x b.x d:xa. }x b  ax  d.
-b2#     ex a cx  d a
+2# ac
+x     a
+x  da b
+b
+2#  #c  a
+x   c.
+xab  d
+b
+3# d  c&{
+x b.
+x d:
+xa. }
+x b  a
+x  d.
+b
+2#     e
+x a c
+x  d a
 b
 1.  #cc a
 bQ
@@ -2336,14 +2661,28 @@ b
 b
 
 b
-3#c  b&{xa.xc:xd.}
+3#c  b&{
+xa.
+xc:
+xd.}
 2aa c
-b2# ea c{x a. }x a - d
 b
-3# c  ax a.x c:x d.
+2# ea c{
+x a. }
+x a - d
+b
+3# c  a
+x a.
+x c:
+x d.
 2a:
 b
-3#    c{x f.x e:x c.x e:x  d.}
+3#    c{
+x f.
+x e:
+x c.
+x e:
+x  d.}
 b
 1aac  a
 2Q   #c
@@ -2366,15 +2705,22 @@ b
 2. #bd a
 3 d.
 2a:
-b2aaa c{
+b
+2aaa c{
 1 e. }
 b
 2aac  a
 1Q   #c
 bQ
 1@     Qa
-b2#   c&{xd:xa.}
-b2#f:x    axab  d
+b
+2#   c&{
+xd:
+xa.}
+b
+2#f:
+x    a
+xab  d
 b
 2. dba d&{
 3a.  }
@@ -2388,23 +2734,47 @@ b
 2  d:
 bQ
 
-bQ2  d ca
+bQ
+2  d ca
 1  #c.
 bQ
 1@  QdQcQa
 b
 1.  +dca
 bb
-3#a   d&{x d.xa:xb.
+3#a   d&{
+x d.
+xa:
+xb.
 2-#a: }
-b2# dx     dx #b  a
-b2 a#c  a
-3#   cx  a.x  cx  d.
 b
-2#  #c:x     ax ac
+2# d
+x     d
+x #b  a
 b
-3# b  ax d.xa:xd.x-#c:xa.
-b3#c  -  //axa.x e:x c.x(e:x )d.
+2 a#c  a
+3#   c
+x  a.
+x  c
+x  d.
+b
+2#  #c:
+x     a
+x ac
+b
+3# b  a
+x d.
+xa:
+xd.
+x-#c:
+xa.
+b
+3#c  -  //a
+xa.
+x e:
+x c.
+x(e:
+x )d.
 b
 
 b
@@ -2412,19 +2782,34 @@ b
 1Q   #c
 bQ
 1@     Qa
-bQ2   c&{
-3#d:xc.
+bQ
+2   c&{
+3#d:
+xc.
 2a:}
-b2#f:x    axab  d
-b2 d   d&{
-3#a:x d. }x b  ax  d.
 b
-2# a#cx     ax   c
-b2  #aa
-3#      ax  c.
+2#f:
+x    a
+xab  d
+b
+2 d   d&{
+3#a:
+x d. }
+x b  a
+x  d.
+b
+2# a#c
+x     a
+x   c
+b
+2  #aa
+3#      a
+x  c.
 2  d:
-b2  #c.
-3#     ax  d.
+b
+2  #c.
+3#     a
+x  d.
 2  f:
 b
 1@  QdQcQa
@@ -6747,56 +7132,95 @@ B
 B
 b
 Sc
-2# dd   axa2#c  axd
+2# dd   a
+xa
+2#c  a
+xd
 b
-2.f   a3h.
-2#f   axf.
+2.f   a
+3h.
+2#f   a
+xf.
 b
-3#h  axk.
-2l:2#Qk   ax-Qh.
+3#h  a
+xk.
+2l:
+2#Qk   a
+x-Qh.
 bX
 2.f   a
 3h
-2f   abQ
+2f   a
+bQ
 bQ
 2f
 bQ
-3# d ax cx dxa3#cxaxcxd
+3# d a
+x c
+x d
+xa
+3#c
+xa
+xc
+xd
 b
 2.fcd a
 3fcd
-2#    ax  d.
+2#    a
+x  d.
 b
-3# a ax c
-2 d2# c  ax ac  a
+3# a a
+x c
+2 d
+2# c  a
+x ac  a
 bX
 2.  d a
 3  d
 2    a
 bQ
-bQ2f
+bQ
+2f
 b
 
-b2#da cxc2#a   axc
+b
+2#da c
+xc
+2#a   a
+xc
 bQ
 2. d a
 3a
-2#cx d
-b2#da cxc2a   a
+2#c
+x d
+b
+2#da c
+xc
+2a   a
 bQ
-bQ2f
+bQ
+2f
 bX
 2. dd   a
 3 dd
-2#   axf
-b2#da cxc2#a   axc
+2#   a
+xf
+b
+2#da c
+xc
+2#a   a
+xc
 b
 2. d a
 3a
 2c
-3#axc
+3#a
+xc
 b
-2#da cxc2#a   axf
+2#da c
+xc
+2#a   a
+xf
 bQ
 2. dd   a
 3 dd
@@ -6809,116 +7233,457 @@ B
 B
 b1
 Sc
-2#   c-ax  a2#  ccx  de
-1 acc-a1 acc
+2#   c-a
+x  a
+2#  cc
+x  de
+1 acc-a
+1 acc
 b
-2# acc-ax cd2# daxa-c
+2# acc-a
+x cd
+2# da
+xa-c
 2.  dca
 3 a
-2 c3# ax  d
+2 c
+3# a
+x  d
 b
 2.  cc-a
-3  d3# ax    cx  d-ex  c
-2#  aax  c2#  d-ex   c
-b2# aa-cx a-c-e2#  deax  abc
-1 acc-a1 acc
+3  d
+3# a
+x    c
+x  d-e
+x  c
+2#  aa
+x  c
+2#  d-e
+x   c
+b
+2# aa-c
+x a-c-e
+2#  dea
+x  abc
+1 acc-a
+1 acc
 bb
 
 b2
 b
-2# acc-axa- c2# cdx e-e2#a-cc-ax cd2# acx  de
-b2# acc-ax cd2# dax ac2# cd-ax a-c-e2# cd-ax  db-c
-b2# acc-ax aab2# accx  ece2# aa-cx ca b2# ea-cx a-c-e
-b2# ca-ax a-c-e2 ca-a
-3# aa-cx  d2 acc-a
-3#   cx  a3#  cx  ax  cx  d
+2# acc-a
+xa- c
+2# cd
+x e-e
+2#a-cc-a
+x cd
+2# ac
+x  de
+b
+2# acc-a
+x cd
+2# da
+x ac
+2# cd-a
+x a-c-e
+2# cd-a
+x  db-c
+b
+2# acc-a
+x aab
+2# acc
+x  ece
+2# aa-c
+x ca b
+2# ea-c
+x a-c-e
+b
+2# ca-a
+x a-c-e
+2 ca-a
+3# aa-c
+x  d
+2 acc-a
+3#   c
+x  a
+3#  c
+x  a
+x  c
+x  d
 bb
 
 b3
-b2 a - a
-4# cx d
+b
+2 a - a
+4# c
+x d
 3a
-4# dx c
+4# d
+x c
 3 a
-4#  dx  c4#  ax  cx  dx  a4#  c- ax  ax  cx  d4# ax  dx  cx  a4#   cx   bx   cx  a4#  cx  ax  cx  d
+4#  d
+x  c
+4#  a
+x  c
+x  d
+x  a
+4#  c- a
+x  a
+x  c
+x  d
+4# a
+x  d
+x  c
+x  a
+4#   c
+x   b
+x   c
+x  a
+4#  c
+x  a
+x  c
+x  d
 b
 3 a - a
-4# cx d
+4# c
+x d
 3a
-4# dx c
+4# d
+x c
 3 a
-4# dx c4# ax cx dx a
+4# d
+x c
+4# a
+x c
+x d
+x a
 3 c- a
-4#  ax  c4#  dx  cx  dx a
+4#  a
+x  c
+4#  d
+x  c
+x  d
+x a
 3 c
-4# ax c
-3# ax  d
+4# a
+x c
+3# a
+x  d
 b
 
-b3  c- a
-4#   cx  a4#  cx  ax  cx  d3# ax  dx ax c3 ea c
-4# ax c
-3# ex c3 a - e
-4#  dx a
-3# cx a
-b3 c- a
-4#  ax  c
-3#  dx  c3  acc
-4#   bx   c
-3#   bx  d3# acc-ax  dex acx cd3# eaxa-cx cdx ea
+b
+3  c- a
+4#   c
+x  a
+4#  c
+x  a
+x  c
+x  d
+3# a
+x  d
+x a
+x c
+3 ea c
+4# a
+x c
+3# e
+x c
+3 a - e
+4#  d
+x a
+3# c
+x a
+b
+3 c- a
+4#  a
+x  c
+3#  d
+x  c
+3  acc
+4#   b
+x   c
+3#   b
+x  d
+3# acc-a
+x  de
+x ac
+x cd
+3# ea
+xa-c
+x cd
+x ea
 b4
 b
-2#aaccxfc2#e-fxc-d2#aaccx cd2# acx  de
+2#aacc
+xfc
+2#e-f
+xc-d
+2#aacc
+x cd
+2# ac
+x  de
 b
 
-b2 acc-a
-3#ax   a3#a - ex  dx d- cx  c
-2# c- ax da2 c-c
-3# ax  d
-b3#  c- ax  d- cx a - ex ca-a2# ea-cxa d-e2#c- ax a2#aa- ex  e
-b2# ea-cx a-c-e2# ca-ax ea-c
+b
+2 acc-a
+3#a
+x   a
+3#a - e
+x  d
+x d- c
+x  c
+2# c- a
+x da
+2 c-c
+3# a
+x  d
+b
+3#  c- a
+x  d- c
+x a - e
+x ca-a
+2# ea-c
+xa d-e
+2#c- a
+x a
+2#aa- e
+x  e
+b
+2# ea-c
+x a-c-e
+2# ca-a
+x ea-c
 3a-cc-a
-4# ex c
-4# ax  dx  cx  a
-3#   cx  ax  cx  d
+4# e
+x c
+4# a
+x  d
+x  c
+x  a
+3#   c
+x  a
+x  c
+x  d
 bb
 
 b5
-b3# ax     ax cx  d3# ax     ax  dx  a3#  cx     ax   cx  a3#  cx  dx ax c
-b3# ax     axax    a3#a - ex  dx d- cx  c3# cx    ax   cx a3 c- a
-4# ax c
-3# ax  d
-b3#  c- ax  ax  cx  d3# ax    cx  d-ex  c3#  aax   cx  ax  c3#  dx    ex   cx  d
-b3# ax    cx     ex   c3#  ax    ax    cx  d
+b
+3# a
+x     a
+x c
+x  d
+3# a
+x     a
+x  d
+x  a
+3#  c
+x     a
+x   c
+x  a
+3#  c
+x  d
+x a
+x c
+b
+3# a
+x     a
+xa
+x    a
+3#a - e
+x  d
+x d- c
+x  c
+3# c
+x    a
+x   c
+x a
+3 c- a
+4# a
+x c
+3# a
+x  d
+b
+3#  c- a
+x  a
+x  c
+x  d
+3# a
+x    c
+x  d-e
+x  c
+3#  aa
+x   c
+x  a
+x  c
+3#  d
+x    e
+x   c
+x  d
+b
+3# a
+x    c
+x     e
+x   c
+3#  a
+x    a
+x    c
+x  d
 
-4!3#  Qcc-ax ax  cx  d3# axax cx e
+4!
+3#  Qcc-a
+x a
+x  c
+x  d
+3# a
+xa
+x c
+x e
 b6
 b
-2#aaccxce2#efxfh2#hk - axkl2#hkxfh
-b2#ef
-xcd2#fcxe-f2#fcx  d2    a
-3#cxe
+2#aacc
+xce
+2#ef
+xfh
+2#hk - a
+xkl
+2#hk
+xfh
+b
+2#ef
+xcd
+2#fc
+xe-f
+2#fc
+x  d
+2    a
+3#c
+xe
 b
 2f
-3#eax c
-2#cdxac2# ea-cxa - e2#c  bxaa - e
+3#ea
+x c
+2#cd
+xac
+2# ea-c
+xa - e
+2#c  b
+xaa - e
 b
-3# c- ax e
-2a- ce2# f ecx e
+3# c- a
+x e
+2a- ce
+2# f ec
+x e
 
 4!
 3a-cc-a
-4# ax c
-3# ax  d3#  cx  ax  cx  d
+4# a
+x c
+3# a
+x  d
+3#  c
+x  a
+x  c
+x  d
 b7
 b
-3# a-U ax  d 3x a X3#  cUx  d 3x a X3# c Ux a  3x  dX3#  cUx  d 3x  aX3#  cU-ax  a 3x  cX3#   cUx  a  3x  c X3#  dUx a  3x c X3# a Ux c  3x  dX
-b3# aU- ax c 3x dX3#a Ux d 3x cX3# aUx c 3x dX3# cUx d 3x aX3# cUx a 3x cX3# dUx c 3x aX3#  dUx a  3x c X3# a Ux c  3x  dX
+3# a-U a
+x  d 3
+x a X
+3#  cU
+x  d 3
+x a X
+3# c U
+x a  3
+x  dX
+3#  cU
+x  d 3
+x  aX
+3#  cU-a
+x  a 3
+x  cX
+3#   cU
+x  a  3
+x  c X
+3#  dU
+x a  3
+x c X
+3# a U
+x c  3
+x  dX
+b
+3# aU- a
+x c 3
+x dX
+3#a U
+x d 3
+x cX
+3# aU
+x c 3
+x dX
+3# cU
+x d 3
+x aX
+3# cU
+x a 3
+x cX
+3# dU
+x c 3
+x aX
+3#  dU
+x a  3
+x c X
+3# a U
+x c  3
+x  dX
 b
 
-b3#  cU-ax  a 3x  cX3#   cUx  a  3x  c X3#  dUx a  3x c X3# cUx e 3xa X3# eU-cx c 3x eX3#a Ux e 3x cX3# a U-ex  d 3x a X3#  cUx  d 3x a X
-b3# cU-ax a 3x cX3#  dUx a  3x c X3# a-Ucx  d 3x  cX3#  aUx  c 3x  dX
-3#  c- ax ax cx e3#ax exaxc
+b
+3#  cU-a
+x  a 3
+x  cX
+3#   cU
+x  a  3
+x  c X
+3#  dU
+x a  3
+x c X
+3# cU
+x e 3
+xa X
+3# eU-c
+x c 3
+x eX
+3#a U
+x e 3
+x cX
+3# a U-e
+x  d 3
+x a X
+3#  cU
+x  d 3
+x a X
+b
+3# cU-a
+x a 3
+x cX
+3#  dU
+x a  3
+x c X
+3# a-Uc
+x  d 3
+x  cX
+3#  aU
+x  c 3
+x  dX
+3#  c- a
+x a
+x c
+x e
+3#a
+x e
+xa
+xc
 b8
 b
 3#e -- a
@@ -6939,35 +7704,107 @@ x  c
 x  a
 x  c
 x  d
-b3#e -- axfxhxf3#excxax d3# c- ax dxax c3#  dx a3 c
-4# ax  d
 b
-3#  c- ax  dx ax c3# ex    c
+3#e -- a
+xf
+xh
+xf
+3#e
+xc
+xa
+x d
+3# c- a
+x d
+xa
+x c
+3#  d
+x a
+3 c
+4# a
+x  d
+b
+3#  c- a
+x  d
+x a
+x c
+3# e
+x    c
 2a - e
-3#c- axaxcx a3#a - ex exax  e
-b3# ex    c
-2 a-c-e2 ca-a
-3# e- cx  d
+3#c- a
+xa
+xc
+x a
+3#a - e
+x e
+xa
+x  e
+b
+3# e
+x    c
+2 a-c-e
+2 ca-a
+3# e- c
+x  d
 2a-cc-a
-3# ex c3# ax  dx  cx  a
+3# e
+x c
+3# a
+x  d
+x  c
+x  a
 bQ
 b
 
 b9
 bQ
 2 acc-a
-3#   bx    e3#    cx    ax     ex     c
+3#   b
+x    e
+3#    c
+x    a
+x     e
+x     c
 2 acc-a
-3# dx c3# ax  dx  cx  a
+3# d
+x c
+3# a
+x  d
+x  c
+x  a
 b
 2 acc-a
-3#ax d3# cx ax  dx  c
+3#a
+x d
+3# c
+x a
+x  d
+x  c
 2  d-a
-3#  cx  a3#   cx   bx   cx  a
-b3#  c- ax  ax  cx  d3# ax    cx  d-ex  c
-2#  aax a- c2# a-cex  e
-b2# aa-cx a-c-e2 cdca
-3# aa-cx  d
+3#  c
+x  a
+3#   c
+x   b
+x   c
+x  a
+b
+3#  c- a
+x  a
+x  c
+x  d
+3# a
+x    c
+x  d-e
+x  c
+2#  aa
+x a- c
+2# a-ce
+x  e
+b
+2# aa-c
+x a-c-e
+2 cdca
+3# aa-c
+x  d
 Yaaccca
 b
 B
@@ -6977,60 +7814,124 @@ B
 b
 Sc
 2#  d!#a
-x a.2# c!#x d - c
-1aac!#-a1   c!#
+x a.
+2# c!#
+x d - c
+1aac!#-a
+1   c!#
 b
-2#aa - axc.!#2#dxf!#  a
+2#aa - a
+xc.!#
+2#d
+xf!#  a
 2. d a
 3a.
-2#c!#xc.
+2#c!#
+xc.
 b
 2. c!# a
 3 d.
-2#a!#xa.
+2#a!#
+xa.
 2. a!#- a
 3 c.
-2# d  cxc!# a
-b2#a - ex c!# a2# d ax acc
-1  d!#a1a.!#
+2# d  c
+xc!# a
+b
+2#a - e
+x c!# a
+2# d a
+x acc
+1  d!#a
+1a.!#
 b
 2. c!# a
 3 d.
-2#a!#xa.
+2#a!#
+xa.
 2. a!#  a
 3 c.
-2# d  cxc!# a
+2# d  c
+xc!# a
 b
 
 b
-2#a - ex c!# a2# d ax acc
-1  d!#a1a.!#
+2#a - e
+x c!# a
+2# d a
+x acc
+1  d!#a
+1a.!#
 bb
-3#  d ax  c.x  dx a.3# cx a.x c - c{x d.  }3#a -- a
+3#  d a
+x  c.
+x  d
+x a.
+3# c
+x a.
+x c - c{
+x d.  }
+3#a -- a
 x d.
-xaxc.
-2#a!#xa.
-b2#aa!#- axc.!#2#dxf!#  a
-3# d ax c.x dxa.
-2#c!#xc.
+xa
+xc.
+2#a!#
+xa.
 b
-3# c- ax a.x cx d.
-2#a!#xa.
+2#aa!#- a
+xc.!#
+2#d
+xf!#  a
+3# d a
+x c.
+x d
+xa.
+2#c!#
+xc.
+b
+3# c- a
+x a.
+x c
+x d.
+2#a!#
+xa.
 
 4!
-3# a - ax  d.x ax c.3# d  cxa.
+3# a - a
+x  d.
+x a
+x c.
+3# d  c
+xa.
 2c!# a
 bQ
-2#a - ex c!# a2# d!#ax acc
-1  d!#a1a.!#
+2#a - e
+x c!# a
+2# d!#a
+x acc
+1  d!#a
+1a.!#
 b
-3# c- ax a.x cx d.
-2#a!#xa.
-3# a - ax  d.x ax c.3# d  cxa.
+3# c- a
+x a.
+x c
+x d.
+2#a!#
+xa.
+3# a - a
+x  d.
+x a
+x c.
+3# d  c
+xa.
 2c!# a
 b
-2#a - ex c!# a2# d!#ax acc
-1  d!#aYa.!#
+2#a - e
+x c!# a
+2# d!#a
+x acc
+1  d!#a
+Ya.!#
 b
 B
 
@@ -7039,14 +7940,20 @@ B
 B
 b
 Sc
-2.  d a3 a.2# c  ax d
+2.  d a
+3 a.
+2# c  a
+x d
 b
 1aac  a
 2#   c
 xa.
 b
-3#c  axe.
-2f  a2#ea cxcaa c
+3#c  a
+xe.
+2f  a
+2#ea c
+xcaa c
 b
 1aac  a
 2a.
@@ -7054,39 +7961,89 @@ bQ
 bQ
 2   c
 bX
-3#  d ax  c.x  dx a.3# c  ax a.x cx d.
+3#  d a
+x  c.
+x  d
+x a.
+3# c  a
+x a.
+x c
+x d.
 b
 
-b3#aac  ax d.xaxc.
-2#aac  axa.
 b
-3#c  axe2f  a2#ea cxcaa cbX
 3#aac  a
 x d.
 xa
 xc.
-2aac  abQ
+2#aac  a
+xa.
+b
+3#c  a
+xe
+2f  a
+2#ea c
+xcaa c
+bX
+3#aac  a
+x d.
+xa
+xc.
+2aac  a
+bQ
 bQ
 2a.
-bQ2# d ax c.2# ac  ax c.
-b2.  d a
-3 a.2# c  axa.
-b2# d ax c.2# ac  axa.
+bQ
+2# d a
+x c.
+2# ac  a
+x c.
+b
+2.  d a
+3 a.
+2# c  a
+xa.
+b
+2# d a
+x c.
+2# ac  a
+xa.
 b
 
 b
 1  d a
-2   cbQ
+2   c
+bQ
 bQ
 2a.
 bX
 2. d a
 3 c.
-2# ac  axa.
+2# ac  a
+xa.
 bQ
-3#  d ax  c.x  dx a.3# c  ax d.xax c.
-b3# d ax c.x ax  d.3# accx  d.x  ax  c.
-b3#  d ax  c.x  dx a.
+3#  d a
+x  c.
+x  d
+x a.
+3# c  a
+x d.
+xa
+x c.
+b
+3# d a
+x c.
+x a
+x  d.
+3# acc
+x  d.
+x  a
+x  c.
+b
+3#  d a
+x  c.
+x  d
+x a.
 2  d a
 Y   c
 b
@@ -8120,77 +9077,174 @@ x
 B
 b
 S3
-3#afx e.x fxc.3#ex f.xcxa.3#cxa.xcxe.
+3#af
+x e.
+x f
+xc.
+3#e
+x f.
+xc
+xa.
+3#c
+xa.
+xc
+xe.
 bQ
-2#cxhi2#ghxhi
-3# hx f.
+2#c
+xhi
+2#gh
+xhi
+3# h
+x f.
 2gh
 bQ
 3ha
-4#f.xe4#c.xax d.x c
-3# a.x    cx    ex   b3#   cx dxaxcbQ
-3#dx     ax     dx    a3#cef cxh.xexg.3#Qhx Qe.x ax c.bQ
+4#f.
+xe
+4#c.
+xa
+x d.
+x c
+3# a.
+x    c
+x    e
+x   b
+3#   c
+x d
+xa
+xc
+bQ
+3#d
+x     a
+x     d
+x    a
+3#cef c
+xh.
+xe
+xg.
+3#Qh
+x Qe.
+x a
+x c.
+bQ
 
 bQ
-3# eQax    cx   ax   c3#   ex ax dxa3#cx     d
-x     Qcx     a
+3# eQa
+x    c
+x   a
+x   c
+3#   e
+x a
+x d
+xa
+3#c
+x     d
+x     Qc
+x     a
 bQ
 1Qcce  c
 1Qcef c
 bbX
-2#cxe
+2#c
+xe
 bQ
-1@f2   e
-2Qacd3#hxk
+1@f
+2   e
+2Qacd
+3#h
+xk
 bQ
-1@l2   k2fhi
-3#  dx a
+1@l
+2   k
+2fhi
+3#  d
+x a
 bQ
-1@ b2    a2 abc
-3#afxc
+1@ b
+2    a
+2 abc
+3#af
+xc
 bQ
 
 bQ
-2#dxabQd2cef
-3#   cx  a2#  b
-x   abQ
-2#abb dxhaa  h
-3#fxe.xcxa.
+2#d
+xabQd
+2cef
+3#   c
+x  a
+2#  b
+x   a
+bQ
+2#abb d
+xhaa  h
+3#f
+xe.
+xc
+xa.
 2@ ea   a
-3  dbQ
-2# ax     a
+3  d
+bQ
+2# a
+x     a
 2#cef c
-xafg a1cef a
-b0Qaac  a
+xafg a
+1cef a
+b
+0Qaac  a
 bbX
-2#cxe.
+2#c
+xe.
 bQ
 2f  e c
-3#exc.
+3#e
+xc.
 2acd a
-3#hxk
+3#h
+xk
 2@l  k h
 3k
 bQ
 
 bQ
 2fhi f
-3#fxh.
+3#f
+xh.
 2i  h f
-3#hxf.
+3#h
+xf.
 2dfg d
-3#afxc.bQ
-2da c a3#cxa.
+3#af
+xc.
+bQ
+2da c a
+3#c
+xa.
 2cef c
-3#afxc.3#dxa.
-2cebQ
+3#af
+xc.
+3#d
+xa.
+2ce
+bQ
 2afg
-3#   cx  a3#  b.x     a
+3#   c
+x  a
+3#  b.
+x     a
 2  dcd
 2cef Qc
-3#axcbQ
-3#dx     cx     dx    a
-2#cef cxafg a2#he   hx  a
+3#a
+xc
+bQ
+3#d
+x     c
+x     d
+x    a
+2#cef c
+xafg a
+2#he   h
+x  a
 bQ
 Yeff  a
 b

--- a/LN-LZ153/LZtoLN153.tab
+++ b/LN-LZ153/LZtoLN153.tab
@@ -12,125 +12,264 @@ BX
 bX
 Sc
 2   c
-b2#  dca
+b
+2#  dca
 x a
-2# bx d
+2# b
+x d
 1.aacc
 2ab
-b2# dbx a2# bdx    a
+b
+2# db
+x a
+2# bd
+x    a
 1. acc
 2 a
 bQ
-1 bd1 db
+1 bd
+1 db
 0abbcd
 b
-2#  dax bdca2# adcx  c
+2#  da
+x bdca
+2# adc
+x  c
 0  dca
 bb
 1 acc
-2#  cx  d
-1 acc1 bd
+2#  c
+x  d
+1 acc
+1 bd
 bQ
 
 bQ
 1. acc
-2 a2# bdx d2#abxc
+2 a
+2# bd
+x d
+2#ab
+xc
 b
-1da1c
+1da
+1c
 0aacc
 b
-2#   cx     a2#dxc2#abx    d2#   cx  a
-b2#  bx d2# axa2# bdx    a2#    dx   a
+2#   c
+x     a
+2#d
+xc
+2#ab
+x    d
+2#   c
+x  a
+b
+2#  b
+x d
+2# a
+xa
+2# bd
+x    a
+2#    d
+x   a
 b
 0 acc
-1 acc1 bd
+1 acc
+1 bd
 bQ
-2# dbxa
-1bdda1abd
+2# db
+xa
+1bdda
+1abd
 2    a
-3# dx b
+3# d
+x b
 b
 
 b
-2# ax  d2#   cx  c
+2# a
+x  d
+2#   c
+x  c
 0  dca
 bb
-3#   cx   cx   cx   c
-2#   cx    a3#   cx   cx   cx   c
-2#   cx    c
+3#   c
+x   c
+x   c
+x   c
+2#   c
+x    a
+3#   c
+x   c
+x   c
+x   c
+2#   c
+x    c
 b
-3#   cx   cx   cx   c
-2#   cx    a
-3#   cx   cx   cx   c
-2#   cx    c
-b2#     a
-x     c2#     dx    a
+3#   c
+x   c
+x   c
+x   c
+2#   c
+x    a
+3#   c
+x   c
+x   c
+x   c
+2#   c
+x    c
+b
+2#     a
+x     c
+2#     d
+x    a
 2#    c
 x    a
 1    c
-bQ0aaccca
+bQ
+0aaccca
 bbX
-2#   cxa2#d
+2#   c
+xa
+2#d
 xc
 bQ
 
 bQ
-2#abx    d2#   cx  a2#  bx d2# axa
-b2# bdx    a2#    dx   a
+2#ab
+x    d
+2#   c
+x  a
+2#  b
+x d
+2# a
+xa
+b
+2# bd
+x    a
+2#    d
+x   a
 0 acc
 b
 1abd
 2.f
 3d
 2.c
-3a3# dx bx ax  d
+3a
+3# d
+x b
+x a
+x  d
 bX
-2#  ccx  d
-3# ax bx dx b
-2# ax  d2#   cx  c
+2#  cc
+x  d
+3# a
+x b
+x d
+x b
+2# a
+x  d
+2#   c
+x  c
 bQ
 1@  dca
 b
 B
 b
-2a2#axb2#ax d
+2a
+2#a
+xb
+2#a
+x d
 b
 
 b
 2. bd
 3 a
 2  d
-3# ax b
-2# dx b2# ax  d
+3# a
+x b
+2# d
+x b
+2# a
+x  d
 b
 1. acc
-2 a2# ax b2# ax  d
-b2#  ccx  d2# ax b2# ax  d2#   cx  c
+2 a
+2# a
+x b
+2# a
+x  d
+b
+2#  cc
+x  d
+2# a
+x b
+2# a
+x  d
+2#   c
+x  c
 bQ
 1.  dca
 bbX
-3# ax b
-2# dx a2# bx d
-b2#ax   c
+3# a
+x b
+2# d
+x a
+2# b
+x d
+b
+2#a
+x   c
 1d
-2#caxab
+2#ca
+xab
 2# a
 x e
 b
 
 b
 1.aacc
-3#axc
-2#dxc2#ax d
-b2#abx    d2#   cx  a2#  bx d2# axa
-bQ2# bdx    a2#    dx   a1. acc
-2 a
-b2# bx a2# bx d
-3#ax dxaxb
-2a
-3# dx b
+3#a
+xc
+2#d
+xc
+2#a
+x d
+b
+2#ab
+x    d
+2#   c
+x  a
+2#  b
+x d
+2# a
+xa
 bQ
-2# ax  d2#   cx  c
+2# bd
+x    a
+2#    d
+x   a
+1. acc
+2 a
+b
+2# b
+x a
+2# b
+x d
+3#a
+x d
+xa
+xb
+2a
+3# d
+x b
+bQ
+2# a
+x  d
+2#   c
+x  c
 Y  dca
 b
 B
@@ -384,27 +523,44 @@ Sc
 2d.
 1c
 1a.
-b1caa c
-2#ax d.
-1 c1 a.
+b
+1caa c
+2#a
+x d.
+1 c
+1 a.
 b
 1.caa c
 2d.
-1c1a.
-b1caa c
-2#ax d.
-1 c1 a.
+1c
+1a.
+b
+1caa c
+2#a
+x d.
+1 c
+1 a.
 b
 bQ
 1.acd a
 2 d.
-1a1c
-b1acd a1 d.1 c1 a.
+1a
+1c
+b
+1acd a
+1 d.
+1 c
+1 a.
 b
 1.acd a
 2 d.
-1a1c.
-b1acd a1 d.1 c1 a.
+1a
+1c.
+b
+1acd a
+1 d.
+1 c
+1 a.
 bQ
 b
 
@@ -412,50 +568,97 @@ b
 bQ
 1.caa c
 2d.
-1c1a.
-b1caa c
-2#ax d.
-1 c1 a.
+1c
+1a.
+b
+1caa c
+2#a
+x d.
+1 c
+1 a.
 b
 1.caa c
 2d.
-1c1a.
-b1caa c
-2#ax d.
-1 c1 a.
+1c
+1a.
+b
+1caa c
+2#a
+x d.
+1 c
+1 a.
 b
 bQ
 1.acd a
-2 d.2# cx d.2#axc.
+2 d.
+2# c
+x d.
+2#a
+xc.
 b
-1acd a1 d.1 c1 a.
+1acd a
+1 d.
+1 c
+1 a.
 b
 1.acd a
 2 d.
-2# cx d.2#axc.
+2# c
+x d.
+2#a
+xc.
 b
-1acd a1 d.1 c1 a.
+1acd a
+1 d.
+1 c
+1 a.
 bQ
 b
 
-bbQ
-1 daac1 a.
-2# cx a.2# cx  e.
+b
+bQ
+1 daac
+1 a.
+2# c
+x a.
+2# c
+x  e.
 b
 0 aaac
-1 a1a.
-bbQ
-1 daac1 a
-3# cx a.x  ex  c.3# ax  e.x  cx  e.
+1 a
+1a.
+b
+bQ
+1 daac
+1 a
+3# c
+x a.
+x  e
+x  c.
+3# a
+x  e.
+x  c
+x  e.
 b
 0 aaac
-1 a1a.
-bbQ
-1 daac1 a.
-3# cx a.x  ex  c.3# ax  e.x  cx  e.
+1 a
+1a.
+b
+bQ
+1 daac
+1 a.
+3# c
+x a.
+x  e
+x  c.
+3# a
+x  e.
+x  c
+x  e.
 b
 0 aaac
-1 a.1a
+1 a.
+1a
 b
 bQ
 Yca bc
@@ -468,9 +671,12 @@ S3
 b
 0caa c
 1a.
-b1caa c
-2#ax d.
-2# cx a
+b
+1caa c
+2#a
+x d.
+2# c
+x a
 b
 0 c
 1 a.
@@ -479,10 +685,14 @@ bQ
 0caa c
 1d.
 b
-0caa c1a.
-b1caa c
-2#ax d.
-2# cx a.
+0caa c
+1a.
+b
+1caa c
+2#a
+x d.
+2# c
+x a.
 b
 0 c
 1 a.
@@ -497,13 +707,18 @@ b
 0acdca
 1 d.
 b
-0 c1 a.
+0 c
+1 a.
 bQ
 b
 
-bbQ
+b
+bQ
 1acdca
-2# cx a.2# cx d.
+2# c
+x a.
+2# c
+x d.
 b
 0acdca
 1c.
@@ -518,84 +733,129 @@ bQ
 0caa c
 1d.
 b
-0caa c1a.
-b1.caa c
-2a.1 d
+0caa c
+1a.
 b
-0 c1 a.
+1.caa c
+2a.
+1 d
+b
+0 c
+1 a.
 b
 bQ
 0caa c
 1d.
 b
-0caa c1a
-b1.caa c
-2a.1 d
+0caa c
+1a
 b
-0 c1 a.
-b
-bQ
-0acdca
-1 d.
-b
-
-b
-1acdca2# cx d.2#axc.
-b
-0acd a1 d.
-b0 c1 a.
-b
-bQ
-0acdca
-1 d.
-b
-1acdca
-2# cx d.2#axc.
-b
-1acdca
-2#ax d.2# cx a.
+1.caa c
+2a.
+1 d
 b
 0 c
 1 a.
-bbQ
-0 daac1 a.
 b
-1 ce
-2# cx a.2# cx  e.
-b
-1 aaac
-1 a.1 aaac
+bQ
+0acdca
+1 d.
 b
 
-b0 aaac
+b
+1acdca
+2# c
+x d.
+2#a
+xc.
+b
+0acd a
+1 d.
+b
+0 c
+1 a.
+b
+bQ
+0acdca
+1 d.
+b
+1acdca
+2# c
+x d.
+2#a
+xc.
+b
+1acdca
+2#a
+x d.
+2# c
+x a.
+b
+0 c
+1 a.
+b
+bQ
+0 daac
+1 a.
+b
+1 ce
+2# c
+x a.
+2# c
+x  e.
+b
+1 aaac
+1 a.
+1 aaac
+b
+
+b
+0 aaac
 bQ
 bQ
 1a.
 bX
 1. daac
-2 c.1 a
+2 c.
+1 a
 b
-3# cx a.x  ex  c.3#  ax  c.x  ex a.
+3# c
+x a.
+x  e
+x  c.
+3#  a
+x  c.
+x  e
+x a.
 3# c
 x a.
 x c
 x  e.
 b
 1 aaac
-1 a.1 aaac
+1 a.
+1 aaac
 b
 0 aaac
 bQ
 bQ
 1a.
-bX1. daac
-2 c.1 a
+bX
+1. daac
+2 c.
+1 a
 b
 1 ce
-2# cx a.3# cx a.x cx  e.
+2# c
+x a.
+3# c
+x a.
+x c
+x  e.
 b
 1 aaac
-1 a.1 aaac
+1 a.
+1 aaac
 b
 Y aaac
 b
@@ -605,26 +865,44 @@ B
 BX
 bX
 Sc
-1c da1c da1a bc
-2#da cxc
+1c da
+1c da
+1a bc
+2#da c
+xc
 bQ
 0Qa bc
 0 da c
 bb
 1a bc
-2# dx c
+2# d
+x c
 0 dda
 bb
 S3
-1c da1c.1a bc
+1c da
+1c.
+1a bc
 bQ
-2#dxc2#ax d.
-1a bcbQ
-1 da c1    c1 da c
-bb1a bc
-2# dx c2# ax c
+2#d
+xc
+2#a
+x d.
+1a bc
 bQ
-1 dda1   aY dda
+1 da c
+1    c
+1 da c
+bb
+1a bc
+2# d
+x c
+2# a
+x c
+bQ
+1 dda
+1   a
+Y dda
 b
 B
 
@@ -633,41 +911,76 @@ B
 B
 b
 Sc
-1fdde1      a1fdde1      abQ
 1fdde
-2#dxc
-1a1 d
-bbQ
-1fdde1      a1fdde1      abQ
-1fdde
-2#dxc
-1a1 d
-bb1   a
-2#axc
 1      a
-2#axc
+1fdde
+1      a
 bQ
-1dabc1cdd   a1acd a1 d
+1fdde
+2#d
+xc
+1a
+1 d
+b
+bQ
+1fdde
+1      a
+1fdde
+1      a
+bQ
+1fdde
+2#d
+xc
+1a
+1 d
+bb
+1   a
+2#a
+xc
+1      a
+2#a
+xc
+bQ
+1dabc
+1cdd   a
+1acd a
+1 d
 bb
 
-bb1cdda  a1a1 dba d1acd abQ
+bb
+1cdda  a
+1a
+1 dba d
+1acd a
+bQ
 0Q dQda  a
-1 dda1      a
+1 dda
+1      a
 bb
 S3
 1.fdde
 2fdd
 1      a
-b1fdde
-2#dxc2#ax d
+b
+1fdde
+2#d
+xc
+2#a
+x d
 bb
 1.cdda
 2cdd
-1      abQ
+1      a
+bQ
 1aabc
-2#dxc2#ax d
+2#d
+xc
+2#a
+x d
 bb
-1cdda1 dba d1acd a
+1cdda
+1 dba d
+1acd a
 bQ
 1. dda  a
 2 dda
@@ -680,119 +993,213 @@ B
 B
 b
 Sc
-1fdaa  a1fda   a
+1fdaa  a
+1fda   a
 b
 2fda   a
-3#dxc
-2#ax d
-bbQ
-2#f     axd2#fxh
-b2fda   a
-3#dxc
-2#ax d
-bbQ
-2#c     ax d2#c  ax d
-b2#d    axc2#a   ax d
+3#d
+xc
+2#a
+x d
+b
+bQ
+2#f     a
+xd
+2#f
+xh
+b
+2fda   a
+3#d
+xc
+2#a
+x d
+b
+bQ
+2#c     a
+x d
+2#c  a
+x d
+b
+2#d    a
+xc
+2#a   a
+x d
 bQ
 b
 
-bbQ
-2#c     ax d2#c  ax d
-b2f     a
-3#dxc
-2#a   ax d
-bbQ
-2#c     ax d2#a   ax c
 b
-1 dda1      a
-bbQ
-1  da  a1  da  a
+bQ
+2#c     a
+x d
+2#c  a
+x d
+b
+2f     a
+3#d
+xc
+2#a   a
+x d
+b
+bQ
+2#c     a
+x d
+2#a   a
+x c
+b
+1 dda
+1      a
+b
+bQ
+1  da  a
+1  da  a
 b
 2  da  a
-3#  bx  a
-2#   cx   a
-bbQ
-2#  d   ax  b2#  dx a
+3#  b
+x  a
+2#   c
+x   a
+b
+bQ
+2#  d   a
+x  b
+2#  d
+x a
 b
 
-b2  da  a
-3#  bx  a
-2#   cx   a
-bbQ
-2#  a   ax   a2#  a   ax   a
-b2#  b   ax  a2#   cx   a
 b
-bQ2#  a   ax   a2#  a   ax  b
-b2  da  a
-3#  bx  a
-2#   cx   a
-bbQ
-2#  a   ax   a2#   cx    a
+2  da  a
+3#  b
+x  a
+2#   c
+x   a
 b
-1   a  aY  aa  a
+bQ
+2#  a   a
+x   a
+2#  a   a
+x   a
+b
+2#  b   a
+x  a
+2#   c
+x   a
+b
+bQ
+2#  a   a
+x   a
+2#  a   a
+x  b
+b
+2  da  a
+3#  b
+x  a
+2#   c
+x   a
+b
+bQ
+2#  a   a
+x   a
+2#   c
+x    a
+b
+1   a  a
+Y  aa  a
 b
 B
 
-{H3c. Pauren Tantz - 7F AABBAABB2/D-LEm II.6.15, p. 371}B
+{H3c. Pauren Tantz - 7F AABBAABB2/D-LEm II.6.15, p. 371}
+B
 b
 Sc
-1Qfdaa2#fdaaxfdaa
-b2fdaa
-3#dxc2#ax dda
-b
-bQ
-1Qfdaa2#fdaaxfdaa
+1Qfdaa
+2#fdaa
+xfdaa
 b
 2fdaa
-3#dxc2#ax dda
+3#d
+xc
+2#a
+x dda
+b
+bQ
+1Qfdaa
+2#fdaa
+xfdaa
+b
+2fdaa
+3#d
+xc
+2#a
+x dda
 b
 bQ
 2cdda
 3#a
 xc
-2#dab  dxa
+2#dab  d
+xa
 b
 1.fdaa
 2f
 b
 bQ
 2cdda
-3#axc
-2#acd axc
-b0Q dda  a
+3#a
+xc
+2#acd a
+xc
+b
+0Q dda  a
 bb
 
 bb
-3#cddaxa2 d
 3#cdda
-xa2 d
+xa
+2 d
+3#cdda
+xa
+2 d
 b
-3#fdaaxd
+3#fdaa
+xd
 2c
-3#a   axc
+3#a   a
+xc
 2 d
 b
 bQ
-3#cddaxa
+3#cdda
+xa
 2 d
-3#cddaxa
+3#cdda
+xa
 2 d
 b
-3#fdaaxd2c2#a   ax d
+3#fdaa
+xd
+2c
+2#a   a
+x d
 b
 bQ
-3#cddaxa
+3#cdda
+xa
 2c
-3#acd ax d2 c
+3#acd a
+x d
+2 c
 b
 2. dda
 3a
-2#cxdQab  d
+2#c
+xdQab  d
 b
 bQ
-3#cddaxa
+3#cdda
+xa
 2c
-2acd a3# d
+2acd a
+3# d
 x c
 bQ
 Y dda  a
@@ -803,72 +1210,173 @@ B
 {H3d. Trab trab Schimmel trab - Nachdantz - AABBC2-AABBC4/D-W Guelf. 18.8, f. 35r}
 B
 b
-Sc1fdda1  d1fdda1  d
-bQ1fdda
-2#dxc.
-1acd a1 dbQ
+Sc
+1fdda
+1  d
+1fdda
+1  d
 bQ
-1fdda1  d1fdda1h.
-bQ1fdda
-2#dxc.
-1acd a1 d.bQbQ2#cdda
-xa2# d.x c2# d.xa2#c.x d.
+1fdda
+2#d
+xc.
+1acd a
+1 d
 bQ
-1dab  d1cdda1acd a1 dbQ
+bQ
+1fdda
+1  d
+1fdda
+1h.
+bQ
+1fdda
+2#d
+xc.
+1acd a
+1 d.
+bQ
+bQ
+2#cdda
+xa
+2# d.
+x c
+2# d.
+xa
+2#c.
+x d.
+bQ
+1dab  d
+1cdda
+1acd a
+1 d
+bQ
 bQ
 
 bQ
-bQ1cdda1 d1cdda1fbQ1dab  d1cdda
-2#acd axc.2#dxa.
 bQ
-bQ1cdda1 dba d
-2#acd ax d2#ax cbQ2# ddax c.2# dxa.
-1 dd1   a
+1cdda
+1 d
+1cdda
+1f
+bQ
+1dab  d
+1cdda
+2#acd a
+xc.
+2#d
+xa.
+bQ
+bQ
+1cdda
+1 dba d
+2#acd a
+x d
+2#a
+x c
+bQ
+2# dda
+x c.
+2# d
+xa.
+1 dd
+1   a
 bb
 S3
 1.fdda
 2fdd
 1Q   a
-b1fdda1  d1h
-b1fdda1d1cdda
+b
+1fdda
+1  d
+1h
+b
+1fdda
+1d
+1cdda
 b
 
-b1acd a
-2# dxa.2#cxd.
+b
+1acd a
+2# d
+xa.
+2#c
+xd.
 b
 bQ
 1.fdda
 2fdd
 1   a
-b1fdda1  d1h.
-b1fdda1d1cdda
+b
+1fdda
+1  d
+1h.
+b
+1fdda
+1d
+1cdda
 b
 0acd a
 bQ
 bQ
 1 dda
 bX
-2#cddaxa2# dxa.2#cxd.
+2#cdda
+xa
+2# d
+xa.
+2#c
+xd.
 b
-1c da1  d1f.
-b1dabc1a.1cdda
+1c da
+1  d
+1f.
+b
+1dabc
+1a.
+1cdda
 b
 
 b
 0@acd a
 b
 bQ
-2#cddaxa.
-2# dxa.2#c
+2#cdda
+xa.
+2# d
+xa.
+2#c
 xd.
 bQ
-1cdda1  d.1fddabQ1dabc1a.1cdda
-bQ1acd a2#axc.2#dxa.bQ
-bQ2#cddaxa2# dx c2# ax  d
-bQ1dab  d1 d  c1acd abQ1@ dda
+1cdda
+1  d.
+1fdda
+bQ
+1dabc
+1a.
+1cdda
+bQ
+1acd a
+2#a
+xc.
+2#d
+xa.
+bQ
+bQ
+2#cdda
+xa
+2# d
+x c
+2# a
+x  d
+bQ
+1dab  d
+1 d  c
+1acd a
+bQ
+1@ dda
 2Q dd
 1   a
-bQ1 dda
+bQ
+1 dda
 Y dda
 b
 B
@@ -877,44 +1385,90 @@ B
 B
 b
 Sc
-1-Qea1     a1-Qea1     a
+1-Qea
+1     a
+1-Qea
+1     a
 b
-2# axf
+2# a
+xf
 1e
-1ca1     a
-bbQ
-1ea1     a1ea1     a
-b1fa1e1ca1     a
-bbQ
-1ea
-1     a1ea1     a
-b1fa1e1c1   c
+1ca
+1     a
 b
 bQ
-2# ax c2# exa2#cxa2# cx e
+1ea
+1     a
+1ea
+1     a
+b
+1fa
+1e
+1ca
+1     a
+b
+bQ
+1ea
+1     a
+1ea
+1     a
+b
+1fa
+1e
+1c
+1   c
+b
+bQ
+2# a
+x c
+2# e
+xa
+2#c
+xa
+2# c
+x e
 b
 
 b
-1aac1     a1aac1     a
+1aac
+1     a
+1aac
+1     a
 b
 bQ
-1    c1 a1 c  c1 a
-b1 a  c
-2#  dx  c
-1  a1   c
+1    c
+1 a
+1 c  c
+1 a
+b
+1 a  c
+2#  d
+x  c
+1  a
+1   c
 b
 bQ
 0 a  c
-1 c1  d
-b1 a  Qc
-2#  dx  c1  a1   c
+1 c
+1  d
+b
+1 a  Qc
+2#  d
+x  c
+1  a
+1   c
 b
 bQ
 1  c
-2#  ax  c
-1  d1  a c
-b1  cc a1  c
-1   cY     a
+2#  a
+x  c
+1  d
+1  a c
+b
+1  cc a
+1  c
+1   c
+Y     a
 b
 B
 
@@ -923,19 +1477,34 @@ B
 B
 b
 Sc
-2#hff hxe
+2#hff h
+xe
 1h  g
 b
-2fcde3#cx a
-2#fcdex e
-b2#ea cxacd a
-3#aaa cx e
-4#ax ex cx e
+2fcde
+3#c
+x a
+2#fcde
+x e
+b
+2#ea c
+xacd a
+3#aaa c
+x e
+4#a
+x e
+x c
+x e
 b
 2.a cce
 3 e
-2#a dcaxf a
-b2#eaccxacd a2#caa cx e
+2#a dca
+xf a
+b
+2#eacc
+xacd a
+2#caa c
+x e
 b
 
 b
@@ -948,29 +1517,48 @@ bb
 3c d
 2#eac
 xac
-b2#cddaxe
+b
+2#cdda
+xe
 1fda
 b
-3#aaccx exaxc d
+3#aacc
+x e
+xa
+xc d
 2#eac
 xac
 b
-2#cddaxe2#fdaxh
-b2#eaccxf2#ca  cx e
+2#cdda
+xe
+2#fda
+xh
+b
+2#eacc
+xf
+2#ca  c
+x e
 b
 2.a cce
 3 e
-2#a dcaxf a
+2#a dca
+xf a
 b
 
-b2#eacc
+b
+2#eacc
 xacd a
 3#aaa c
-x e4#a
-x ex c
+x e
+4#a
+x e
+x c
 x e
 b
-2#aQaccx     a2#aQaccx     a
+2#aQacc
+x     a
+2#aQacc
+x     a
 bb
 S3
 1hff h
@@ -980,10 +1568,16 @@ b
 2k  h
 b
 1hff h
-3#ffhxe
+3#ffh
+xe
 b
-2#ca  cx exa cce
-bb2#ca  cx exa cce
+2#ca  c
+x e
+xa cce
+bb
+2#ca  c
+x e
+xa cce
 b
 
 b
@@ -996,13 +1590,22 @@ b
 b
 1cdda
 2hdf  h
-b2#ea cxffxcef c
+b
+2#ea c
+xff
+xcef c
 b
 1a cce
 2f dce
-b2#eaccxacd a
-3#aaa cx e
-4#ax ex cx e
+b
+2#eacc
+xacd a
+3#aaa c
+x e
+4#a
+x e
+x c
+x e
 b
 Yaacc a
 b
@@ -1012,58 +1615,106 @@ B
 B
 b
 Sc
-1fdaa1cdda
+1fdaa
+1cdda
 b
-3# ddaxa
-2c2#a   ax dda
+3# dda
+xa
+2c
+2#a   a
+x dda
 b
 bQ
 2.fdaa  a
 3d
 2cdda
-3#axc
-b3# ddaxa
-2c2#a   ax dda
-bbQ
-2# ddaxc2# dxc
+3#a
+xc
+b
+3# dda
+xa
+2c
+2#a   a
+x dda
+b
+bQ
+2# dda
+xc
+2# d
+xc
 b
 
 b
-3# ddaxa
-2c2#a   ax dda
-bbQ
+3# dda
+xa
+2c
+2#a   a
+x dda
+b
+bQ
 2cdda
-3#axc
-2# dxc
+3#a
+xc
+2# d
+xc
 b
-3# ddaxa
-2c2#a   ax dda
+3# dda
+xa
+2c
+2#a   a
+x dda
 b
 bQ
-1  da  a1  aa  a
+1  da  a
+1  aa  a
 b
-3#   ax   c
-2   e2#   cx   a
+3#   a
+x   c
+2   e
+2#   c
+x   a
 bQ
 b
 
-bbQ
-2#  da  ax  a2#   ax  a
 b
-3#   ax   c
-2   e2#   cx   a
-bbQ
-2#  a   ax   a2#  a   ax   a
 bQ
-3#   ax   c
-2   e2#   cx   a
-bbQ
+2#  da  a
+x  a
+2#   a
+x  a
+b
+3#   a
+x   c
+2   e
+2#   c
+x   a
+b
+bQ
+2#  a   a
+x   a
+2#  a   a
+x   a
+bQ
+3#   a
+x   c
+2   e
+2#   c
+x   a
+b
+bQ
 2  d   a
-3#  ax  b
+3#  a
+x  b
 2  d
-3#  ax  b
-b3#  dx  bx  ax   c
-2  a   aY   a
+3#  a
+x  b
+b
+3#  d
+x  b
+x  a
+x   c
+2  a   a
+Y   a
 b
 B
 
@@ -1071,18 +1722,22 @@ B
 B
 b
 Sc
-1fdaa1cdda
+1fdaa
+1cdda
 b
-3# daa  axa
+3# daa  a
+xa
 2c
 1Qacdca
 bb
-2 daa  a3#a
+2 daa  a
+3#a
 xc
 2#da c
 xc  a
 b
-3# dda  axa
+3# dda  a
+xa
 2c
 1acd a
 bb
@@ -1093,57 +1748,78 @@ xcdda
 bQ
 
 bQ
-3# ddaxa
+3# dda
+xa
 2c
 1acd a
 bb
-3# dda  axa
+3# dda  a
+xa
 2c
-3# dda  axa
-2cbQ
-3# dda  axa
+3# dda  a
+xa
+2c
+bQ
+3# dda  a
+xa
 2c
 1acd a
 bb
 2#cdda
-x da c2# ddcax c
+x da c
+2# ddca
+x c
 b
-2Q daa  a3# cx a
+2Q daa  a
+3# c
+x a
 Y  d
 b
 B
-{H5c. Heyducken dantz - 7F AABB2/D-Lr 2000, p. 73}
+
+{H5c. Heyducken dantz - 7F AABB2/D-Lr 2000, p. 73}
 BX
 bX
 Sc
-1fdaa1cdda
+1fdaa
+1cdda
 b
-3# daa  axa
+3# daa  a
+xa
 2c
 1acdca
 b
 bQ
-1fc ca1cdda
+1fc ca
+1cdda
 b
-3# daa  axa
+3# daa  a
+xa
 2c
 1acdca
 b
 bQ
-3# dda  axa
+3# dda  a
+xa
 2c
-3# dda  axa
+3# dda  a
+xa
 2c
 b
-3# dda  axa
+3# dda  a
+xa
 2c
 1Qacdca
 b
 bQ
-3# dda  axa
-2c2#dab  dxcdda
+3# dda  a
+xa
+2c
+2#dab  d
+xcdda
 b
-3# dda  axa
+3# dda  a
+xa
 2c
 Yacdca
 b
@@ -1156,112 +1832,234 @@ Sc
 2. bd a
 3 a
 2  d a
-3#  bx  a
+3#  b
+x  a
 2. ab  a
 3 ab
-2#   cx ab  a
-b2 bd a
-3#   cx a3#  d ax ax bx d
+2#   c
+x ab  a
+b
+2 bd a
+3#   c
+x a
+3#  d a
+x a
+x b
+x d
 2abb d
-3#  dx a3# bx dxaxc
+3#  d
+x a
+3# b
+x d
+xa
+xc
 b
 2.dab  d
 3cdda
-2#abb dx db c
+2#abb d
+x db c
 2Q bd a
-3#   c x a
-2#  d axabb d
+3#   c 
+x a
+2#  d a
+xabb d
 b
 
 b
-3# d ax bx ax  d3# ac  ax  dx ax  c
+3# d a
+x b
+x a
+x  d
+3# ac  a
+x  d
+x a
+x  c
 2. cd a
 3 cd
-2#   cx    a
+2#   c
+x    a
 b
 bQ
 2. bd a
 3 a
 2    a
-3#  bx  a3# ab  ax  a
-4#  bx  ax  bx  d
-2# ab  ax   c
+3#  b
+x  a
+3# ab  a
+x  a
+4#  b
+x  a
+x  b
+x  d
+2# ab  a
+x   c
 b
 2 bd a
-3#   cx a3#  d ax ax bx d3#abb dx ax  dx a3# bx dxaxc
+3#   c
+x a
+3#  d a
+x a
+x b
+x d
+3#abb d
+x a
+x  d
+x a
+3# b
+x d
+xa
+xc
 b
 
 b
 2dab  d
-3#   axc
+3#   a
+xc
 2abb d
-3#    cx db
+3#    c
+x db
 2 bd a
-3#   cx a
+3#   c
+x a
 2  d a
-3#    dxabb
+3#    d
+xabb
 b
 3 d a
-4# ax b4# dx bx ax  d
+4# a
+x b
+4# d
+x b
+x a
+x  d
 3 acc a
-4#  dx  c4#  dx  cx  ax  c
+4#  d
+x  c
+4#  d
+x  c
+x  a
+x  c
 2 cd a
-3#   cx d
-2# cd ax   c
+3#   c
+x d
+2# cd a
+x   c
 bQ
 b
 
-bbQ
+b
+bQ
 2 bd a
-3# ax b
-2# db  dx db
+3# a
+x b
+2# db  d
+x db
 2.abb d
 3ab
-2#  bxdabc
+2#  b
+xdabc
 b
-2#cddaxabb d2#abd ax ea c
+2#cdda
+xabb d
+2#abd a
+x ea c
 2.aac  a
 3aac
 2#   c
 xaac  a
-b2 bd a
-3# ax b3# db  dx a
-4# bx ax bx d
+b
+2 bd a
+3# a
+x b
+3# db  d
+x a
+4# b
+x a
+x b
+x d
 
 4!
-3#abb dx ax bx d3#axcxdxa
-bX3#   axcddx    dxabb3#    axabdx    cx ea3#     axaacx   cx  d
+3#abb d
+x a
+x b
+x d
+3#a
+xc
+xd
+xa
+bX
+3#   a
+xcdd
+x    d
+xabb
+3#    a
+xabd
+x    c
+x ea
+3#     a
+xaac
+x   c
+x  d
 2aac  a
 bQ
 bQ
-3#axc
+3#a
+xc
 b
 2dab  d
-3#   axc
-2#abb dx db c2 bd a
-3#   cx a
-2#  d axabb d
+3#   a
+xc
+2#abb d
+x db c
+2 bd a
+3#   c
+x a
+2#  d a
+xabb d
 b
-3# d ax bx ax  d3# acc ax  ax  dx  c
+3# d a
+x b
+x a
+x  d
+3# acc a
+x  a
+x  d
+x  c
 
 4!
 2. cd a
 3 cd
 2   c
-3#axc
+3#a
+xc
 b
 2dab  d
-3#   axc
+3#   a
+xc
 2abb d
-3#    cx db
+3#    c
+x db
 2 bd a
-3#   cx a
+3#   c
+x a
 2  d a
-3#    dxabb
-b3 d a
-4# ax b4# dx bx ax  d
+3#    d
+xabb
+b
+3 d a
+4# a
+x b
+4# d
+x b
+x a
+x  d
 3 acc a
-4# dxa4#cxaxcxe
+4# d
+xa
+4#c
+xa
+xc
+xe
 2.fcd a
 3fcd
 2   c
@@ -1276,64 +2074,208 @@ bX
 Sc
 1cdda
 b
-2#ac+d ax a.2# c:x d.
-1acd a1cdda
-b1dab  d
-2#d:xc.2#a:x d.2# c:x a.
+2#ac+d a
+x a.
+2# c:
+x d.
+1acd a
+1cdda
 b
-1acd a1 dbac
-2#ac+d ax a.2# d:x c.
-b2#cddaxa.2#c:xd.
-1cdd1cdda
+1dab  d
+2#d:
+xc.
+2#a:
+x d.
+2# c:
+x a.
 b
-2#ac+d ax a.2# c:x d.
-1acd a1cdda
+1acd a
+1 dbac
+2#ac+d a
+x a.
+2# d:
+x c.
+b
+2#cdda
+xa.
+2#c:
+xd.
+1cdd
+1cdda
+b
+2#ac+d a
+x a.
+2# c:
+x d.
+1acd a
+1cdda
 b
 
 b
-2# aba dx  a.2#  b:x  d.2# a:x c.2# d:xa.
-b
-1cdda1 dbac
-2#ac+d ax a.2# d:x c.
+2# aba d
+x  a.
+2#  b:
+x  d.
+2# a:
+x c.
+2# d:
+xa.
 b
 1cdda
-2# a:x c.2# d:xa.
+1 dbac
+2#ac+d a
+x a.
+2# d:
+x c.
+b
+1cdda
+2# a:
+x c.
+2# d:
+xa.
 bQ
 bQ
 1cdda
 bX
-2#a +d ax d.2# c:xa.2# daa+cx c.2# a:x d.
-b2# cd+cax a.2#  d:x c.
+2#a +d a
+x d.
+2# c:
+xa.
+2# daa+c
+x c.
+2# a:
+x d.
+b
+2# cd+ca
+x a.
+2#  d:
+x c.
 
-4!2# aba +dx  d.2#  b:x a.
-b2#  da +cx  a.2#  b:x  d.2#  b+c ax a.2#  d:x  b.
-b2#  aax  b.2#  d:x  b.2#  a:x   c.
+4!
+2# aba +d
+x  d.
+2#  b:
+x a.
+b
+2#  da +c
+x  a.
+2#  b:
+x  d.
+2#  b+c a
+x a.
+2#  d:
+x  b.
+b
+2#  aa
+x  b.
+2#  d:
+x  b.
+2#  a:
+x   c.
 1cdda
 b
-2#a +d ax d.2# c:xa.2# daa+cx c.2# a:x d.
-b2# c +cax a.2#  d:x c.2# aba +dx  d.2#  b:x a.
+2#a +d a
+x d.
+2# c:
+xa.
+2# daa+c
+x c.
+2# a:
+x d.
+b
+2# c +ca
+x a.
+2#  d:
+x c.
+2# aba +d
+x  d.
+2#  b:
+x a.
 b
 
-b2#  d  +cx  b.2#  aax  d.2#  b+c ax a.2#  d:x  b.
-b2# ddax   c.2#  a:x  b.2#  d:x  b.2#  d:x a.
-bbQ
-2#abb +dx a.2# b:x d.2#abb +dxd.2#c:xa.
-b2#cd+daxa.2#d:xc.
-2#a:x d.2# c:x a.
 b
-1acd a1 dbac
-2#ac+d ax a.2# d:x c.
+2#  d  +c
+x  b.
+2#  aa
+x  d.
+2#  b+c a
+x a.
+2#  d:
+x  b.
+b
+2# dda
+x   c.
+2#  a:
+x  b.
+2#  d:
+x  b.
+2#  d:
+x a.
+b
+bQ
+2#abb +d
+x a.
+2# b:
+x d.
+2#abb +d
+xd.
+2#c:
+xa.
+b
+2#cd+da
+xa.
+2#d:
+xc.
+2#a:
+x d.
+2# c:
+x a.
+b
+1acd a
+1 dbac
+2#ac+d a
+x a.
+2# d:
+x c.
 b
 
-b2#cd+daxa.2#c:xd.
-1cdda1abb d
 b
-2#abb +dx a.2# b:x d.2#abb +dxd.2#c:xa.
-b2#cddaxa.2#d:xc.2#a:x d.2# c:x a.
+2#cd+da
+xa.
+2#c:
+xd.
+1cdda
+1abb d
 b
-1acd a1 dbac
-2#ac+d ax a.2# d:x c.
-b2#cd+dax c.2# d:xa.
+2#abb +d
+x a.
+2# b:
+x d.
+2#abb +d
+xd.
+2#c:
+xa.
+b
+2#cdda
+xa.
+2#d:
+xc.
+2#a:
+x d.
+2# c:
+x a.
+b
+1acd a
+1 dbac
+2#ac+d a
+x a.
+2# d:
+x c.
+b
+2#cd+da
+x c.
+2# d:
+xa.
 Ycdda
 b
 B
@@ -1343,34 +2285,47 @@ B
 BX
 bX
 Sc
-1laaaa1haaaa
+1laaaa
+1haaaa
 b
-3#daaxf
+3#daa
+xf
 2haa
 1feca
 bb
-3#daaxf
+3#daa
+xf
 2haa
-3#daaxf
+3#daa
+xf
 2haa
 bQ
-3#daaxf
+3#daa
+xf
 2haa
 1feca
 b
 bQ
-3#daaaaxf
-2haa2#ifffaxhaaaa
+3#daaaa
+xf
+2haa
+2#ifffa
+xhaaaa
 b
-3#daaaaxf
+3#daaaa
+xf
 2haa
 1feca
 bb
-3#laaxi
-2haa2f ff f
-3#dacaxc.
+3#laa
+xi
+2haa
+2f ff f
+3#daca
+xc.
 b
-1QdaaaaYdaa
+1Qdaaaa
+Ydaa
 b
 B
 
@@ -1380,35 +2335,101 @@ b
 Sc
 2#aa c a
 xa
-2#cxa
-bQ2#aa c ax a2 a
-3# cx e
-bQ2#aa c axa2#cxa
-bQ1 a c a1 a
+2#c
+xa
 bQ
-bQ2#aa c axa2#cxabQ2#aa c ax a2 a
-3# cx e
-bQ2#aa c axa2#cxa
-bQ1 a c a
+2#aa c a
+x a
+2 a
+3# c
+x e
+bQ
+2#aa c a
+xa
+2#c
+xa
+bQ
+1 a c a
 1 a
 bQ
-bQ2#ea c axe2e
-3#cxe
-bQ2#fa c axe2#cxabQ
-
-bQ2#ea c axe2e
-3#cxe
-bQ2#fa c axe2#cxfbQ2#ea c axa2c
-3#ax e
-bQ1aa c a1a
 bQ
-bQ2#ea c axe2e
-3#cxe
-bQ2#fa c axe2#cxabQ2#ea c axe2e
-3#cxe
-bQ2#fa c axe2#c
+2#aa c a
+xa
+2#c
+xa
+bQ
+2#aa c a
+x a
+2 a
+3# c
+x e
+bQ
+2#aa c a
+xa
+2#c
+xa
+bQ
+1 a c a
+1 a
+bQ
+bQ
+2#ea c a
+xe
+2e
+3#c
+xe
+bQ
+2#fa c a
+xe
+2#c
+xa
+bQ
+
+bQ
+2#ea c a
+xe
+2e
+3#c
+xe
+bQ
+2#fa c a
+xe
+2#c
 xf
-bQ2#ea c a
+bQ
+2#ea c a
+xa
+2c
+3#a
+x e
+bQ
+1aa c a
+1a
+bQ
+bQ
+2#ea c a
+xe
+2e
+3#c
+xe
+bQ
+2#fa c a
+xe
+2#c
+xa
+bQ
+2#ea c a
+xe
+2e
+3#c
+xe
+bQ
+2#fa c a
+xe
+2#c
+xf
+bQ
+2#ea c a
 xa
 2c
 3#a
@@ -1416,19 +2437,22 @@ x e
 bQ
 
 bQ
-1aa c a1a
+1aa c a
+1a
 bQ
 bQ
 S3
 0aa c a
 1a
-bQ0aa c a1c
-bQ0aa c a1 abQ0 a c a2# c
-x e
-bQ0aa c a
+bQ
+0aa c a
 1c
-bQ0aa c a1 a
-bQ0 a c a2# c
+bQ
+0aa c a
+1 a
+bQ
+0 a c a
+2# c
 x e
 bQ
 0aa c a
@@ -1438,7 +2462,18 @@ bQ
 1 a
 bQ
 0 a c a
-2# cx e
+2# c
+x e
+bQ
+0aa c a
+1c
+bQ
+0aa c a
+1 a
+bQ
+0 a c a
+2# c
+x e
 bQ
 
 bQ
@@ -1455,7 +2490,8 @@ bQ
 1e
 bQ
 0ea c a
-2#cxe
+2#c
+xe
 bQ
 0fa c a
 1e
@@ -1467,7 +2503,8 @@ bQ
 1e
 bQ
 0ea c a
-2#cxe
+2#c
+xe
 bQ
 0fa c a
 1e
@@ -1481,16 +2518,19 @@ bQ
 
 bQ
 0ca a  a
-2#ax e
+2#a
+x e
 bQ
-0aa c a1Qa
+0aa c a
+1Qa
 bQ
 bQ
 0ea c a
 1e
 bQ
 0ea c a
-2#cxe
+2#c
+xe
 bQ
 0fa c a
 1e
@@ -1502,19 +2542,23 @@ bQ
 1e
 bQ
 0ea c a
-2#cxe
+2#c
+xe
 bQ
 0fd a  a
 1e
 bQ
 0ca a  a
-1fbQ
+1f
+bQ
 1ea c a
-2#cxe
+2#c
+xe
 1a
 bQ
 0ca a  a
-2#ax e
+2#a
+x e
 bQ
 
 bQ
@@ -1552,7 +2596,8 @@ bQ
 1a
 bQ
 0Qca a  a
-2#ax e
+2#a
+x e
 bQ
 0aa c a
 Yaa c a
@@ -1568,35 +2613,63 @@ Sc
 3d
 2#c
 xcaa c
-b2caabc
-3# dxa3#cxd
+b
+2caabc
+3# d
+xa
+3#c
+xd
 2f    c
-b2#dab  dxcdda
-3#aab  axdxcxa
-b3#caabcxax ex c
+b
+2#dab  d
+xcdda
+3#aab  a
+xd
+xc
+xa
+b
+3#caabc
+xa
+x e
+x c
 1 a
 bb
 2.hd f d
 3f
-2#hxhd f d
-b2.hd f d
+2#h
+xhd f d
+b
+2.hd f d
 3f
-2#hxhd f d
+2#h
+xhd f d
 b
 
-b2#i   axh    d2#fdaaxda c
 b
-1fdaa1dab  d
+2#i   a
+xh    d
+2#fdaa
+xda c
+b
+1fdaa
+1dab  d
 b
 bQ
 2fdaa
-3#fxd
-2#c  axa   d
+3#f
+xd
+2#c  a
+xa   d
 b
 2. ea c
 3 c
-2# axda   a
-b2#c    cxaa   d2#    ax ea c
+2# a
+xda   a
+b
+2#c    c
+xaa   d
+2#    a
+x ea c
 b
 1aac  a
 Yaac  a
@@ -1659,35 +2732,52 @@ B
 b
 S3
 1fdaa
-2#fdax   a
+2#fda
+x   a
 b
 1dabc
-2#dabx   c
-b2#cddaxaabc2# aa cx e
+2#dab
+x   c
+b
+2#cdda
+xaabc
+2# aa c
+x e
 b
 1aac  a
-2#aacx   c
+2#aac
+x   c
 bb
-2#abb dxd2#cddax d
-b2abb d
-3# dx b
+2#abb d
+xd
+2#cdda
+x d
+b
+2abb d
+3# d
+x b
 1 ab  d
 bQ
 2abb d
-3#cxd
+3#c
+xd
 2cdda
-3#ax d
+3#a
+x d
 b
 
 b
 2abb d
-3# dx b
+3# d
+x b
 1 ab  d
 b
 2abd a
-3# ax  d
+3# a
+x  d
 2aac  a
-3#  dx  c
+3#  d
+x  c
 b
 0acd a
 bb 
@@ -1698,7 +2788,9 @@ bQ
 0Qdabc
 1Qdab
 b
-1cdda1aabc1 ea c
+1cdda
+1aabc
+1 ea c
 b
 1.aac  a
 2aac
@@ -1719,14 +2811,21 @@ b
 b
 2.abb d
 3d
-2.cdda3# d2@abb d3Q b
+2.cdda
+3# d
+2@abb d
+3Q b
 b
 1. ab  d
 2 ab
 1   a
 b
 2abd a
-3# ax  d2Qaac  a3#  dx  c
+3# a
+x  d
+2Qaac  a
+3#  d
+x  c
 b
 Yacd a
 b
@@ -1905,14 +3004,21 @@ B
 B
 b
 Sc
-2#  d ax a2# c  ax ea c
+2#  d a
+x a
+2# c  a
+x ea c
 b
 2.aac  a
 3aac
-2#     axa
+2#     a
+xa
 bQ
-3#c  axd
-2f2#ea cxc
+3#c  a
+xd
+2f
+2#ea c
+xc
 b
 2.aac  a
 3aac
@@ -1921,23 +3027,56 @@ bQ
 bQ
 2a
 bX
-3#  d ax  cx  dx a3# cx ax cx d
-b3#aac  ax  ax  cx  d
-2#aac  axa
+3#  d a
+x  c
+x  d
+x a
+3# c
+x a
+x c
+x d
+b
+3#aac  a
+x  a
+x  c
+x  d
+2#aac  a
+xa
 b
 
 b
-3#c  axexfxc3#e  cxaxcx e
+3#c  a
+xe
+xf
+xc
+3#e  c
+xa
+xc
+x e
 bQ
 2.aac  a
 3aac
-2     abQ
+2     a
+bQ
 bQ
 2a
-bX2# dda  ax c2# ac  axa
-b2  d a
-3#  dx a3# cx d2a
-b2# d ax c2# ac  axa
+bX
+2# dda  a
+x c
+2# ac  a
+xa
+b
+2  d a
+3#  d
+x a
+3# c
+x d
+2a
+b
+2# d a
+x c
+2# ac  a
+xa
 b
 2.  dca
 3  dc
@@ -1950,23 +3089,44 @@ B
 BX
 bX
 Sc
-2#  d ax a2# c  ax ea c
+2#  d a
+x a
+2# c  a
+x ea c
 b
 2.aac  a
 3aac
-2#     axa
+2#     a
+xa
 b
-3#c  axd
-2f2#ea cxc
+3#c  a
+xd
+2f
+2#ea c
+xc
 b
 2.aac  a
 3aac
 2     a
-bbX2a
-b2# d ax c2# ac  axa
-bQ2  d a
-3#  dx a3# cx d2a
-b2# dda  ax c2# ac  axa
+bbX
+2a
+b
+2# d a
+x c
+2# ac  a
+xa
+bQ
+2  d a
+3#  d
+x a
+3# c
+x d
+2a
+b
+2# dda  a
+x c
+2# ac  a
+xa
 b
 2.  dca
 3  dc
@@ -1978,82 +3138,154 @@ B
 B
 b
 Sc
-2#      ax   c.2#  ax  b.
+2#      a
+x   c.
+2#  a
+x  b.
 b
 1  da  a
-2#  dax      a
+2#  da
+x      a
 b
-3# ax c.
-2 d:2# c.x a:
+3# a
+x c.
+2 d:
+2# c.
+x a:
 b
-1  dca1  dc
+1  dca
+1  dc
 b
-2# dda  axa2#c  axd
+2# dda  a
+xa
+2#c  a
+xd
 b
 1fcd a
-2#fcd.x    a
+2#fcd.
+x    a
 bQ
-3#c  axd.
-2f:2#   cxe.
+3#c  a
+xd.
+2f:
+2#   c
+xe.
 b
 
 b
 1fcd a
-2#fcdxf
+2#fcd
+xf
 b
-2# Qc  Qax Qd2#acd axc.
+2# Qc  Qa
+x Qd
+2#acd a
+xc.
 b
 2. dd   a
 3a
-2#cx d
-b2#da cxc2#acd axf.
+2#c
+x d
+b
+2#da c
+xc
+2#acd a
+xf.
 bX
-1 dda2#      a
+1 dda
+2#      a
 x  d.
-bQ2#  ax  b.2#   cx  a.
-b2#   a  ax   c.2#  ax   a.
-b2#  b  ax  a.2#   cx  d.
+bQ
+2#  a
+x  b.
+2#   c
+x  a.
+b
+2#   a  a
+x   c.
+2#  a
+x   a.
+b
+2#  b  a
+x  a.
+2#   c
+x  d.
 b
 
-b1Q dd   a1Q dda
-bb1  da  a
-2# ax  b.
+b
+1Q dd   a
+1Q dda
+bb
+1  da  a
+2# a
+x  b.
 b
 1  da  a
-2#  ax   a.
+2#  a
+x   a.
 b
 1  da  a
-2# ax  b.
-b2#  da  ax  a
+2# a
+x  b.
+b
+2#  da  a
+x  a
 1   a
 bQ
 1f     a
-2#hxd.
+2#h
+xd.
 b
 1f     Qa
-2#cx d
+2#c
+x d
 b
 1f     a
-2#hxd.b
-2#f     axc
+2#h
+xd.
+b
+2#f     a
+xc
 1 d
 b
 
 b
-3#      ax  b.
-2  d.2#  bx  a.b2#  Qbx  Qa2#   cx   a
+3#      a
+x  b.
+2  d.
+2#  b
+x  a.
 b
-3#      ax  b.
-2  d:2#  bx  a.
+2#  Qb
+x  Qa
+2#   c
+x   a
 b
-1 cd a1 dd   a
+3#      a
+x  b.
+2  d:
+2#  b
+x  a.
+b
+1 cd a
+1 dd   a
 bQ
-3#c  axd.
-2f:2#dxc
-b2#dxc.2#ax d.
+3#c  a
+xd.
+2f:
+2#d
+xc
 b
-3#c  axd.
-2f:2#dxc.
+2#d
+xc.
+2#a
+x d.
+b
+3#c  a
+xd.
+2f:
+2#d
+xc.
 b
 1acd a
 Y dd   a
@@ -2088,7 +3320,8 @@ b
 3 c
 2 e
 1a    Qa
-bbX2a
+bbX
+2a
 b
 1c   Qc
 2 e
@@ -2129,8 +3362,10 @@ b
 2 e
 1 a Qc
 2 a
-b2 c
-1 e  Qc1a    Qa
+b
+2 c
+1 e  Qc
+1a    Qa
 bbX
 2e
 b
@@ -2138,13 +3373,18 @@ b
 1 e
 1 a   Qa
 2e
-b2h   Qh
-1e1a    Qa
+b
+2h   Qh
+1e
+1a    Qa
 2e
-b2c   Qc
-1 e1 a Qc
+b
+2c   Qc
+1 e
+1 a Qc
 2 a
-b2 c
+b
+2 c
 1 e  Qc
 Ya    Qa
 b
@@ -2155,7 +3395,8 @@ B
 b
 Sc
 1aa - a
-2# afx c
+2# af
+x c
 b
 2. ea - /a
 3a
@@ -2163,71 +3404,131 @@ b
 b
 2.aa c a
 3# d
-x ca- cx a
+x ca- c
+x a
 2 c
-b2 aa c
-1      /a
-3#exf
 b
-2#hx a - e2# c- ax a - e
-b2#fc - cxea - a
+2 aa c
+1      /a
+3#e
+xf
+b
+2#h
+x a - e
+2# c- a
+x a - e
+b
+2#fc - c
+xea - a
 1ca  c
 b
 2aa - e
-3#ex    a
-2#caa cx      /a
+3#e
+x    a
+2#caa c
+x      /a
 bQ
 
 bQ
-1aac- a1   c
+1aac- a
+1   c
 bb
 2. ea - /a
 3a.
-2#cxea - a
-b2#fc - cxce  c
+2#c
+xea - a
+b
+2#fc - c
+xce  c
 1ef - a
 b
-2# a - exa2ccf  c
-3#  exa
+2# a - e
+xa
+2ccf  c
+3#  e
+xa
 b
 2 ea c
-3#      /ax c
-2# ax  d
-b2# ac- ax   c2#ca bx    c
+3#      /a
+x c
+2# a
+x  d
 b
-3#ea - axf.
-2h2#   exg.
+2# ac- a
+x   c
+2#ca b
+x    c
+b
+3#ea - a
+xf.
+2h
+2#   e
+xg.
 b
 
 b
-2#ha gx    h2#f- ex    f
-b2#aa - ex     a2# aa   Qbxc
-b2#  Qd exa2#fx   b
-b2ea c
-3#ax     a
-2#caa cx      /a
+2#ha g
+x    h
+2#f- e
+x    f
+b
+2#aa - e
+x     a
+2# aa   Qb
+xc
+b
+2#  Qd e
+xa
+2#f
+x   b
+b
+2ea c
+3#a
+x     a
+2#caa c
+x      /a
 b
 1fc e c
-2#haa - /ax f
-b2# ea - /ax a2#cxe
+2#haa - /a
+x f
+b
+2# ea - /a
+x a
+2#c
+xe
 b
 
-b2fc
-3#    ax e.
-2#efx     a
+b
+2fc
+3#    a
+x e.
+2#ef
+x     a
 b
 2caa   b
 1      /a
-3#exf
+3#e
+xf
 b
-2#hx a - e2# c- ax a - e
-b2#fc - cxea - a
+2#h
+x a - e
+2# c- a
+x a - e
+b
+2#fc - c
+xea - a
 1ca- c
 b
 2aa - e
-3#ex    a
-2#caa cx      /a
-b2#     axaac2#   cx  d
+3#e
+x    a
+2#caa c
+x      /a
+b
+2#     a
+xaac
+2#   c
+x  d
 b
 Yaac- a
 b
@@ -2239,49 +3540,66 @@ B
 b
 Sc
 1dabc
-2# dffxcdda
+2# dff
+xcdda
 bQ
-1aabc1 efec
+1aabc
+1 efec
 b
 2abb d
-3#cxd
-2#c d axa b
+3#c
+xd
+2#c d a
+xa b
 bQ
-1 ef c1   e
+1 ef c
+1   e
 bb
 2. da c
-3#    ax db  dx     c
+3#    a
+x db  d
+x     c
 2Qdab  a
 bQ
-3#caa cx   c
+3#caa c
+x   c
 2   b
 1aac  a
 b
 2. cd a
-3#     dx cd  cx     a
+3#     d
+x cd  c
+x     a
 2cdd   a
 bQ
 
 bQ
-3#acd ax d
+3#acd a
+x d
 2 c
 1 da   a
 b
 bQ
 2.cdda
-3#a   ex da cx    a
+3#a   e
+x da c
+x    a
 2ddf  d
 bQ
-3#cddaxa
+3#cdda
+xa
 2c
 1ddf  d
 b
-3#ddf  dx    a
+3#ddf  d
+x    a
 2 da c
-3#acd axc
+3#acd a
+xc
 2dab  a
 bQ
-2#caa cx   b
+2#caa c
+x   b
 Yaac  a
 b
 B
@@ -2291,7 +3609,8 @@ B
 b
 Sc
 1 dda
-2#  dx a
+2#  d
+x a
 b
 2. cd a
 3 d
@@ -2299,71 +3618,131 @@ b
 b
 2. dda  a
 3# b
-x a c ax  d
+x a c a
+x  d
 2 a
-b2 Qcdc
-1    a
-3#cxd
 b
-2#fx  d  c2# a   dx  d  c
-b2#da   axc da
+2 Qcdc
+1    a
+3#c
+xd
+b
+2#f
+x  d  c
+2# a   d
+x  d  c
+b
+2#da   a
+xc da
 1a d a
 b
 2 dd  c
-3#cx     d
-2#acdx    a
+3#c
+x     d
+2#acd
+x    a
 bQ
 
 bQ
-1 dda  a1   a
+1 dda  a
+1   a
 bb
 2. cd a
 3 d
-2#axc da
-b2#da   axac  a
+2#a
+xc da
+b
+2#da   a
+xac  a
 1cd a
 b
-2#  d  cx d2aad  a
-3#  cx d
+2#  d  c
+x d
+2aad  a
+3#  c
+x d
 b
 2 cdc
-3#    ax a
-2#  dx  b
-b2#  defx   a2#a d ex    a
+3#    a
+x a
+2#  d
+x  b
 b
-3#c daxd
-2f2#   cxe
+2#  def
+x   a
+2#a d e
+x    a
+b
+3#c da
+xd
+2f
+2#   c
+xe
 b
 
 b
-2#f dex    f2#d  cx    d
-b2# dd  cx   a2#  dcexa
-b2#  Qb cx d2#dx    e
-b2c da
-3# dx   a
-2#acdx    a
+2#f de
+x    f
+2#d  c
+x    d
+b
+2# dd  c
+x   a
+2#  dce
+xa
+b
+2#  Qb c
+x d
+2#d
+x    e
+b
+2c da
+3# d
+x   a
+2#acd
+x    a
 b
 1da c a
-2#fcd ax d
-b2# c cax  d2#axc
+2#fcd a
+x d
+b
+2# c ca
+x  d
+2#a
+xc
 b
 
-b2da
-3#     dx c
-2#cdx   a
+b
+2da
+3#     d
+x c
+2#cd
+x   a
 b
 2a dce
 1    a
-3#cxd
+3#c
+xd
 b
-2#fx  d  c2# a   dx  d  c
-b2#da   axc da
+2#f
+x  d  c
+2# a   d
+x  d  c
+b
+2#da   a
+xc da
 1a d a
 b
 2 dd  c
-3#cx     d
-2#acdx    a
-b2#    fx dd2#   ex   f
+3#c
+x     d
+2#acd
+x    a
+b
+2#    f
+x dd
+2#   e
+x   f
 b
 Y ddef
 b
@@ -2381,23 +3760,36 @@ bQ
 1aac  a
 1Q daac
 bQ
-3#aa c axcxdxa3#fcd axdxcxa
+3#aa c a
+xc
+xd
+xa
+3#fcd a
+xd
+xc
+xa
 bQ
-1caa c2#caax    c
+1caa c
+2#caa
+x    c
 bb
 2@ daac
 3Qabd a
 2# ab  d
 xaac  a
-b1caa c1aac  a
-bQ2@cdda
+b
+1caa c
+1aac  a
+bQ
+2@cdda
 3Qacc e
 1Q daac
 b
 
 b
 2Q dba d
-3# ddcax c
+3# ddca
+x c
 1Q dda  a
 b
 bQ
@@ -2411,11 +3803,22 @@ b
 1Qddf  d
 b
 2Qddf  d
-3#fxh
-2#fdd   axda c abQ
-1caa c1aac  abQ
-3#aacc axcxdxa
-3#fcd axdxcxa
+3#f
+xh
+2#fdd   a
+xda c a
+bQ
+1caa c
+1aac  a
+bQ
+3#aacc a
+xc
+xd
+xa
+3#fcd a
+xd
+xc
+xa
 bQ
 Ycaabc
 b
@@ -2427,17 +3830,24 @@ b
 S3
 1 \3d\2da
 2      a
-b2  aa
+b
+2  aa
 1  \3d.
 b
 2.c- a
 3a.
 2 \3d:
-b2#a - ax \1c.x      ///a
+b
+2#a - a
+x \1c.
+x      ///a
 b
 1 \3d\2da
 2      a
-b2#  aax  \3d.x-\1c:
+b
+2#  aa
+x  \3d.
+x-\1c:
 b
 2.a - a
 3 \3d.
@@ -2460,12 +3870,16 @@ b
 3a
 2 \3d
 b
-2#a - ax cx      ///a
+2#a - a
+x c
+x      ///a
 b
 1 \3d\2da
 2      a
 b
-2#  aax  \3d.x-\1c:
+2#  aa
+x  \3d.
+x-\1c:
 b
 2.a - a
 3 \3d.
@@ -2491,7 +3905,11 @@ b
 2 c
 2@ a c
 3Q  d
-b3# aUx  dXx  cUx  aX
+b
+3# aU
+x  dX
+x  cU
+x  aX
 2   c
 b
 1  dca
@@ -2500,19 +3918,32 @@ b
 2.    e
 3   a
 2   c
-b2# cx a cx  Qc
+b
+2# c
+x a c
+x  Qc
 b
 1@  dca
 bb
 
 bb
-2# cx a cx  d
+2# c
+x a c
+x  d
 b
-3# aUx cX
-2# a cx  d
-bQ2# cx a cx  d
+3# aU
+x cX
+2# a c
+x  d
+bQ
+2# c
+x a c
+x  d
 b
-3# a Ux  dXx  cUx  aX
+3# a U
+x  dX
+x  cU
+x  aX
 2  c
 b
 1  dca
@@ -2521,7 +3952,8 @@ b
 2.    e
 3   a
 2   c
-b2 c
+b
+2 c
 2. a c
 3  d
 b
@@ -2662,18 +4094,27 @@ bQ
 bQ
 1
 2 a
-b2# b  Qax dx b2. a   Qd3  d2 a
+b
+2# b  Qa
+x d
+x b
+2. a   Qd
+3  d
+2 a
 b
 1  d Qa
 2  d
-2#c  Qaxaxc
+2#c  Qa
+xa
+xc
 b
 
 b
 1d  Qc
 2 d
 2#a   Qd
-x dx b
+x d
+x b
 bX
 1. a   Qd
 bQ
@@ -2697,7 +4138,9 @@ b
 b
 1d  Qc
 2 d
-2#a   Qdx dx b
+2#a   Qd
+x d
+x b
 b
 1. a   Qd
 Y  b
@@ -2784,82 +4227,165 @@ BX
 bX
 S3
 2 d
-b2#cx      axd2# dxf
+b
+2#c
+x      a
+xd
+2# d
+xf
 x d
 b
 1.#a   a
 1 c
 2  d
-b2# dx      ax   a1Q     c2  d
+b
+2# d
+x      a
+x   a
+1Q     c
+2  d
 b
 1.   +ca
 1      ///a
 2   c
-b2  a
+b
+2  a
 1      a
 2  d
 1     c
 b
-2# a - dx cx d2a
+2# a - d
+x c
+x d
+2a
 1     a
 b
-2# c  ax dxa2#cx     cxa
+2# c  a
+x d
+xa
+2#c
+x     c
+xa
 b
 
-b2# d- cxax b  a2 a
+b
+2# d- c
+xa
+x b  a
+2 a
 1     d
 b
-2#  d- cx ax     a2#  bx  dx      a
-b2#  ax  bx      /a2#   cx   ex   a- a
-b2#    ex      ///ax  d2#      ax   ex   #ca
-b2   a
+2#  d- c
+x a
+x     a
+2#  b
+x  d
+x      a
+b
+2#  a
+x  b
+x      /a
+2#   c
+x   e
+x   a- a
+b
+2#    e
+x      ///a
+x  d
+2#      a
+x   e
+x   #ca
+b
+2   a
 1      a
 1
 bb
 2   ,c
-b2#    ex      ///ax    a
+b
+2#    e
+x      ///a
+x    a
 1  d
 2   c
 b
 
-b2#  ax      ax  d2#   cx      /ax  b
-b2#  ax      ax   a
+b
+2#  a
+x      a
+x  d
+2#   c
+x      /a
+x  b
+b
+2#  a
+x      a
+x   a
 1 d
 2  d
-b2 a
+b
+2 a
 1     d
 1a
 2 c
-bQ1Q    a2a&,
+bQ
+1Q    a
+2a&,
 1a -- e
 2 a
-b2# cx    ax  a&,
+b
+2# c
+x    a
+x  a&,
 1  b
 2 d
 b
-2#  ax    ax c2#   cx     ex a
+2#  a
+x    a
+x c
+2#   c
+x     e
+x a
 b
 
-b2#   ax     cx  d2#    ex     ax  b
-b1Q  a2   a
+b
+2#   a
+x     c
+x  d
+2#    e
+x     a
+x  b
+b
+1Q  a
+2   a
 1c
 2f
 b
 1@f d-- /a
-2#c  -  ax dxf
+2#c  -  a
+x d
+xf
 b
 1@f d   ///a
 2@      //a
 3d
 2c
-b2@a  -  /a
+b
+2@a  -  /a
 3c
 2d
 2@c  -  a
 3d
 2f
-b2# c    ///ax  dxf1Q      a2c
-bQ1Qa - a2 dY      a
+b
+2# c    ///a
+x  d
+xf
+1Q      a
+2c
+bQ
+1Qa - a
+2 d
+Y      a
 b
 B
 
@@ -2869,38 +4395,60 @@ BX
 bX
 S3
 2a
-b2# c  ax  dx  d1  d e
+b
+2# c  a
+x  d
+x  d
+1  d e
 2f
 b
 1.c     a
 1   a
 2h
-b2#e  c axaxa
+b
+2#e  c a
+xa
+xa
 1a  c
 2f
 b
 1. c  a
 1    a
 2a
-b2# a  cx ax a
+b
+2# a  c
+x a
+x a
 1 a  c
 2a
-b2# c  ax  dx  d
+b
+2# c  a
+x  d
+x  d
 1  d e
 2f
 b
 
-b2#c  axcxc
+b
+2#c  a
+xc
+xc
 1c  a
 2h
 b
 1.a  c
 1   c
 2f
-b2#c daxcxc
+b
+2#c da
+xc
+xc
 1ca  c
 2h
-b2#e   exaxa
+b
+2#e   e
+xa
+xa
 2.f   a
 3h
 2k
@@ -2923,24 +4471,45 @@ b
 2.f d e
 3h
 2.k   a
-b2#h    exhxf    c
+b
+2#h    e
+xh
+xf    c
 2.e    a
 3c
 2a     a
 b
-2#f   ex cx c  c
+2#f   e
+x c
+x c  c
 1 c  a
 2a
 b
 1. ac  a
 1Q   Qc
 bbX
-3# cx d
-b2#a   axax c2#a   axax  d
+3# c
+x d
+b
+2#a   a
+xa
+x c
+2#a   a
+xa
+x  d
 b
 
-b2#a   axax c2#a   axax  d
-b2#a   axaxa    e
+b
+2#a   a
+xa
+x c
+2#a   a
+xa
+x  d
+b
+2#a   a
+xa
+xa    e
 2.c    c
 3e
 2f   a
@@ -2948,14 +4517,34 @@ b
 1.ea c a
 1.ha gh
 b
-2#kf hxkxf2#hffgxhxa
-b2#c dexfx  d2 ccc
+2#kf h
+xk
+xf
+2#hffg
+xh
+xa
+b
+2#c de
+xf
+x  d
+2 ccc
 1aa
 b
 
 b
-2#c daxcx d e2#a d exax c c
-b2# aa cx dx ac2# c  ax  dxf   e
+2#c da
+xc
+x d e
+2#a d e
+xa
+x c c
+b
+2# aa c
+x d
+x ac
+2# c  a
+x  d
+xf   e
 b
 2.ea c
 3c
@@ -2999,7 +4588,10 @@ b
 2 c  a
 1 a   e
 2 d  c
-b2# c  ax  dxfc
+b
+2# c  a
+x  d
+xfc
 2.ea c a
 3c
 2e
@@ -3007,16 +4599,42 @@ b
 1.fQcQd a
 1Q  Qd
 bbX
-3# cx d
+3# c
+x d
 b
 
 b
-2#a   ax cxc2#a   ax cx  d
+2#a   a
+x c
+xc
+2#a   a
+x c
+x  d
 b
-3#a   ex dx cx dxaxc3#a   cx dx cx a
+3#a   e
+x d
+x c
+x d
+xa
+xc
+3#a   c
+x d
+x c
+x a
 2  d
 b
-3#  dcax ax cx dxa    exc3#e   exfxhxfxe   axc
+3#  dca
+x a
+x c
+x d
+xa    e
+xc
+3#e   e
+xf
+xh
+xf
+xe   a
+xc
 b
 3#e    a
 x     c
@@ -3031,32 +4649,42 @@ x  c
 x  d
 x a
 b
-3#fcdxh
+3#fcd
+xh
 2#k
 x  h
-3#eacxf
+3#eac
+xf
 2#h
 x a
 b
 
 b
-3#c axe
+3#c a
+xe
 2#f
 x  d
 2#e  c
 xa
 x  c
 b
-3# dfaxa
+3# dfa
+xa
 2#c
 x  a
-3# c  ex d
+3# c  e
+x d
 2#a
 x   c
 b
 2 da c
-3#ax dx ccx a
-2# c  ax  dxfc
+3#a
+x d
+x cc
+x a
+2# c  a
+x  d
+xfc
 b
 2.ea c
 3f  e
@@ -3101,7 +4729,10 @@ b
 2. a   e
 3    a
 2 d  c
-b2# c  ax  dxfc
+b
+2# c  a
+x  d
+xfc
 2.ea c a
 3c
 2e
@@ -3115,7 +4746,10 @@ BX
 bX
 Sc
 2a
-b2# Qc  Qax  dx  d
+b
+2# Qc  Qa
+x  d
+x  d
 bQ
 1  d Qe
 2f
@@ -3124,7 +4758,10 @@ b
 bQ
 1
 2h
-b2#e  Qcxaxa
+b
+2#e  Qc
+xa
+xa
 bQ
 1a  Qc
 2f
@@ -3133,17 +4770,27 @@ b
 bQ
 1Q
 2a
-b2# a  Qcx ax a
+b
+2# a  Qc
+x a
+x a
 bQ
 2. a  Qc
 3 c
 2 d
-bQbQ
-2# c  Qax  dx  d
+bQ
+
+bQ
+2# c  Qa
+x  d
+x  d
 bQ
 1  d Qe
 2f
-bQ2#c  Qaxcxc
+bQ
+2#c  Qa
+xc
+xc
 bQ
 1c  Qa
 2h
@@ -3152,7 +4799,10 @@ b
 bQ
 1
 2f
-b2#c  Qaxcxc
+b
+2#c  Qa
+xc
+xc
 bQ
 1h    Qa
 2a
@@ -3166,7 +4816,10 @@ bQ
 2k
 bQ
 
-bQ2#h    Qaxaxa
+bQ
+2#h    Qa
+xa
+xa
 bQ
 1a   Qa
 2f
@@ -3175,17 +4828,25 @@ bQ
 bQ
 1.c  Qa
 bQ
-2#e    Qaxexa
+2#e    Qa
+xe
+xa
 bQ
 2.f   Qa
 3h
 2k
-bQ2#h    Qexhxf    Qc
+bQ
+2#h    Qe
+xh
+xf    Qc
 bQ
 1e    Qa
-3#c  Qaxe
+3#c  Qa
+xe
 bQ
-2#f   Qex cx c
+2#f   Qe
+x c
+x c
 bQ
 1 c  Qa
 2 c
@@ -3197,19 +4858,34 @@ b
 1
 b2
 b
-3#ax d
+3#a
+x d
 bX
-2# c  Qax  dx  db2  d Qe
-3#fxexcxa
+2# c  Qa
+x  d
+x  d
+b
+2  d Qe
+3#f
+xe
+xc
+xa
 b
 1.c  Qa
 bQ
 1
-3#hxf
+3#h
+xf
 b
-2#e    Qaxaxa
-bQ2a    Qa
-3#fxexfx  d
+2#e    Qa
+xa
+xa
+bQ
+2a    Qa
+3#f
+xe
+xf
+x  d
 b
 1. c  Qa
 bQ
@@ -3218,68 +4894,154 @@ bQ
 1
 2a
 b
-3# a  Qcx  dx  cx  a
+3# a  Qc
+x  d
+x  c
+x  a
 2   c
-b3# a  Qcx  dx ax cx dxa
 b
-2# c  Qax  dx  d
-b2  d Qe
-3#fxexcxa
+3# a  Qc
+x  d
+x a
+x c
+x d
+xa
 b
-2#c  Qaxcxc
-b2c  Qa
-3#hxfxexc
+2# c  Qa
+x  d
+x  d
+b
+2  d Qe
+3#f
+xe
+xc
+xa
+b
+2#c  Qa
+xc
+xc
+b
+2c  Qa
+3#h
+xf
+xe
+xc
 b
 1.a    Qa
 bQ
 1
-3#fxe
+3#f
+xe
 b
 
-b3#c  Qaxaxcxexfxc
+b
+3#c  Qa
+xa
+xc
+xe
+xf
+xc
 bQ
 1h    Qa
 2a
 bQ
-3#a   Qax dxaxcxexa
-bQ3#f   Qaxexfxhxkxl
+3#a   Qa
+x d
+xa
+xc
+xe
+xa
+bQ
+3#f   Qa
+xe
+xf
+xh
+xk
+xl
 b
-2#h    Qaxhxa
-b2a    Qa
-3#cxe
+2#h    Qa
+xh
+xa
+b
+2a    Qa
+3#c
+xe
 2f
 bQ
-3# c  Qax ax  dx  c
+3# c  Qa
+x a
+x  d
+x  c
 2  a
 bQ
-3#c  Qaxax dx c
+3#c  Qa
+xa
+x d
+x c
 2 a
-bQ2#e    Qaxexa
+bQ
+2#e    Qa
+xe
+xa
 bQ
 
 bQ
-3#f   Qaxexfxhxkxl
+3#f   Qa
+xe
+xf
+xh
+xk
+xl
 b
-2#h    Qexhxf    Qc
+2#h    Qe
+xh
+xf    Qc
 b
-3#e    Qaxcxexfxhxe
+3#e    Qa
+xc
+xe
+xf
+xh
+xe
 b
-2#f   Qex cx c
+2#f   Qe
+x c
+x c
 b
-3# c  Qax ax cx dxax c
+3# c  Qa
+x a
+x c
+x d
+xa
+x c
 b
 1. a   Qa
 bQ
 1
 2a
 b
-bQ2#a   Qaxax c
+bQ
+2#a   Qa
+xa
+x c
 b
 
-b2#a   Qaxax  d
-b2#a   Qaxax c
-b2#a   Qaxax  d
-b2#a   Qaxaxa
+b
+2#a   Qa
+xa
+x  d
+b
+2#a   Qa
+xa
+x c
+b
+2#a   Qa
+xa
+x  d
+b
+2#a   Qa
+xa
+xa
 b
 1a   Qa
 2f
@@ -3289,23 +5051,51 @@ b
 b
 1a    Qa
 2h
-b2#k   Qaxkxf
-b2#h    Qaxhxa
+b
+2#k   Qa
+xk
+xf
+b
+2#h    Qa
+xh
+xa
 bQ
-2#f   Qaxfx  d
+2#f   Qa
+xf
+x  d
 b
 
 b
 2 c  Qa
 1a
 b
-2#c  Qaxcx d
-b2#a   Qaxax  d
-b2# a   Qax dx a
-b2# c  Qax  dxf
-b2#e    Qaxaxe
-b2#f   Qaxhxk
-b2#h    Qaxkxl
+2#c  Qa
+xc
+x d
+b
+2#a   Qa
+xa
+x  d
+b
+2# a   Qa
+x d
+x a
+b
+2# c  Qa
+x  d
+xf
+b
+2#e    Qa
+xa
+xe
+b
+2#f   Qa
+xh
+xk
+b
+2#h    Qa
+xk
+xl
 b
 1k   Qa
 2k
@@ -3351,74 +5141,185 @@ bQ
 b
 
 b
-bQ2#a   Qaxax c
+bQ
+2#a   Qa
+xa
+x c
 b
-3#a   Qax dx cx a
+3#a   Qa
+x d
+x c
+x a
 2  d
 b
-3#a   Qax  dx cx dxaxc
-b3#a   Qax dx cx a
+3#a   Qa
+x  d
+x c
+x d
+xa
+xc
+b
+3#a   Qa
+x d
+x c
+x a
 2  d
 b
-3#a   Qax cx  dxax cx  d
-b3#a   Qax  dxax cx  dxf
+3#a   Qa
+x c
+x  d
+xa
+x c
+x  d
 b
-2#e    Qaxaxa
+3#a   Qa
+x  d
+xa
+x c
+x  d
+xf
+b
+2#e    Qa
+xa
+xa
 bQ
 1a    Qa
 2h
 b
 
 b
-3#k   axlxkxh
+3#k   a
+xl
+xk
+xh
 2f
-b2#h    Qaxhxa
-b2#f   Qaxf
-3#  dx  c
+b
+2#h    Qa
+xh
+xa
+b
+2#f   Qa
+xf
+3#  d
+x  c
 bQ
-3#  d Qax ax cx dxax c
+3#  d Qa
+x a
+x c
+x d
+xa
+x c
 b
-2#c  Qaxcx d
-b2#a   Qaxax  d
+2#c  Qa
+xc
+x d
 b
-3# a   Qax  dx ax cx dx a
+2#a   Qa
+xa
+x  d
 b
-2# c  Qax  dxf
+3# a   Qa
+x  d
+x a
+x c
+x d
+x a
+b
+2# c  Qa
+x  d
+xf
 b
 
 b
-3#e    Qaxcxexaxcxe
-b3#f   Qaxexfxhxkxf
-b3#h    Qaxfxhxkxlxh
+3#e    Qa
+xc
+xe
+xa
+xc
+xe
+b
+3#f   Qa
+xe
+xf
+xh
+xk
+xf
+b
+3#h    Qa
+xf
+xh
+xk
+xl
+xh
 b
 2k   Qa
-3#fxhxkxl
+3#f
+xh
+xk
+xl
 b
 2h    Qa
-3#exfxhxk
+3#e
+xf
+xh
+xk
 b
 2f   Qa
-3#cxexfxh
+3#c
+xe
+xf
+xh
 bQ
 2e    Qa
-3#axcxexf
+3#a
+xc
+xe
+xf
 b
 
 b
 2c  Qa
-3# dxaxcxd
+3# d
+xa
+xc
+xd
 b
 2a   Qa
-3# cx dxaxc
+3# c
+x d
+xa
+xc
 b
 2 d Qa
-3# ax cx dxa
-b3# c  Qax ax  dx ax cx d
-b3# a   Qax  dx  cx  dx ax c
+3# a
+x c
+x d
+xa
+b
+3# c  Qa
+x a
+x  d
+x a
+x c
+x d
+b
+3# a   Qa
+x  d
+x  c
+x  d
+x a
+x c
 b
 1  d Qa
-3#fxh
-bQ3#k   Qaxfxhxaxcxe
+3#f
+xh
+bQ
+3#k   Qa
+xf
+xh
+xa
+xc
+xe
 b
 1.f
 b
@@ -4739,56 +6640,93 @@ b
 B
 
 { }
-{App 2. In Frulinngs zeit (In spring time) - 7F ABC8/D-BAU 13.4o.85, pp. 80-81}BX
+{App 2. In Frulinngs zeit (In spring time) - 7F ABC8/D-BAU 13.4o.85, pp. 80-81}
+BX
 bX
 Sc
 2. dda
 3 c
-2# a   dx cd a
-b2 dda
-3# ax c
-2# dx dda
-b2#acd axcdda2#da cxa   e
+2# a   d
+x cd a
+b
+2 dda
+3# a
+x c
+2# d
+x dda
+b
+2#acd a
+xcdda
+2#da c
+xa   e
 b
 2.cdda
 3d
-2#cxa   e
+2#c
+xa   e
 b
-3#c  axe
-2f2# a  cxe
+3#c  a
+xe
+2f
+2# a  c
+xe
 b
 2.f - a
 4#d
 xc
-2#ax d
-b2#acd ax da c2. cd a
+2#a
+x d
+b
+2#acd a
+x da c
+2. cd a
 4# a
 x c
 b
-2# dx   a
+2# d
+x   a
 1      a
 bb
 
 bb
-3# ddaxaxcxd
-2#fxc  a
+3# dda
+xa
+xc
+xd
+2#f
+xc  a
 b
-1da c1acd a
+1da c
+1acd a
 b
-3#  d ax ax cx d
-2#a - ax c
+3#  d a
+x a
+x c
+x d
+2#a - a
+x c
 b
 2. da c
 3 c
 1Q acc
 b
-3# a   ax  dx ax c
-2# da cx acc
-b2 cd a
-3# ax c
-2# da cx cd a
-b2# accx  de
-3# a ax  d
+3# a   a
+x  d
+x a
+x c
+2# da c
+x acc
+b
+2 cd a
+3# a
+x c
+2# da c
+x cd a
+b
+2# acc
+x  de
+3# a a
+x  d
 2  c
 b
 1  d a
@@ -4797,25 +6735,48 @@ bb
 
 bb
 2fdaa
-3#cxd
-2#fxda c
+3#c
+xd
+2#f
+xda c
 b
-1cdda1acd a
+1cdda
+1acd a
 b
-3#cddaxaxcxd
-2#c  axacd a
+3#cdda
+xa
+xc
+xd
+2#c  a
+xacd a
 b
-1 da c1 ca  c
+1 da c
+1 ca  c
 b
-3# da cx cx dxa
-2# da cx cd a
+3# da c
+x c
+x d
+xa
+2# da c
+x cd a
 b
-3# a   dx  dx ax c3# dx ax cx d
-b2# cd ax d  c
-3#a   Qex d
+3# a   d
+x  d
+x a
+x c
+3# d
+x a
+x c
+x d
+b
+2# cd a
+x d  c
+3#a   Qe
+x d
 2 cd a
 b
-1 ddaY      a
+1 dda
+Y      a
 b
 B
 
@@ -4910,58 +6871,121 @@ B
 B
 b
 Sc
-2.aa - a3c2#dxf
-b2#hx f2# eaxf
+2.aa - a
+3c
+2#d
+xf
+b
+2#h
+x f
+2# ea
+xf
 b
 2.df - a
 3 a.
-2# bx a.
-b2 bbc
-3#dx    c2#c daxa - d
-b2 ea c
-3#      /axa
-2#cxda
-b2#axc d2dd f
-3#     dxf
-bQ2#hxi - a2#h    dx d
+2# b
+x a.
+b
+2 bbc
+3#d
+x    c
+2#c da
+xa - d
+b
+2 ea c
+3#      /a
+xa
+2#c
+xda
+b
+2#a
+xc d
+2dd f
+3#     d
+xf
+bQ
+2#h
+xi - a
+2#h    d
+x d
 b
 
-b2#f g axda - a2#caa cx      /a
-b2#     axaac2#   cx  d
+b
+2#f g a
+xda - a
+2#caa c
+x      /a
+b
+2#     a
+xaac
+2#   c
+x  d
 b
 0aac- a
 bb
 1.h
 2     a
-b2#     dx     a
-2#fc - cx e
-b2dQf - a
+b
+2#     d
+x     a
+2#fc - c
+x e
+b
+2dQf - a
 1f
 2 da c
-b2a   d
-3#f - dxd.
-2#ca  cxda   d
 b
-3#    ax bx    cx d3#    dxax   axc
+2a   d
+3#f - d
+xd.
+2#ca  c
+xda   d
+b
+3#    a
+x b
+x    c
+x d
+3#    d
+xa
+x   a
+xc
 b
 
 b
-2#     dxddf
+2#     d
+xddf
 2.   f
-4#cc- axa
+4#cc- a
+xa
 b
-2# ea cx      /a
+2# ea c
+x      /a
 1   e
 b
-2# aa - /axc
+2# aa - /a
+xc
 1h
 b
-2#c  -  bx  a2da - a
-3#cxa.
+2#c  -  b
+x  a
+2da - a
+3#c
+xa.
 bQ
-2#fc - cxca- c2#df - dxhd
-b2#f g axda - a2#ca  cx      /a
-b2#     axaac2#   cx  d
+2#fc - c
+xca- c
+2#df - d
+xhd
+b
+2#f g a
+xda - a
+2#ca  c
+x      /a
+b
+2#     a
+xaac
+2#   c
+x  d
 b
 Yaac  a
 b
@@ -4972,170 +6996,349 @@ B
 B
 b
 Sc
-2# aa +cx      /a2# dxc
-b2#a - ax d.2# c - cx  e.
-b2# aa +cx      /a2# +dxc.
-b2#caa - /ax a.2# d -- /axc.
-b2#+fxc.2#c- ax d.
-b2#a - ax c.2# c- ax  d.
-b2# aa cxh2#h axg
-b2#haa   /ax      /a
+2# aa +c
+x      /a
+2# d
+xc
+b
+2#a - a
+x d.
+2# c - c
+x  e.
+b
+2# aa +c
+x      /a
+2# +d
+xc.
+b
+2#caa - /a
+x a.
+2# d -- /a
+xc.
+b
+2#+f
+xc.
+2#c- a
+x d.
+b
+2#a - a
+x c.
+2# c- a
+x  d.
+b
+2# aa c
+xh
+2#h a
+xg
+b
+2#haa   /a
+x      /a
 1haa
 bb
 
 bb
-3# aa-cx  d.x ax c.3# d -- /axa.xcx d.
-b3#a - Qax d.x cx a.3#  e- cx  a.x  cx  e.
-b3# aa cx  d.x ax c.3# dxa.xcxd.
+3# aa-c
+x  d.
+x a
+x c.
+3# d -- /a
+xa.
+xc
+x d.
+b
+3#a - Qa
+x d.
+x c
+x a.
+3#  e- c
+x  a.
+x  c
+x  e.
+b
+3# aa c
+x  d.
+x a
+x c.
+3# d
+xa.
+xc
+xd.
 b
 2-*caa - /a
-3# ax c.3# dxa.xcxd.
-b3#f- axd.xcxa.3# d axa.xcx d.
+3# a
+x c.
+3# d
+xa.
+xc
+xd.
+b
+3#f- a
+xd.
+xc
+xa.
+3# d a
+xa.
+xc
+x d.
 b
 
-b3#a - ax d.x cx a.3#  d-a
-x a.x cx  d.
-b3# a- cx c.x dx a.3#  e- cx a.x cx  e.
 b
-2# aa +cx      /a
+3#a - a
+x d.
+x c
+x a.
+3#  d-a
+x a.
+x c
+x  d.
+b
+3# a- c
+x c.
+x d
+x a.
+3#  e- c
+x a.
+x c
+x  e.
+b
+2# aa +c
+x      /a
 1 aa
 bb
-3#c:x a.x      /axa;3# c:x  d.x    ax c.
-b3#a:x a.x      /axa;3# c:x  a.x     cx c.
+3#c:
+x a.
+x      /a
+xa;
+3# c:
+x  d.
+x    a
+x c.
+b
+3#a:
+x a.
+x      /a
+xa;
+3# c:
+x  a.
+x     c
+x c.
 b
 
-b3# a:x  a.x    cx a;3# d:x  a.x    cx d.
-b3# a:x  a.x    cx c.3# d:x  a.x    cxa.
 b
-3#c:x d.x   axc.3#f:x d.x   axf.
-b3#a:x c.x    axa;3# c:x  d.x    ax c.
-b3# a:x  a.x    cxh.3#  axh.
+3# a:
+x  a.
+x    c
+x a;
+3# d:
+x  a.
+x    c
+x d.
+b
+3# a:
+x  a.
+x    c
+x c.
+3# d:
+x  a.
+x    c
+xa.
+b
+3#c:
+x d.
+x   a
+xc.
+3#f:
+x d.
+x   a
+xf.
+b
+3#a:
+x c.
+x    a
+xa;
+3# c:
+x  d.
+x    a
+x c.
+b
+3# a:
+x  a.
+x    c
+xh.
+3#  a
+xh.
 2-*g
 b
-2#haa - /ax      /a
+2#haa - /a
+x      /a
 1haa
 bb
 
 bb
 3. aa +c
 4 c
-2 d3. da - /a
+2 d
+3. da - /a
 4a
-2cb
+2c
+b
 3.a - Qa
 4c
-2 d3. ca- c
+2 d
+3. ca- c
 4 a
-2 cb
+2 c
+b
 3. aa c
 4 c
-2 d3. d -- /a
+2 d
+3. d -- /a
 4a
-2cb
+2c
+b
 3.caa - /a
 4a
-2 d3.a - a
-4c
-2db
-3.f- a
-4d
-2f3.f- a
-4c
-2 db
+2 d
 3.a - a
 4c
-2a3.a - a
+2d
+b
+3.f- a
+4d
+2f
+3.f- a
+4c
+2 d
+b
+3.a - a
+4c
+2a
+3.a - a
 4 c
-2  db
+2  d
+b
 
 b
 3. aa-c
 4 c
-2 d3. ca- c
+2 d
+3. ca- c
 4 a
-2 cb
-2# aa +cx      /a
+2 c
+b
+2# aa +c
+x      /a
 Y aa
 bb
 S3
 2@ aa +c
 3Q c
-2 d2@ da - /a
+2 d
+2@ da - /a
 3Qa
-2cb
+2c
+b
 2@a - Qa
 3c
-2 d2@ ca- c
+2 d
+2@ ca- c
 3Q a
-2 cb
+2 c
+b
 2@ aa c
 3Q c
-2 d2@ d -- /a
+2 d
+2@ d -- /a
 3Qa
-2cb
+2c
+b
 2@caa - /a
 3Qa
-2 d2@a - a
+2 d
+2@a - a
 3Qc
-2db
+2d
+b
 
 b
 2@f- a
 3Qd
-2f2@f- a
+2f
+2@f- a
 3Qc
-2 db
+2 d
+b
 2@a - a
 3Qc
-2a2@a - a
+2a
+2@a - a
 3Q c
-2  db
+2  d
+b
 2@ aa-c
 3Q c
-2 d2@ ca- c
+2 d
+2@ ca- c
 3Q a
-2 cb
-1Q aa +c2      /a
+2 c
+b
+1Q aa +c
+2      /a
 1@ aa
 bb
 2# aa +c
 x c
-x d2# da - /a
+x d
+2# da - /a
 xa
-xcb
+xc
+b
 2#a - Qa
 xc
-x d2# ca- c
+x d
+2# ca- c
 x a
-x cb
+x c
+b
 
 b
 2# aa c
 x c
-x d2# d -- /a
+x d
+2# d -- /a
 xa
-xcb
+xc
+b
 2#caa - /a
 xa
-x d2#a - a
-xc
-xdb
-2#f- a
-xd
-xf2#f- a
-xc
-x db
+x d
 2#a - a
 xc
-xa2#a - a
+xd
+b
+2#f- a
+xd
+xf
+2#f- a
+xc
+x d
+b
+2#a - a
+xc
+xa
+2#a - a
 x c
-x  db
+x  d
+b
 2# aa-c
 x c
-x d2# ca- c
+x d
+2# ca- c
 x a
-x cb
-1 aa +c2      /a
+x c
+b
+1 aa +c
+2      /a
 Y aa
 b
 B
@@ -5152,10 +7355,14 @@ b
 3 d.
 b
 3.a - a
-4 b.3.  d
-4b.3.a   a
-4 b.3.  d
-4  d.b
+4 b.
+3.  d
+4b.
+3.a   a
+4 b.
+3.  d
+4  d.
+b
 2. *bd a
 3 b.
 2. db  d
@@ -5170,16 +7377,20 @@ bb
 
 bb
 3.a - d
-4b.2d:
+4b.
+2d:
 3.d - d
-4f.2d
+4f.
+2d
 b
 3. f- d
-4 g.3d:
+4 g.
+3d:
 4# g
 xd.
 3.f
-4d.2 f
+4d.
+2 f
 b
 2.+f - a
 3  d.
@@ -5187,7 +7398,9 @@ b
 3 d- c
 b
 3.a - d
-4   a3# adcx  *c.
+4   a
+3# adc
+x  *c.
 Y  +dca
 b
 B
@@ -5203,10 +7416,14 @@ b
 x d.
 b
 3#a - a
-x b.x  d
-xb.3#a   a
-x b.x  d
-x  d.b
+x b.
+x  d
+xb.
+3#a   a
+x b.
+x  d
+x  d.
+b
 2. *bd a
 3 b.
 2# db  d
@@ -5221,16 +7438,20 @@ bb
 
 bb
 3#a - d
-xb.2d:
+xb.
+2d:
 3#d - d
-xf.2d
+xf.
+2d
 b
 3# f- d
-x g.3d:
+x g.
+3d:
 4# g
 xd.
 3#f
-xd.2 f
+xd.
+2 f
 b
 2.+f - a
 3  d.
@@ -5238,7 +7459,9 @@ b
 x d- c
 b
 3#a - d
-x   ax adcx  *c.
+x   a
+x adc
+x  *c.
 Y  +dca
 b
 B
@@ -5250,15 +7473,29 @@ bX
 S3
 2i - a
 b
-2#*h -- axa.xf - abQ
-2#*e -- axa.xf - a
+2#*h -- a
+xa.
+xf - a
+bQ
+2#*e -- a
+xa.
+xf - a
 b
 2.*ea - a
 3f.
-2hbQ
-2#i - axlxi.
-b2#*h -- axa.xf - abQ
-2#*e -- axa.xf - a
+2h
+bQ
+2#i - a
+xl
+xi.
+b
+2#*h -- a
+xa.
+xf - a
+bQ
+2#*e -- a
+xa.
+xf - a
 b
 2.+h -- a
 3f.
@@ -5269,18 +7506,34 @@ bbX
 2-*a.
 bQ
 
-bQ2# d- cx     dx *b- a
-b2# a - ax  *c.x   cbQ
-2#  d-ax *bx d - d
+bQ
+2# d- c
+x     d
+x *b- a
+b
+2# a - a
+x  *c.
+x   c
+bQ
+2#  d-a
+x *b
+x d - d
 bQ
 1Qa*b- d
-2+d.bQ
-2# d- cx     dx *b- abQ
-2# a - ax  *c.x  +dca
+2+d.
+bQ
+2# d- c
+x     d
+x *b- a
+bQ
+2# a - a
+x  *c.
+x  +dca
 b
 2. a-a
 3  d.
-2 a*ccbQ
+2 a*cc
+bQ
 Y *cdca
 b
 B
@@ -5460,15 +7713,29 @@ bX
 S3
 2d -- a
 b
-2#*c - Qc /ax a.xa -- abQ
-2# *e- Qc /ax a.xa -- a
+2#*c - Qc /a
+x a.
+xa -- a
+bQ
+2# *e- Qc /a
+x a.
+xa -- a
 b
 2. *ea-Qc /a
 3a.
-2cbQ
-2#d -- axfxd.
-b2#*c - Qc /ax a.xa -- abQ
-2# *e- Qc /ax a.xa -- a
+2c
+bQ
+2#d -- a
+xf
+xd.
+b
+2#*c - Qc /a
+x a.
+xa -- a
+bQ
+2# *e- Qc /a
+x a.
+xa -- a
 b
 2.+c - Qc /a
 3a.
@@ -5476,22 +7743,37 @@ b
 bQ
 1Q+a -- a
 bbX
-2 *a.bQ
+2 *a.
+bQ
 
 bQ
-2#  dQe cx   Qa  ax  *bQc a
-b2#  a-Qc /ax   *b.x    cbQ
-2#   c-ax  *bx  dQa  a
+2#  dQe c
+x   Qa  a
+x  *bQc a
+b
+2#  a-Qc /a
+x   *b.
+x    c
+bQ
+2#   c-a
+x  *b
+x  dQa  a
 bQ
 1Q a*b- d
-2 +d.bQ
-2#  dQe cx   Qa  a
-x  *bQc abQ
-2#  a-Qc /ax   *b.x   +cca
+2 +d.
+bQ
+2#  dQe c
+x   Qa  a
+x  *bQc a
+bQ
+2#  a-Qc /a
+x   *b.
+x   +cca
 b
 2.  a-a
 3   c.
-2  a*bcbQ
+2  a*bc
+bQ
 Y  *ccca
 b
 B
@@ -7657,128 +9939,385 @@ B
 B
 b
 Sc
-1Qa - a1Q bd
-1 a - a1  cc
-b1  dca
-2#  dx a
-1 bd a1 d  c
-b
-bQ
-2#a - ax d2# bdx d2# a - ax  d
+1Qa - a
+1Q bd
+1 a - a
 1  cc
 b
-2#    ax  dc2#  dx a2 b  a
-3# ax b
+1  dca
+2#  d
+x a
+1 bd a
 1 d  c
 b
 bQ
-2#a - axc2#dxa2#c -- axa2#  cxa
+2#a - a
+x d
+2# bd
+x d
+2# a - a
+x  d
+1  cc
+b
+2#    a
+x  dc
+2#  d
+x a
+2 b  a
+3# a
+x b
+1 d  c
+b
+bQ
+2#a - a
+xc
+2#d
+xa
+2#c -- a
+xa
+2#  c
+xa
 b
 
-b2#  dcx    a2#  dx    c
-1  d d1  ddf
+b
+2#  dc
+x    a
+2#  d
+x    c
+1  d d
+1  ddf
 bb
 2  d a
-3# ax b3# dx bx ax  d
+3# a
+x b
+3# d
+x b
+x a
+x  d
 2 a - a
-3#  dx a3# bx ax  dx  c
+3#  d
+x a
+3# b
+x a
+x  d
+x  c
 b
 2  d a
-3#  ax  c3#  dx ax bx d3# b- ax  dx ax b3# d  cx ax bx d
-bbQ
-3#a - ax dxaxc3#dxcxdxa
+3#  a
+x  c
+3#  d
+x a
+x b
+x d
+3# b- a
+x  d
+x a
+x b
+3# d  c
+x a
+x b
+x d
+b
+bQ
+3#a - a
+x d
+xa
+xc
+3#d
+xc
+xd
+xa
 
-4!3#c -- axax dx b3# ax bx dx a
-b3# b  ax ax  dx  b3#  ax  bx  dx a
+4!
+3#c -- a
+xa
+x d
+x b
+3# a
+x b
+x d
+x a
+b
+3# b  a
+x a
+x  d
+x  b
+3#  a
+x  b
+x  d
+x a
 2 b  a
-3# ax b
+3# a
+x b
 1 d  c
 b
 bQ
 2abd
-3#  dx d
-2#ax  d2 acc
-3#  cx  d
-2# ax   c
-b2  d a
-3#    ax    c
-2#    dx   a2  d a
-3#  dx a
-2# bx d
+3#  d
+x d
+2#a
+x  d
+2 acc
+3#  c
+x  d
+2# a
+x   c
+b
+2  d a
+3#    a
+x    c
+2#    d
+x   a
+2  d a
+3#  d
+x a
+2# b
+x d
 bQ
 b
 
 b
-bQ2abd
-3#  dx a3# bx d
-2a2 ac
-3#   cx  a3#  cx  d
+bQ
+2abd
+3#  d
+x a
+3# b
+x d
+2a
+2 ac
+3#   c
+x  a
+3#  c
+x  d
 2 a
-b2  d a
-3#    ax    c3#    ex   a
-2   c2  d a
-3#  dx a3# cx e
+b
+2  d a
+3#    a
+x    c
+3#    e
+x   a
+2   c
+2  d a
+3#  d
+x a
+3# c
+x e
 2 f
 b
 bQ
-3#f   ax ixhxf3#ixhxixf3#e -- ax hxexf3#hxfxhxe
+3#f   a
+x i
+xh
+xf
+3#i
+xh
+xi
+xf
+3#e -- a
+x h
+xe
+xf
+3#h
+xf
+xh
+xe
 b
 
-b3#f   axaxbx d3#ax bx dx a3# b- ax  dx ax  c3#  dx ax bx d
+b
+3#f   a
+xa
+xb
+x d
+3#a
+x b
+x d
+x a
+3# b- a
+x  d
+x a
+x  c
+3#  d
+x a
+x b
+x d
 bQ
-b3# b  ax ax bx d3#ax  cx  dx a3#  c  ax  ax  cx  d3# ax   cx  ax  c
+b
+3# b  a
+x a
+x b
+x d
+3#a
+x  c
+x  d
+x a
+3#  c  a
+x  a
+x  c
+x  d
+3# a
+x   c
+x  a
+x  c
 b
 2  d a
-3#  cx  a
+3#  c
+x  a
 2   c
-3#  ax  c
+3#  a
+x  c
 2  d
-3#  cx  d
+3#  c
+x  d
 2 a
-3# bx d
+3# b
+x d
 bQ
 b
 
 b
-bQ2#a - ax b2#  dxa2# a - ax  c2#   cx a
-b2#  dx   c2#    ax a2# bx  d2# dx  f
-bbQ
-2# b  Qax  d2# a cx b2# a   Qax  c2#   cx d
-b2#  dx   c2#    ax a
-1 bdca1 d  c
+bQ
+2#a - a
+x b
+2#  d
+xa
+2# a - a
+x  c
+2#   c
+x a
+b
+2#  d
+x   c
+2#    a
+x a
+2# b
+x  d
+2# d
+x  f
 b
 bQ
-2#aU- axc 3xdX
-2#cUxd 3xaX2#c U  axa  3x dX2# bUx d 3x aX
+2# b  Qa
+x  d
+2# a c
+x b
+2# a   Qa
+x  c
+2#   c
+x d
+b
+2#  d
+x   c
+2#    a
+x a
+1 bdca
+1 d  c
+b
+bQ
+2#aU- a
+xc 3
+xdX
+2#cU
+xd 3
+xaX
+2#c U  a
+xa  3
+x dX
+2# bU
+x d 3
+x aX
 b
 
-b2# bU ax d 3xa X2#  dUx  d 3x a X2# b   Ux  d   3x    aX2# d   Ux  d   3x    aX
-bbQ2# f  U
-x  g  3x   hX2# b  Ux  d  3x   cX2#  f  Ux   g  3x    hX2#  c   Ux   c   3x     aX
-b2#  d  Ux   c  3x    aX2#  d  Ux   c  3x    cX2#  d  Ux   c  3x    dX2#  d  Ux   d  3x    fX
+b
+2# bU a
+x d 3
+xa X
+2#  dU
+x  d 3
+x a X
+2# b   U
+x  d   3
+x    aX
+2# d   U
+x  d   3
+x    aX
+b
+bQ
+2# f  U
+x  g  3
+x   hX
+2# b  U
+x  d  3
+x   cX
+2#  f  U
+x   g  3
+x    hX
+2#  c   U
+x   c   3
+x     aX
+b
+2#  d  U
+x   c  3
+x    aX
+2#  d  U
+x   c  3
+x    cX
+2#  d  U
+x   c  3
+x    dX
+2#  d  U
+x   d  3
+x    fX
 bQ
 b
 
-bbQ
-2# b   Ux  d   3x    aX2# d   Ux  f   3x    aX2# a    Ux  c    3x     aX2# f    Ux  c    3x     aX
-b2#  d  Ux   c  3x    aX2# a   Ux  d   3x    aX2# b   Ux  d   3x    aX
+b
+bQ
+2# b   U
+x  d   3
+x    aX
+2# d   U
+x  f   3
+x    aX
+2# a    U
+x  c    3
+x     aX
+2# f    U
+x  c    3
+x     aX
+b
+2#  d  U
+x   c  3
+x    aX
+2# a   U
+x  d   3
+x    aX
+2# b   U
+x  d   3
+x    aX
 1. d  c
-bbQ
+b
+bQ
 2.a   a
 3d
 2b
 2.a
 3 d
-2 b2. a - a
+2 b
+2. a - a
 3 d
-2 b2. a
+2 b
+2. a
 3  d
 2  c
-b2.  d a
+b
+2.  d a
 3   d
-2   c2.   a
+2   c
+2.   a
 3    d
-2    c2#    aUx  d   3x a   X
+2    c
+2#    aU
+x  d   3
+x a   X
 1 b c
 2 d
 bQ
@@ -7788,168 +10327,401 @@ b
 bQ
 2.  d a
 3    c
-2    d2.    c
+2    d
+2.    c
 3    d
-2    a2.  c  a
+2    a
+2.  c  a
 3  d
-2 a2.  d
+2 a
+2.  d
 3 a
 2  c
 b
 2. b  a
 3 d
-2a2.c
+2a
+2.c
 3e
-2f2.ea - a
+2f
+2.ea - a
 3f
 2h
 1@QfQfQh Qa
-bbQ
-1i   a1f1h    a1e    a
-b1f   a
-2#  d ax a
-1 bd a1 d  c
 b
 bQ
-2#f   axh2#ixf2#h -- axe
+1i   a
+1f
+1h    a
+1e    a
+b
+1f   a
+2#  d a
+x a
+1 bd a
+1 d  c
+b
+bQ
+2#f   a
+xh
+2#i
+xf
+2#h -- a
+xe
 1 f
 b
 
 b
-2#  dx   c2#    ax a2# bdx    a
+2#  d
+x   c
+2#    a
+x a
+2# bd
+x    a
 1 d  c
-bbQ
-2#f   axh2#ixf2#e -- axf2#hxe
-b2# b  ax d2#ax  c2#  dx a2# bx d
-bbQ2# bd ax    c2#    dx   a2# a cx  d2# ax  c
-b2# bd ax d2#ax   e2#a cx d
+b
+bQ
+2#f   a
+xh
+2#i
+xf
+2#e -- a
+xf
+2#h
+xe
+b
+2# b  a
+x d
+2#a
+x  c
+2#  d
+x a
+2# b
+x d
+b
+bQ
+2# bd a
+x    c
+2#    d
+x   a
+2# a c
+x  d
+2# a
+x  c
+b
+2# bd a
+x d
+2#a
+x   e
+2#a c
+x d
 1 bd
-bbQ
-1 acc1 bd d1 dd c1aac  a
+b
+bQ
+1 acc
+1 bd d
+1 dd c
+1aac  a
 b
 
-b1 bd a
-2# bd ax db c
-1a b d1c da
-bbQ
-1ef c1f g d1ha - h1eff  a
-b1ffg a
-2#ax    c1a b d1 dddf
-bbQ1af  a2#  gxf
+b
+1 bd a
+2# bd a
+x db c
+1a b d
+1c da
+b
+bQ
+1ef c
+1f g d
+1ha - h
+1eff  a
+b
+1ffg a
+2#a
+x    c
+1a b d
+1 dddf
+b
+bQ
+1af  a
+2#  g
+xf
 1e f  a
-2#   gxh
+2#   g
+xh
 b
 1ffd a
-2#  dx f2#ffg axd
+2#  d
+x f
+2#ffg a
+xd
 1cd
 b
 bQ
-2#ab- dx df
+2#ab- d
+x df
 1 bd
-2# ac  ax  de
+2# ac  a
+x  de
 1  cc
 b
 
 b
-2#fh  axdf
+2#fh  a
+xdf
 1cd
-2#ac  ax df
+2#ac  a
+x df
 1 cd
 b
 bQ
-3# b  ax ax bx d
-2#ax  d
-3#  c  ax  ax  cx  d
-2# ax   c
-b3#  d ax    cx    ex   a
-2#   cx    a
-3# c  ax ax cx d
-2#ax c
+3# b  a
+x a
+x b
+x d
+2#a
+x  d
+3#  c  a
+x  a
+x  c
+x  d
+2# a
+x   c
 b
-bQ3# b  ax ax bx d
-2#ax b
-3#  c  ax  ax  cx  d
-3# ax  c
+3#  d a
+x    c
+x    e
+x   a
+2#   c
+x    a
+3# c  a
+x a
+x c
+x d
+2#a
+x c
+b
+bQ
+3# b  a
+x a
+x b
+x d
+2#a
+x b
+3#  c  a
+x  a
+x  c
+x  d
+3# a
+x  c
 2   c
 bQ
-3#f   axexfxh3#fxa
+3#f   a
+xe
+xf
+xh
+3#f
+xa
 2 c
 
-4!3#a - ax dxaxc3#ax c
+4!
+3#a - a
+x d
+xa
+xc
+3#a
+x c
 2  d
-bbQ
-3#  g ax d
+b
+bQ
+3#  g a
+x d
 2 f
-3#  dx  f
+3#  d
+x  f
 2  g
-3# a - ax b
+3# a - a
+x b
 2 d
-3#  cx  d
+3#  c
+x  d
 2  f
 b
-3#  d ax a
+3#  d a
+x a
 2 b
-3#  ax  c
+3#  a
+x  c
 2  d
-3#  d ax    c
+3#  d a
+x    c
 2    d
-3#    cx    d
+3#    c
+x    d
 2    f
 b
 bQ
-3# b  ax d
+3# b  a
+x d
 2a
-3#  ax  c
+3#  a
+x  c
 2  d
-3#  c  ax  d
+3#  c  a
+x  d
 2 a
-3#   cx  a
+3#   c
+x  a
 2  c
 b
 
 b
-3# b  ax d
+3# b  a
+x d
 2a
-3#cxe
+3#c
+xe
 2f
-3#fxh
+3#f
+xh
 2f
-3# ax c
+3# a
+x c
 2 d
-bbQ
+b
+bQ
 2 b  a
-4# dx bx a
+4# d
 x b
-2#  dxa2  c  a
-4#  dx  cx  ax  c
-2#   cx a
-b2 c  a
-4# dx cx ax c
-2# dxc
+x a
+x b
+2#  d
+xa
+2  c  a
+4#  d
+x  c
+x  a
+x  c
+2#   c
+x a
+b
+2 c  a
+4# d
+x c
+x a
+x c
+2# d
+xc
 2 f  a
-4# hx fx ex f
-2# ax d
+4# h
+x f
+x e
+x f
+2# a
+x d
 bQ
 b
 
-bbQ
+b
+bQ
 2  d a
-3#bxa3# dx bx ax  d
+3#b
+xa
+3# d
+x b
+x a
+x  d
 2  c  a
-3#dxc3#ax d
-x cx a
+3#d
+xc
+3#a
+x d
+x c
+x a
 bQ
 2f   a
-3#dxc3#ax dx cx a2  d a
-3#  cx  a3#   cx   ax    ex    c
-bbQ
-3#  d ax    cx    dx   a3#   cx  ax  cx  d3#  c- ax  ax  cx  d3# ax cx dx a
+3#d
+xc
+3#a
+x d
+x c
+x a
+2  d a
+3#  c
+x  a
+3#   c
+x   a
+x    e
+x    c
+b
+bQ
+3#  d a
+x    c
+x    d
+x   a
+3#   c
+x  a
+x  c
+x  d
+3#  c- a
+x  a
+x  c
+x  d
+3# a
+x c
+x d
+x a
 b
 
-b3# c  ax ax  dx  c3#  dx ax cx d3#a - axcxdxc3#ax dx bx a
-bbQ
-3# b  ax ax bx d3#axcxexf3#h -- axfxexc3#ax dx cx a
-b3#  d ax  cx  dx a3# bx dxaxc3#e -- axfxhxe
+b
+3# c  a
+x a
+x  d
+x  c
+3#  d
+x a
+x c
+x d
+3#a - a
+xc
+xd
+xc
+3#a
+x d
+x b
+x a
+b
+bQ
+3# b  a
+x a
+x b
+x d
+3#a
+xc
+xe
+xf
+3#h -- a
+xf
+xe
+xc
+3#a
+x d
+x c
+x a
+b
+3#  d a
+x  c
+x  d
+x a
+3# b
+x d
+xa
+xc
+3#e -- a
+xf
+xh
+xe
 Yffh a
 b
 B
@@ -7959,111 +10731,284 @@ BX
 bX
 Sc
 1dab  d
-b1cdda
-2#     cxd.
 b
-1cdda1dab  d
-b1ab  d
-2#   cx d.
+1cdda
+2#     c
+xd.
 b
-1ab  d1ha f
-b1f aa1dabc
-b1ab  d1cdda
-b1 ab  d
-2#   ax  d.
+1cdda
+1dab  d
 b
-1 ab  dbbX
+1ab  d
+2#   c
+x d.
+b
+1ab  d
+1ha f
+b
+1f aa
+1dabc
+b
+1ab  d
+1cdda
+b
+1 ab  d
+2#   a
+x  d.
+b
+1 ab  d
+bbX
 1dab  d
 b
 
 b
-3#cdd&xaxa.x dx c.3# dxa.xcxd.
+3#cdd&xa
+xa.
+x d
+x c.
+3# d
+xa.
+xc
+xd.
 b
 2cdd&xa
-3#dxc.3#ax d.x bx a.
-b3#ab  dx a.x  dx  b.3#  dx a.x bx d.
-b3#ab  dx a.x bx d.3#a
-xc.xdxa.
-b3#cddaxa.xcxd.3#fxd.xcxa.
+3#d
+xc.
+3#a
+x d.
+x b
+x a.
+b
+3#ab  d
+x a.
+x  d
+x  b.
+3#  d
+x a.
+x b
+x d.
+b
+3#ab  d
+x a.
+x b
+x d.
+3#a
+xc.
+xd
+xa.
+b
+3#cdda
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xa.
 b
 
-b3#cddaxd.xcxa.3#dxc.xaxc.
+b
+3#cdda
+xd.
+xc
+xa.
+3#d
+xc.
+xa
+xc.
 b
 2da   d
-3#cxa.3# dx b.x ax  d.
+3#c
+xa.
+3# d
+x b.
+x a
+x  d.
 b
-1 ab  dbbX
+1 ab  d
+bbX
 1dab  d
 b
-2#cddaxa.2# ddxc.
-b2#ab  dx d.2# bQbxa.
-b2# da cx b.2# ab  dx d.
-b2# b  ax a.2#  dex b.
+2#cdda
+xa.
+2# dd
+xc.
+b
+2#ab  d
+x d.
+2# bQb
+xa.
+b
+2# da c
+x b.
+2# ab  d
+x d.
+b
+2# b  a
+x a.
+2#  de
+x b.
 b
 
-b2# ab  dx  d.2#  bx a.
-b2#  dax  b c2#  d dx  aa
-b2# ab  dx   a2# ab.x  d.
 b
-1 ab  dbbX
+2# ab  d
+x  d.
+2#  b
+x a.
+b
+2#  da
+x  b c
+2#  d d
+x  aa
+b
+2# ab  d
+x   a
+2# ab.
+x  d.
+b
+1 ab  d
+bbX
 1dab  d
 b
-2#cddaxa.2 dd
-3#dxc.
+2#cdda
+xa.
+2 dd
+3#d
+xc.
 b
-2#ab  dx d.2 b.
-3#bxa.
+2#ab  d
+x d.
+2 b.
+3#b
+xa.
 b
-2# da cx b.2 ab  d
-3#ax d.
+2# da c
+x b.
+2 ab  d
+3#a
+x d.
 b
 
 b
-2# b  ax a.2  de
-3# dx b.
+2# b  a
+x a.
+2  de
+3# d
+x b.
 b
-2# ab  dx  d.2  ba
-3# bx a.
+2# ab  d
+x  d.
+2  ba
+3# b
+x a.
 b
 2  da
-3#  ax  b.3#  dx  a.x  bx  d.
+3#  a
+x  b.
+3#  d
+x  a.
+x  b
+x  d.
 b
-2# ab  dx   a2# ab.x  d.
+2# ab  d
+x   a
+2# ab.
+x  d.
 b
 1 ab  d
 bbX
-2#  dx a.
-b2# bddx a.2#  dx  b.
-b2 bdd
-3# dx b.3# ax  d.x  bx  a.
+2#  d
+x a.
+b
+2# bdd
+x a.
+2#  d
+x  b.
+b
+2 bdd
+3# d
+x b.
+3# a
+x  d.
+x  b
+x  a.
 b
 
 b
-2# ab  dx   a2# ab.x d.
-b2# ab  dxd.2#cxa.b
-1cdda1dab  d
-b1ab  d1cdda
+2# ab  d
+x   a
+2# ab.
+x d.
 b
-2# ab  dx   a2# ab.x  d.
+2# ab  d
+xd.
+2#c
+xa.
+b
+1cdda
+1dab  d
+b
+1ab  d
+1cdda
+b
+2# ab  d
+x   a
+2# ab.
+x  d.
 b
 1 ab  d
 bbX
-2#  dx a.
+2#  d
+x a.
 b
-3# bdd&xx a.x  dx  b.3#  dx a.x bx d.
+3# bdd&x
+x a.
+x  d
+x  b.
+3#  d
+x a.
+x b
+x d.
 b
 
 b
 2 bdd
-3# dx b.3# ax  d.x  bx  a.
-b3# ab  dx  a.x  bx  d.3# ax  d.x  bx  a.
+3# d
+x b.
+3# a
+x  d.
+x  b
+x  a.
 b
-2# ab  dxd.2#cxa.
-b2cdda
-3#axc.
-2#dabcx    d
-b2#cddaxdab  d2#ab  dxcdda
-b2# ab  dx   a2# ab.x  d.
+3# ab  d
+x  a.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+2# ab  d
+xd.
+2#c
+xa.
+b
+2cdda
+3#a
+xc.
+2#dabc
+x    d
+b
+2#cdda
+xdab  d
+2#ab  d
+xcdda
+b
+2# ab  d
+x   a
+2# ab.
+x  d.
 b
 
 b
@@ -8071,54 +11016,43 @@ b
 bbX
 S3
 1dab  d
-b1cdd&xa
+b
+1cdd&xa
 2#     c
 xa.
-2#cxd.
+2#c
+xd.
 b
-1cdd&xa2#d
+1cdd&xa
+2#d
 xc.
 2#a
 x d.
-b1ab  d&x
+b
+1ab  d&x
 2#  d
 x a.
 2# b
 x d.
 b
-2#ab  dx d.
+2#ab  d
+x d.
 2#a
 xc.
 2#d
 xa.
-b1.cdda
+b
+1.cdda
 2d.
 1cdda
-b1dab  d
+b
+1dab  d
 2#cdd&xa
-xa.2#d
+xa.
+2#d
 xc.
 b
 
-b
-1.dab  d2dab.
-1   a
-b
-1dab  d
-1   a
-bbX
-1dab  d
-b
-2#cddaxa.2#cxd.2#fxd.b
-2#cdda
-xa.
-2#dxc.2#ax d.b2#ab  dx a.2#  dx a.2# bx d.
-b2#ab  dx d.2#a
-xc.2#dxa.
-b
-
-b2#cddaxa.2#cxd.2#fxd.b2#cxa.2#cddaxa.
-2#dxc.
 b
 1.dab  d
 2dab.
@@ -8129,50 +11063,149 @@ b
 bbX
 1dab  d
 b
-2#cddaxa.2# ddxc.
+2#cdda
+xa.
+2#c
+xd.
+2#f
+xd.
+b
+2#cdda
+xa.
+2#d
+xc.
 2#a
 x d.
-b2#ab  dx d.2# bbxa.
-2# d
-x b.
 b
-
-b2# da cx b.2# ab  dx d.
+2#ab  d
+x a.
+2#  d
+x a.
 2# b
-x a.
-b2# b  ax a.2#  dex b.
-2# a
-x  d.
-b2# ab  dx  d.2#  bx a.
-2#  d
-x  b.
-b2#  dax  b.
-2#  d
-x  a.2#  bx  d.
-b1Q ab  d1Q ab.1Q   a
+x d.
 b
-1Q ab  d1Q   a
-bbX
-2#  d
-x a.
-b1. bdd2 bd.1   d
+2#ab  d
+x d.
+2#a
+xc.
+2#d
+xa.
 b
 
-b1 bdd
-2# dx b.2# ax  d.b
-1. ab  d2 ab.1   a
 b
-2# ab  dx  d.
-2# a
-x c.2# d  cxa.b
-1.cdda2d.
-1cdda
-b1dab  d2#cdda
+2#cdda
+xa.
+2#c
+xd.
+2#f
+xd.
+b
+2#c
+xa.
+2#cdda
 xa.
 2#d
 xc.
 b
-1.Qdab  d2 ab.1   a
+1.dab  d
+2dab.
+1   a
+b
+1dab  d
+1   a
+bbX
+1dab  d
+b
+2#cdda
+xa.
+2# dd
+xc.
+2#a
+x d.
+b
+2#ab  d
+x d.
+2# bb
+xa.
+2# d
+x b.
+b
+
+b
+2# da c
+x b.
+2# ab  d
+x d.
+2# b
+x a.
+b
+2# b  a
+x a.
+2#  de
+x b.
+2# a
+x  d.
+b
+2# ab  d
+x  d.
+2#  b
+x a.
+2#  d
+x  b.
+b
+2#  da
+x  b.
+2#  d
+x  a.
+2#  b
+x  d.
+b
+1Q ab  d
+1Q ab.
+1Q   a
+b
+1Q ab  d
+1Q   a
+bbX
+2#  d
+x a.
+b
+1. bdd
+2 bd.
+1   d
+b
+
+b
+1 bdd
+2# d
+x b.
+2# a
+x  d.
+b
+1. ab  d
+2 ab.
+1   a
+b
+2# ab  d
+x  d.
+2# a
+x c.
+2# d  c
+xa.
+b
+1.cdda
+2d.
+1cdda
+b
+1dab  d
+2#cdda
+xa.
+2#d
+xc.
+b
+1.Qdab  d
+2 ab.
+1   a
 b
 1 ab  d
 Y   a
@@ -8184,119 +11217,240 @@ p
 BX
 bX
 Sc
-1dab  dbQ
+1dab  d
+bQ
 1cdda
-2# dxa
+2# d
+xa
 bQ
-1cdda1dab  dbQ
+1cdda
+1dab  d
+bQ
 1abb d
-2#   cx d
+2#   c
+x d
 bQ
-1abb d1dab  dbQ
-1cdda1dabcbQ
-1abb d1cddabQ
+1abb d
 1dab  d
-2#   ax  d
+bQ
+1cdda
+1dabc
+bQ
+1abb d
+1cdda
+bQ
+1dab  d
+2#   a
+x  d
 bQ
 1 aba
-bbX1dab  d
+bbX
+1dab  d
 b
 
 b
-2#cddaxa2#cxd
+2#cdda
+xa
+2#c
+xd
 bQ
-1cdda1dabc
+1cdda
+1dabc
 bQ
-2#abb dx a2# bx dbQ
-2#abb dxc2#dabcxabQ
-2#cddaxa2#dabcxcbQ
-2#abb dxd2#d daxc
+2#abb d
+x a
+2# b
+x d
+bQ
+2#abb d
+xc
+2#dabc
+xa
+bQ
+2#cdda
+xa
+2#dabc
+xc
+bQ
+2#abb d
+xd
+2#d da
+xc
 bQ
 1dab  d
-2#   ax  d
+2#   a
+x  d
 bQ
 1 aba
-bbX1dab  d
+bbX
+1dab  d
 b
 
 b
-2#cddaxa2# daacxcbQ
-2#abb dx d2# bdcaxabQ
-2# daacx b2# aba dx dbQ
-2# bdcax a2#  da cx bbQ
-2# aba dx  d2#  b cx abQ
-2#  d dx  b2#  aax  d
+2#cdda
+xa
+2# daac
+xc
+bQ
+2#abb d
+x d
+2# bdca
+xa
+bQ
+2# daac
+x b
+2# aba d
+x d
+bQ
+2# bdca
+x a
+2#  da c
+x b
+bQ
+2# aba d
+x  d
+2#  b c
+x a
+bQ
+2#  d d
+x  b
+2#  aa
+x  d
 bQ
 1 ab  d
-2#   ax  d
+2#   a
+x  d
 bQ
-1 ababbX
+1 aba
+bbX
 1dab  d
 b
 
 b
-2#cddaxa2 da c
-3#axc
+2#cdda
+xa
+2 da c
+3#a
+xc
 bQ
-2#abb dx d2 bdca
-3# dxa
+2#abb d
+x d
+2 bdca
+3# d
+xa
 bQ
-2# daacx b2 aba d
-3# bx d
+2# daac
+x b
+2 aba d
+3# b
+x d
 bQ
-2# bdcax a2  da c
-3# ax b
+2# bdca
+x a
+2  da c
+3# a
+x b
 bQ
-2# aba dx  d2  b c
-3#  dx a
+2# aba d
+x  d
+2  b c
+3#  d
+x a
 bQ
-2#  d dx  b2  aa
-3#  bx  d
+2#  d d
+x  b
+2  aa
+3#  b
+x  d
 bQ
 1 aba d
-2#   ax  d
+2#   a
+x  d
 bQ
 
 bQ
 1 aba d
 bbX
-2#  dcx a
+2#  dc
+x a
 bQ
-1 bd  b2#   dxabQ
-2# d   bx b2# a dx  dbQ
-1Q ab  d2#   a
-x QdbQ
-2# b   dx a2#  dcx  bbQ
-2#  aax  d2#  b cx abQ
-2#  d dx  b2#  aax  d
+1 bd  b
+2#   d
+xa
+bQ
+2# d   b
+x b
+2# a d
+x  d
+bQ
+1Q ab  d
+2#   a
+x Qd
+bQ
+2# b   d
+x a
+2#  dc
+x  b
+bQ
+2#  aa
+x  d
+2#  b c
+x a
+bQ
+2#  d d
+x  b
+2#  aa
+x  d
 bQ
 1 ab  d
-2#   ax  d
+2#   a
+x  d
 bQ
 1 aba d
 bbX
-2#  dcx a
+2#  dc
+x a
 bQ
 
 bQ
 1 bd  b
-2#   dxabQ
-2# d   bx b2# a dx  d
+2#   d
+xa
+bQ
+2# d   b
+x b
+2# a d
+x  d
 bQ
 1 ab  d
-2#   ax dbQ
-2# b   dx a2#  dcx  bbQ
+2#   a
+x d
+bQ
+2# b   d
+x a
+2#  dc
+x  b
+bQ
 2  da
-3#  bx  d
+3#  b
+x  d
 2  b c
-3#  ax  b
+3#  a
+x  b
 bQ
 2  d d
-3#  bx  d
-2#  bax  a
+3#  b
+x  d
+2#  ba
+x  a
 bQ
 2Q aba d
-3#   ax  a3#  bx  ax  bx  d
+3#   a
+x  a
+3#  b
+x  a
+x  b
+x  d
 bQ
 Y aba d
 b
@@ -8309,45 +11463,78 @@ bX
 Sc
 1dab  d
 b
-2#c  axa.2#cxd.
+2#c  a
+xa.
+2#c
+xd.
 b
-1cdda1dabc
-b1abbcd
-2#abb.x d
-b2#axc.2#dx   c
+1cdda
+1dabc
 b
-1cdda1d  c
-b1dbbcd1cdda
-b1dab  d
-2#dab.x   a
+1abbcd
+2#abb.
+x d
+b
+2#a
+xc.
+2#d
+x   c
+b
+1cdda
+1d  c
+b
+1dbbcd
+1cdda
+b
+1dab  d
+2#dab.
+x   a
 b
 1dab
-bbX1dab  d
+bbX
+1dab  d
 b
-2#c  axd.2#cxa.
+2#c  a
+xd.
+2#c
+xa.
+b
+
+b
+1 da c
+1cd  c
+b
+1abbcd
+2#abb.
+x d
+b
+1abdca
+1abdca
+b
+1 db c
+2# db c
+x b.
+b
+1 ab  d
+1 db  d
+b
+1abdca
+2#abdca
+x a.
+b
+1  d  c
+1  d  c
+b
+1 ab  d
+2# ab.
+x d
+b
+1ab  d
+1  d  c
 b
 
 b
-1 da c1cd  c
-b1abbcd
-2#abb.x d
-b
-1abdca1abdca
-b1 db c
-2# db cx b.
-b
-1 ab  d1 db  d
-b1abdca
-2#abdcax a.
-b
-1  d  c1  d  c
-b1 ab  d
-2# ab.x d
-b
-1ab  d1  d  c
-b
-
-b1 abc a
+1 abc a
 2#   c
 x  d.
 b
@@ -8355,37 +11542,53 @@ b
 2#  d
 x  b.
 b
-1  da1 abc
-b1  bcd1  da
-b1 ab  d
-2# ab.x   a
+1  da
+1 abc
+b
+1  bcd
+1  da
+b
+1 ab  d
+2# ab.
+x   a
 b
 1 ab
 bbX
-2#  dx a.
+2#  d
+x a.
 b
 1 bdd b
-2# bd.x   d
+2# bd.
+x   d
 b
 1 bd.
-2# dx b.
+2# d
+x b.
 b
 1 ab  d
-2# ab.x   a
+2# ab.
+x   a
 b
 
 b
 1 ab.
-2#  dx  b.
+2#  d
+x  b.
 b
-1  da1  bc
-b1  bcd1  da
+1  da
+1  bc
+b
+1  bcd
+1  da
 b
 1 ab  d
-2# abx   a
+2# ab
+x   a
 b
 1 ab
-bbXS31dab  d
+bbX
+S3
+1dab  d
 b
 1.cdda
 2a.
@@ -8482,7 +11685,8 @@ b
 b
 0dab
 bbX
-2#  dx a.
+2#  d
+x a.
 b
 1@ bdd
 2 a.
@@ -8521,110 +11725,286 @@ Sc
 b
 2.cdda
 3a
-2#cddaxddff d
+2#cdda
+xddff d
 b
-3#abb dx a.x bx d.3#axc.xdxa.
+3#abb d
+x a.
+x b
+x d.
+3#a
+xc.
+xd
+xa.
 b
-2#cddaxdabc2#abb dxcdda
+2#cdda
+xdabc
+2#abb d
+xcdda
 b
 2.dab  d
 3  d
-2  bbQ
+2  b
+bQ
 bQ
 2dab  d
 bX
 3@cdda
-4Qa.4#cxa.xcxd.
-2#cddaxddff d
+4Qa.
+4#c
+xa.
+xc
+xd.
+2#cdda
+xddff d
 b
 
 b
-4#    Qdx a.x bx d.4#ax d.x bx a.4# bx d.
-xaxc.4#dxa.xcxd.
+4#    Qd
+x a.
+x b
+x d.
+4#a
+x d.
+x b
+x a.
+4# b
+x d.
+xa
+xc.
+4#d
+xa.
+xc
+xd.
 b
 3c  a
-4#axc.
+4#a
+xc.
 3d  c
-4#cxd.
+4#c
+xd.
 3a   d
-4# dxa.
+4# d
+xa.
 3c  a
-4#axc.
+4#a
+xc.
 bX
-3# ab  dx  a.x  bx  d.
-2  bbQ
+3# ab  d
+x  a.
+x  b
+x  d.
+2  b
+bQ
 bQ
 2dab  d
-b2cdda
-3#   axa.
-2# d  cxcdda
+b
+2cdda
+3#   a
+xa.
+2# d  c
+xcdda
 b
 
-b2abb d
-3#    dx d.
-2# b  axabb d
-b2 d  c
-3#    cx b.
-2# ab  dx d  c
 b
-3# bd axa.x dx b.3# ax  d.x  bx  a.
-bQ3# ab  dx  a.x  bx  d.3# ax  b.x  dx a.
+2abb d
+3#    d
+x d.
+2# b  a
+xabb d
 b
-2#  dQax  bQc2#  b dx  aa
+2 d  c
+3#    c
+x b.
+2# ab  d
+x d  c
+b
+3# bd a
+xa.
+x d
+x b.
+3# a
+x  d.
+x  b
+x  a.
+bQ
+3# ab  d
+x  a.
+x  b
+x  d.
+3# a
+x  b.
+x  d
+x a.
+b
+2#  dQa
+x  bQc
+2#  b d
+x  aa
 b
 
 b
 2. ab  d
 3  d.
-2  bbQ
+2  b
+bQ
 bQ
 2dab  d
 bX
-3#c  axd.xcxa.3# d  cxa.xcx d.
-b3#a   dxb.xax d.3# b  ax d.xax b.
-bQ3# d  cxa.x dx b.3# a   dx b.x dx a.
-b3# b  ax d.x bx a.3#    cx a.x bx  d.
+3#c  a
+xd.
+xc
+xa.
+3# d  c
+xa.
+xc
+x d.
+b
+3#a   d
+xb.
+xa
+x d.
+3# b  a
+x d.
+xa
+x b.
+bQ
+3# d  c
+xa.
+x d
+x b.
+3# a   d
+x b.
+x d
+x a.
+b
+3# b  a
+x d.
+x b
+x a.
+3#    c
+x a.
+x b
+x  d.
 b
 
-b3# a   dx  d.x  bx  a.3#  b  ax  d.x ax  b.
-b3#   ax  d.x   cx  b.3#    dx  b.x   ax  a.
-bQ3# ab  dx  a.x  bx  d.3# ax  b.x  dx a.
+b
+3# a   d
+x  d.
+x  b
+x  a.
+3#  b  a
+x  d.
+x a
+x  b.
+b
+3#   a
+x  d.
+x   c
+x  b.
+3#    d
+x  b.
+x   a
+x  a.
+bQ
+3# ab  d
+x  a.
+x  b
+x  d.
+3# a
+x  b.
+x  d
+x a.
 b
 bQ
 2. bdd b
 3  e
-2#  Qdxabb d
+2#  Qd
+xabb d
 b
-3# bdd bx  ex  dx  b
-2# bdd bx b
+3# bdd b
+x  e
+x  d
+x  b
+2# bdd b
+x b
 b
 
-b2# ab  dx  d2#  bx  da
 b
-3# ab  dx  a.x  bx  d.3# ax  b.x  dx a.
-bQ2#  dax  bc2#  b dx  aa
+2# ab  d
+x  d
+2#  b
+x  da
 b
-4#     dx  a.
-x  bx  d.4# ax  d.x  bx  a.4#  bx  a.x  bx  d.4# ax  b.x  dx a.
+3# ab  d
+x  a.
+x  b
+x  d.
+3# a
+x  b.
+x  d
+x a.
+bQ
+2#  da
+x  bc
+2#  b d
+x  aa
+b
+4#     d
+x  a.
+x  b
+x  d.
+4# a
+x  d.
+x  b
+x  a.
+4#  b
+x  a.
+x  b
+x  d.
+4# a
+x  b.
+x  d
+x a.
 b
 bQ
 2. bdd b
 3  e
-2#  dxabb d
+2#  d
+xabb d
 b
 
 b
 2.bbdd b
 3  e
-2#  dxbbdd b
+2#  d
+xbbdd b
 b
 2. aba d
 3  d
 2#  b
 xcdda
-bQ2 aba d
-3#  dx  b.3#  ax  b.x  dx  b.
-b3#   aUx  b. 3x  d X3#   cUx  a  3x  b X3#    dUx  a   3x  b  X3#   aUx  b  3x  d.X
+bQ
+2 aba d
+3#  d
+x  b.
+3#  a
+x  b.
+x  d
+x  b.
+b
+3#   aU
+x  b. 3
+x  d X
+3#   cU
+x  a  3
+x  b X
+3#    dU
+x  a   3
+x  b  X
+3#   aU
+x  b  3
+x  d.X
 b
 2. ab  d
 3  d
@@ -8640,24 +12020,41 @@ Sc
 b
 2.cdda
 3a.
-2#cddaxdab  d
-b
-2.abb d3 d.2# b
+2#cdda
 xdab  d
 b
-2#cddaxdabc2#abb dxcdda
+2.abb d
+3 d.
+2# b
+xdab  d
+b
+2#cdda
+xdabc
+2#abb d
+xcdda
 bX
 2.dab  d
 3  d
-2  bbQ
+2  b
+bQ
 bQ
 2dab  d
 bQ
 3#cdda
-xa.xcxd.
-2#cddaxdabc
+xa.
+xc
+xd.
+2#cdda
+xdabc
 b
-3#abb dx a.x bx d.3#axc.xdxa.
+3#abb d
+x a.
+x b
+x d.
+3#a
+xc.
+xd
+xa.
 b
 
 b
@@ -8666,67 +12063,124 @@ xdabc
 2#ddda
 xc
 b
-2.dab  d3  d.
-2  bbQ
+2.dab  d
+3  d.
+2  b
+bQ
 bQ
 2dab  d
-bX2cdda
-3#ax d.
-2abQb d3# d
+bX
+2cdda
+3#a
+x d.
+2abQb d
+3# d
 x b.
-bQ2 db c
-3# bx a.
-2 bd a3# a
+bQ
+2 db c
+3# b
+x a.
+2 bd a
+3# a
 x  d.
 bX
 2 aba d
-3#  dx  b.3#  ax  b.x  dx  a.
-bQ3# ab  dx  a.x  bx  d.2  b.bQ
+3#  d
+x  b.
+3#  a
+x  b.
+x  d
+x  a.
+bQ
+3# ab  d
+x  a.
+x  b
+x  d.
+2  b.
+bQ
 bQ
 2dab  d
 b
 
 b
 3#   a
-xc2 a3#    d
-xa.2  d
+xc
+2 a
+3#    d
+xa.
+2  d
 b
 3#    c
 x d.
 2  b
-3#    ax b.
+3#    a
+x b.
 2  a
 b
-3# ab  dx d.x bx a.
-3#  dax  b.x  dx  a.
-b3# ab  dx  a.x  bx  d.
-2  bbQ
+3# ab  d
+x d.
+x b
+x a.
+3#  da
+x  b.
+x  d
+x  a.
+b
+3# ab  d
+x  a.
+x  b
+x  d.
+2  b
+bQ
 bQ
 2 ab  d
 bX
 2. bd a
 3  e
-2#  dxbbd  b
+2#  d
+xbbd  b
 bQ
 2. ab  d
 3  d
-2#  bx ab  d
+2#  b
+x ab  d
 b
 
 b
-2#  dax  bc
-2#  b dx  aa
+2#  da
+x  bc
+2#  b d
+x  aa
 b
 2@ ab  d
 3  d
-2#  bx ab  d
+2#  b
+x ab  d
 b
-3# bd  bx  b.x  dx  e.
-2#  dx bd  b
+3# bd  b
+x  b.
+x  d
+x  e.
+2#  d
+x bd  b
 b
-3# ab  dx  a.x  bx  d.3# ax b.x dxa.
+3# ab  d
+x  a.
+x  b
+x  d.
+3# a
+x b.
+x d
+xa.
 bQ
-3#c  axd.xcxa.3# dx b.x ax  d.
+3#c  a
+xd.
+xc
+xa.
+3# d
+x b.
+x a
+x  d.
 b
 1.dab  d
 2  d
@@ -8795,157 +12249,570 @@ BX
 bX
 Sc
 1daba d
-b1cdda1cdd1cdda1dab  d
-b1abb d1   c1abbcd1daba d
-b1cdda1daba d1abbcd1cdda
-b1daba d1   a1dab1daba d
+b
+1cdda
+1cdd
+1cdda
+1dab  d
+b
+1abb d
+1   c
+1abbcd
+1daba d
+b
+1cdda
+1daba d
+1abbcd
+1cdda
+b
+1daba d
+1   a
+1dab
+1daba d
 b
 bQ
-2#cddaxa
-3#cxaxcxd
+2#cdda
+xa
+3#c
+xa
+xc
+xd
 2#f
-xd2#cxa
+xd
+2#c
+xa
 b
 
 b
 1cdda
-2#axc2#dabcxc2#ax d
+2#a
+xc
+2#dabc
+xc
+2#a
+x d
 b
-3#abb dx ax  dx  b3#  ax  bx  dx a3# bx dxaxc3#dxcxax d
+3#abb d
+x a
+x  d
+x  b
+3#  a
+x  b
+x  d
+x a
+3# b
+x d
+xa
+xc
+3#d
+xc
+xa
+x d
 b
-2#abb dx d2#axc2#dxa
-3#cxaxcxd
+2#abb d
+x d
+2#a
+xc
+2#d
+xa
+3#c
+xa
+xc
+xd
 b
-2#   axcdda
-1dabc1abbcd1cdda
+2#   a
+xcdda
+1dabc
+1abbcd
+1cdda
 b
 
 b
 2#  QdQa
-x-Qd2#Qcx-Qa
-3#dxcxdxc3#dxcxaxc
+x-Qd
+2#Qc
+x-Qa
+3#d
+xc
+xd
+xc
+3#d
+xc
+xa
+xc
 b
 1dab  d
-2#cxa
-3#cxax dx b3# dx bx ax  d
+2#c
+xa
+3#c
+xa
+x d
+x b
+3# d
+x b
+x a
+x  d
 b
 0@ aba d
 bbX
 1dab  d
 b
-2#cddaxa2# ddaxc2#abb dx d2# bbxa
-b2# dba dx b2# aba dx d2# b cax a2#  dex b
+2#cdda
+xa
+2# dda
+xc
+2#abb d
+x d
+2# bb
+xa
 b
-
-b2# aba dx  d2#  bcx a2#  dax  b2#  aax  d
-b2# ab  dx   a2# abx  d
-1 aba d1dab  d
-bQ
-bQ
-2#cddaxa2 dda
-3#axc
-2#abb dx d2 bb
-3#cxa
-b
-2# dbacdx b2 ab
-3# bx d
-2# b cax a2  de
-3# ax b
-b
-
-b
-2# aba dx  d2  bQc
-3#  Qdx a
-2#  dax  b2  aa
-3#  bx  d
-b
-2# ab  dx   a2# abx  d2 ab  d
-3#  dx  b
-2#  dcx a
-bbQ
-2# bdd bx   d2# bdx a2# dddx b2# a cx  d
-b2# aba dx   a2# abx  d2# dba dx a2# b cx a
-b
-
-b2  da
-3#  bx  d
-2  b c
-3#  ax  b
-2  d d
-3#  bx  d
-2#  bax  a
-b2#  ba dx   a2# abx  d2 aba d
-3#  ax  b
-2#  dcx a
-b
-bQ
-3# bd  bx ax  dx  b3#  dx ax bx a3# dba dx bx ax b3# dx bx ax  d
+2# dba d
+x b
+2# aba d
+x d
+2# b ca
+x a
+2#  de
+x b
 b
 
 b
-4# aba dx  ax  bx  d4# ax cx dxa4#cxax dx b4# dx bx ax  d
-3# aba dx bx dx a3# b cx ax  dx  b
-b3#  aax  dx  bx  d3#    cx  bx  ax  b3#    dx  dx  bx  d3#  dax  ax  bx  d
+2# aba d
+x  d
+2#  bc
+x a
+2#  da
+x  b
+2#  aa
+x  d
 b
-2# aba dx   a2# abx  d
+2# ab  d
+x   a
+2# ab
+x  d
 1 aba d
-bbX1dabacd
-b
-
-b
-2#cddaxa
+1dab  d
+bQ
+bQ
+2#cdda
+xa
+2 dda
+3#a
+xc
+2#abb d
+x d
+2 bb
 3#c
-xaxcxd
-2#fxd2#cxa
-b2#   axcdd2#axc2#dabcxd2#cxd
+xa
 b
-3#abb dx ax bx d3#axcxdxc3#dxcxax d3#ax dx bx d
-b3#abb Qdx ax  dx  b3#  dx ax bx d
+2# dbacd
+x b
+2 ab
+3# b
+x d
+2# b ca
+x a
+2  de
+3# a
+x b
+b
 
-4!3#abb dx dxaxc3#dxa
-4#cxaxcxd
 b
-2#   axcdd
-1Qdabc1Qabbcd
-2#  daxd
-b2#cxa
+2# aba d
+x  d
+2  bQc
+3#  Qd
+x a
+2#  da
+x  b
+2  aa
+3#  b
+x  d
+b
+2# ab  d
+x   a
+2# ab
+x  d
+2 ab  d
+3#  d
+x  b
+2#  dc
+x a
+b
+bQ
+2# bdd b
+x   d
+2# bd
+x a
+2# ddd
+x b
+2# a c
+x  d
+b
+2# aba d
+x   a
+2# ab
+x  d
+2# dba d
+x a
+2# b c
+x a
+b
+
+b
+2  da
+3#  b
+x  d
+2  b c
+3#  a
+x  b
+2  d d
+3#  b
+x  d
+2#  ba
+x  a
+b
+2#  ba d
+x   a
+2# ab
+x  d
+2 aba d
+3#  a
+x  b
+2#  dc
+x a
+b
+bQ
+3# bd  b
+x a
+x  d
+x  b
+3#  d
+x a
+x b
+x a
+3# dba d
+x b
+x a
+x b
 3# d
-xaxcxd3#  QdQaxdxcxa3#dxcxaxc
-b
-2daba d
-3#cxa3#cxax dx b3# dx bx ax  d3# ax  dx  bx  a
-b
-
-b3# aba dx  ax  bx  d3# ax  dx ax c3# dx cx dxa3#cxaxcxd
-bbQ
-3#   axc dxaxc3#dab  dxcxax d3#    dxabbcx dxa3#c dxax dx b
-b3#     dx dbx bx d3#a bx dx bx a
-
-4!3#    ax bdx ax b3# dbx bx ax  d
-b3#     dx abax  dx Qa3# b cx ax  dx  b3#   ax  dx  bx  d3# ax  dx  bx  a
-b3# aba dx  a
-4#  bx  ax  bx  d
-3# ax  dx  bx  a3#     dx  bx  ax  b
-2#  dcx a
-bQ
+x b
+x a
+x  d
 b
 
 b
-bQ
-3# bd  Qbx a
-4# bx ax bx d
-3#a  dx dx bx a3#     bx bddx ax b3# d dx bx ax  d
-b4#     dx  ax  bx  d4# ax cx dxa4#cxax dx b4# dx bx ax  d
-3#     d
-x  ax  bx  d3# a
+4# aba d
+x  a
+x  b
+x  d
+4# a
 x c
 x d
-xa3# b cx ax  dx b
-b3#   ax  dx  bx  d3#    cx  bx  ax  b
+xa
+4#c
+xa
+x d
+x b
+4# d
+x b
+x a
+x  d
+3# aba d
+x b
+x d
+x a
+3# b c
+x a
+x  d
+x  b
+b
+3#  aa
+x  d
+x  b
+x  d
+3#    c
+x  b
+x  a
+x  b
+3#    d
+x  d
+x  b
+x  d
+3#  da
+x  a
+x  b
+x  d
+b
+2# aba d
+x   a
+2# ab
+x  d
+1 aba d
+bbX
+1dabacd
+b
 
-4!3#    dx  dx  bx  d
-2#  bax  a
-b2# aba dx   a2# abx  d
+b
+2#cdda
+xa
+3#c
+xa
+xc
+xd
+2#f
+xd
+2#c
+xa
+b
+2#   a
+xcdd
+2#a
+xc
+2#dabc
+xd
+2#c
+xd
+b
+3#abb d
+x a
+x b
+x d
+3#a
+xc
+xd
+xc
+3#d
+xc
+xa
+x d
+3#a
+x d
+x b
+x d
+b
+3#abb Qd
+x a
+x  d
+x  b
+3#  d
+x a
+x b
+x d
+
+4!
+3#abb d
+x d
+xa
+xc
+3#d
+xa
+4#c
+xa
+xc
+xd
+b
+2#   a
+xcdd
+1Qdabc
+1Qabbcd
+2#  da
+xd
+b
+2#c
+xa
+3# d
+xa
+xc
+xd
+3#  QdQa
+xd
+xc
+xa
+3#d
+xc
+xa
+xc
+b
+2daba d
+3#c
+xa
+3#c
+xa
+x d
+x b
+3# d
+x b
+x a
+x  d
+3# a
+x  d
+x  b
+x  a
+b
+
+b
+3# aba d
+x  a
+x  b
+x  d
+3# a
+x  d
+x a
+x c
+3# d
+x c
+x d
+xa
+3#c
+xa
+xc
+xd
+b
+bQ
+3#   a
+xc d
+xa
+xc
+3#dab  d
+xc
+xa
+x d
+3#    d
+xabbc
+x d
+xa
+3#c d
+xa
+x d
+x b
+b
+3#     d
+x db
+x b
+x d
+3#a b
+x d
+x b
+x a
+
+4!
+3#    a
+x bd
+x a
+x b
+3# db
+x b
+x a
+x  d
+b
+3#     d
+x aba
+x  d
+x Qa
+3# b c
+x a
+x  d
+x  b
+3#   a
+x  d
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+b
+3# aba d
+x  a
+4#  b
+x  a
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+3#     d
+x  b
+x  a
+x  b
+2#  dc
+x a
+bQ
+b
+
+b
+bQ
+3# bd  Qb
+x a
+4# b
+x a
+x b
+x d
+3#a  d
+x d
+x b
+x a
+3#     b
+x bdd
+x a
+x b
+3# d d
+x b
+x a
+x  d
+b
+4#     d
+x  a
+x  b
+x  d
+4# a
+x c
+x d
+xa
+4#c
+xa
+x d
+x b
+4# d
+x b
+x a
+x  d
+3#     d
+x  a
+x  b
+x  d
+3# a
+x c
+x d
+xa
+3# b c
+x a
+x  d
+x b
+b
+3#   a
+x  d
+x  b
+x  d
+3#    c
+x  b
+x  a
+x  b
+
+4!
+3#    d
+x  d
+x  b
+x  d
+2#  ba
+x  a
+b
+2# aba d
+x   a
+2# ab
+x  d
 1Q aba d
 bbX
 S3
@@ -8955,128 +12822,300 @@ b
 2cdd
 1   a
 b
-1cdda1   a1daba d
+1cdda
+1   a
+1daba d
 b
 1.abb d
 2abb
 1   c
 b
 
-b1abb d1   c1daba d
+b
+1abb d
+1   c
+1daba d
 b
 1.cdda
 2   a
 1dabc
-b1abb d1   c1cdda
+b
+1abb d
+1   c
+1cdda
 b
 1.daba d
 2dab
 1   a
-b1d b  d1   abQ
+b
+1d b  d
+1   a
+bQ
 bQ
 1daba d
 bX
 2@cdda
-3Qa3#cxaxcxd
-2#fxd
-b2#cdda
+3Qa
+3#c
+xa
+xc
+xd
+2#f
+xd
+b
+2#cdda
 x   a
 2Qcdda
 3#a
-xc1d bc
+xc
+1d bc
 b
 
 b
 2Qabb d
-3#    dx a3# bx dxaxc3#dxcxax d
+3#    d
+x a
+3# b
+x d
+xa
+xc
+3#d
+xc
+xa
+x d
 b
 2abbcd
-3#ax a3# bx dxaxc
+3#a
+x a
+3# b
+x d
+xa
+xc
 1daba d
-b1cdda1cdd1d bc
+b
+1cdda
+1cdd
+1d bc
 b
 2d da
-3#cxa3# dxaxcxd3#cddaxdxaxc
+3#c
+xa
+3# d
+xa
+xc
+xd
+3#cdda
+xd
+xa
+xc
 b
 
 b
 2Qdaba d
-3#cxd3#cxax dx b3# dx bx ax  d
-b3# aba dx  ax  bx  d3# ax  dx ax c
-3# dxaxcxd
+3#c
+xd
+3#c
+xa
+x d
+x b
+3# d
+x b
+x a
+x  d
+b
+3# aba d
+x  a
+x  b
+x  d
+3# a
+x  d
+x a
+x c
+3# d
+xa
+xc
+xd
 b
 bQ
 1cdda
-2#dxc2#ax d
+2#d
+xc
+2#a
+x d
 b
 1abbcd
-2#cxa2# dx b
+2#c
+xa
+2# d
+x b
 b
 1 dbacd
-2#ax d2# bx a
+2#a
+x d
+2# b
+x a
 b
 
 b
 1 bdca
-2# dx b2# ax  d
+2# d
+x b
+2# a
+x  d
 b
 1Q aba d
-2# b cx a2#  dx b
+2# b c
+x a
+2#  d
+x b
 b
 1  da
-2# ax  d2#  bx  a
+2# a
+x  d
+2#  b
+x  a
 b
 1 aba d
-2#   ax  d2#  bx  a
+2#   a
+x  d
+2#  b
+x  a
 bX
-1 aba d1   abQ
+1 aba d
+1   a
+bQ
 bQ
 1daba d
 b
 
 b
 2cdda
-3#axc3#dxcxaxc3#dxcxax d
+3#a
+xc
+3#d
+xc
+xa
+xc
+3#d
+xc
+xa
+x d
 b
 2Qabb Qd
-3# dxa3#cxaxcxa3#cxax dx b
+3# d
+xa
+3#c
+xa
+xc
+xa
+3#c
+xa
+x d
+x b
 b
 2 dbacd
-3# ax b3# dx ax bx d3#ax dx bx a
+3# a
+x b
+3# d
+x a
+x b
+x d
+3#a
+x d
+x b
+x a
 b
 2 bdca
-3#  Qdx a3# bx ax bx a3# bx ax bx  d
+3#  Qd
+x a
+3# b
+x a
+x b
+x a
+3# b
+x a
+x b
+x  d
 b
 
 b
 2 aba d
-3#  dx a3# bx ax bx a3# bx ax  dx  b
+3#  d
+x a
+3# b
+x a
+x b
+x a
+3# b
+x a
+x  d
+x  b
 b
 2  da
-3# ax b3# dx bx ax  d3# ax  dx  bx  a
+3# a
+x b
+3# d
+x b
+x a
+x  d
+3# a
+x  d
+x  b
+x  a
 b
 2     d
-3#  ax  b3#  dx ax cx d3#ax dx bx a
+3#  a
+x  b
+3#  d
+x a
+x c
+x d
+3#a
+x d
+x b
+x a
 b
-2# aba dx  d2# aba dx  a2  b
-3#  dcx a
+2# aba d
+x  d
+2# aba d
+x  a
+2  b
+3#  dc
+x a
 bQ
 b
 
 b
 bQ
-2# bd  bx a2# d dx b2# a dx  d
+2# bd  b
+x a
+2# d d
+x b
+2# a d
+x  d
 b
 1 aba d
-2# b cx a2#  dx  b
+2# b c
+x a
+2#  d
+x  b
 b
 1  da
-2#  bx  d2  b c
-3#  ax  b
+2#  b
+x  d
+2  b c
+3#  a
+x  b
 b
-1  d d1  b1  dQab
+1  d d
+1  b
+1  dQa
+b
 1 ab  d
-2#   ax  b2#  bax  d
+2#   a
+x  b
+2#  ba
+x  d
 b
 Y aba d
 b
@@ -9089,335 +13128,1040 @@ bX
 Sc
 %50r
 1ddf  d
-b11cdda
-2# dxa
-b2cdda
-3#axc
-1ddf  d
-b1abb d
-2#   cx d
-bQ2#abb dxc2#dabcxa
+b1
+1cdda
+2# d
+xa
 b
-1cdda1dabc
-b1abb d1cdda
-b1dab  d
-2#   ax  d
+2cdda
+3#a
+xc
+1ddf  d
+b
+1abb d
+2#   c
+x d
+bQ
+2#abb d
+xc
+2#dabc
+xa
+b
+1cdda
+1dabc
+b
+1abb d
+1cdda
+b
+1dab  d
+2#   a
+x  d
 bX
-1 ababQ
+1 aba
+bQ
 bQ
 1dab  d
 b
 
 b
-3#cddaxax dx c3# dxaxcxd
+3#cdda
+xa
+x d
+x c
+3# d
+xa
+xc
+xd
 b
 2cdda
-3#axc3#dabcxcxax d
-b3#abb dx dx bx a3#  dx ax b
+3#a
+xc
+3#dabc
+xc
+xa
 x d
 b
-2#abb dx d2#dabcx c
-b2cdda
-3#axc
+3#abb d
+x d
+x b
+x a
+3#  d
+x a
+x b
+x d
+b
+2#abb d
+x d
+2#dabc
+x c
+b
+2cdda
+3#a
+xc
 2dabc
-3#cxd
+3#c
+xd
 b
 2Qabb d
-3# dxa
+3# d
+xa
 2cdda
-3#axc
+3#a
+xc
 b
 
 b
-2#ddf  dx  g2#  fx  d
+2#ddf  d
+x  g
+2#  f
+x  d
 b
-1 dffbQ
+1 dff
+bQ
 bQ
 1ddf  d
 bX
-2#cddaxa2# daxc
-b2#abb dx d2# bbxa
-b2# dba dx b2# abx d
-b2# bd ax a2#  dex b
-b2# aba dx  d2#  bcx a
-b2#  dx  b2#  aax  d
+2#cdda
+xa
+2# da
+xc
+b
+2#abb d
+x d
+2# bb
+xa
+b
+2# dba d
+x b
+2# ab
+x d
+b
+2# bd a
+x a
+2#  de
+x b
+b
+2# aba d
+x  d
+2#  bc
+x a
+b
+2#  d
+x  b
+2#  aa
+x  d
 b
 
 b
 1 aba d
-2#   ax  d
+2#   a
+x  d
 b
-1 ababQ
+1 aba
+bQ
 bQ
 1ddf  d
 bX
-2#cddaxa2# da cxc
-b2#abb dx d2# bd axa
-b2# daacx b2# aba dx d
-b2# bd ax a2#  d  cx b
-b2# aba dx  d2#  b cx a
-b2#  d dx  b2#    ax  a
+2#cdda
+xa
+2# da c
+xc
+b
+2#abb d
+x d
+2# bd a
+xa
+b
+2# daac
+x b
+2# aba d
+x d
+b
+2# bd a
+x a
+2#  d  c
+x b
+b
+2# aba d
+x  d
+2#  b c
+x a
+b
+2#  d d
+x  b
+2#    a
+x  a
 b
 
-b2 aba d
-3# dx b3# ax  dx  bx  a
 b
-2# aba dx a2#  dx a
+2 aba d
+3# d
+x b
+3# a
+x  d
+x  b
+x  a
+b
+2# aba d
+x a
+2#  d
+x a
 bQ
 b.
 1 bdd b
-2#   dxa
-b2# dx b2# a dx  d
+2#   d
+xa
+b
+2# d
+x b
+2# a d
+x  d
 b
 1 aba d
-2#   ax d
-b2# b   dx a2#  dx  b
-b2  da
-3#  bx  d
-2  b c
-3#  ax  b
+2#   a
+x d
 b
-2#  d dx  b2#    ax  a
+2# b   d
+x a
+2#  d
+x  b
+b
+2  da
+3#  b
+x  d
+2  b c
+3#  a
+x  b
+b
+2#  d d
+x  b
+2#    a
+x  a
 b
 
 b
 1 aba d
-2#   ax  d
-b2# aba dx c2# dxa
+2#   a
+x  d
+b
+2# aba d
+x c
+2# d
+xa
 .b2
 bQ
-3#cddaxaxcxd3#fxdxcxa
-b3#cxdxaxc3#dabcxcxax d
-b3#abb dx ax bx d3#ax dx bx a
-b3#abb dx dxaxc3#dabcxaxcxd
+3#cdda
+xa
+xc
+xd
+3#f
+xd
+xc
+xa
+b
+3#c
+xd
+xa
+xc
+3#dabc
+xc
+xa
+x d
+b
+3#abb d
+x a
+x b
+x d
+3#a
+x d
+x b
+x a
+b
+3#abb d
+x d
+xa
+xc
+3#dabc
+xa
+xc
+xd
 b
 
 b
 2cdda
-3#axc3#dabcxcxax d
-b3#abb dxcxdxa3#cddaxdxaxc
+3#a
+xc
+3#dabc
+xc
+xa
+x d
+b
+3#abb d
+xc
+xd
+xa
+3#cdda
+xd
+xa
+xc
 b
 2dab  d
-3#   ax  a3#  bx  dx ax  d
-b3# aba dx  ax  bx  d3# ax cx dxa
-bbQ
-3#cddaxax dx c3# dxaxcxd
+3#   a
+x  a
+3#  b
+x  d
+x a
+x  d
+b
+3# aba d
+x  a
+x  b
+x  d
+3# a
+x c
+x d
+xa
+b
+bQ
+3#cdda
+xa
+x d
+x c
+3# d
+xa
+xc
+xd
 b
 
-b3#cddax dxaxc3#dabcxcxax d
-b3#abb dx ax bx d3#ax dx bx a
-b3#abb dx dxaxc3#dabcxaxcxd
-b3#cddaxaxcxa3#dabcxcxax d
-b3#abb dx dx bx a3#cddaxax dx c
+b
+3#cdda
+x d
+xa
+xc
+3#dabc
+xc
+xa
+x d
+b
+3#abb d
+x a
+x b
+x d
+3#a
+x d
+x b
+x a
+b
+3#abb d
+x d
+xa
+xc
+3#dabc
+xa
+xc
+xd
+b
+3#cdda
+xa
+xc
+xa
+3#dabc
+xc
+xa
+x d
+b
+3#abb d
+x d
+x b
+x a
+3#cdda
+xa
+x d
+x c
 b
 
-b3# aba dx   ax   cx  a3#  b
-x  dx ax  d
 b
-3#dab  dx  ax  bx  d3# ax cx dxa
+3# aba d
+x   a
+x   c
+x  a
+3#  b
+x  d
+x a
+x  d
 b
-bQ3#cddaxax dx c
+3#dab  d
+x  a
+x  b
+x  d
+3# a
+x c
+x d
+xa
+b
+bQ
+3#cdda
+xa
+x d
+x c
 2 daac
-3#axc
-b3#abb dx dx bx a2 bb d
-3# dxa
-b3# daacx bx ax  d
+3#a
+xc
+b
+3#abb d
+x d
+x b
+x a
+2 bb d
+3# d
+xa
+b
+3# daac
+x b
+x a
+x  d
 2 aba d
-3# bx d
+3# b
+x d
 b
 
-b3# bd ax ax  dx  b
+b
+3# bd a
+x a
+x  d
+x  b
 2  d a
-3# ax b
-b3# aba dx  dx  bx  a
+3# a
+x b
+b
+3# aba d
+x  d
+x  b
+x  a
 2  b c
-3#  dx a
-b3#  d dx  bx  ax   c3#  aax  bx  dx  a
-b3# aba dx  ax  bx  d3# ax  dx  bx  a
-b3# aba dx  dx ax c3# ax cx dxa
+3#  d
+x a
+b
+3#  d d
+x  b
+x  a
+x   c
+3#  aa
+x  b
+x  d
+x  a
+b
+3# aba d
+x  a
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+b
+3# aba d
+x  d
+x a
+x c
+3# a
+x c
+x d
+xa
 bQ
 b
 
 b
-bQ3#cddaxax dx c3# daacxaxcx d
+bQ
+3#cdda
+xa
+x d
+x c
+3# daac
+xa
+xc
+x d
 b
-3#abb dx dx bx a3# bd ax dxax b
-b3# daacx bx ax  d3# aba dx bx dx a
-b3# bd ax ax  dx  b3#  da cx ax bx d
-b3# aba dx  dx  bx  a3#  bx  dx ax  b
+3#abb d
+x d
+x b
+x a
+3# bd a
+x d
+xa
+x b
+b
+3# daac
+x b
+x a
+x  d
+3# aba d
+x b
+x d
+x a
+b
+3# bd a
+x a
+x  d
+x  b
+3#  da c
+x a
+x b
+x d
+b
+3# aba d
+x  d
+x  b
+x  a
+3#  b
+x  d
+x a
+x  b
 b
 
-b3#  d dx  bx  ax   c3#  aax  bx  dx  a
+b
+3#  d d
+x  b
+x  a
+x   c
+3#  aa
+x  b
+x  d
+x  a
 b
 2 aba d
-3#   ax  a3#  bx  dx ax  d
-b3# aba dx  ax  bx  d3# ax  bx  dx a
+3#   a
+x  a
+3#  b
+x  d
+x a
+x  d
 b
-bQ3# bdd bx ax bx d3#ax dx bx a
-b3#     bx bx ax b3# d dx bx ax  d
+3# aba d
+x  a
+x  b
+x  d
+3# a
+x  b
+x  d
+x a
+b
+bQ
+3# bdd b
+x a
+x b
+x d
+3#a
+x d
+x b
+x a
+b
+3#     b
+x b
+x a
+x b
+3# d d
+x b
+x a
+x  d
 b
 
-b3# aba dx  ax  bx  d3# ax  dx  bx  a
 b
-3# aba dx  bx  dx a3# b cx ax  dx  b
-b3#  dax  ax  bx  d3#    c
-x  bx  ax  b
-b3#  d dx  bx  dx a3# daax bx ax  d
-b3# aba dx  dx ax b3# dx bx ax  d
+3# aba d
+x  a
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+b
+3# aba d
+x  b
+x  d
+x a
+3# b c
+x a
+x  d
+x  b
+b
+3#  da
+x  a
+x  b
+x  d
+3#    c
+x  b
+x  a
+x  b
+b
+3#  d d
+x  b
+x  d
+x a
+3# daa
+x b
+x a
+x  d
+b
+3# aba d
+x  d
+x a
+x b
+3# d
+x b
+x a
+x  d
 b
 
-b3# aQba dx  d
-x ax  d3# ax cx dxa
-bbQ
-3#bbd  bx  ex  dx  b3#  ex  dx  bx  d
-b3#bbd  bx  ex  dx  b3#  dx   dx  bx  d
-b3# aba dx  ax   Qcx  a3#  bx  dx ax  d
-b3# aba dx  ax  bx  d3# b cx ax  dx  b
+b
+3# aQba d
+x  d
+x a
+x  d
+3# a
+x c
+x d
+xa
+b
+bQ
+3#bbd  b
+x  e
+x  d
+x  b
+3#  e
+x  d
+x  b
+x  d
+b
+3#bbd  b
+x  e
+x  d
+x  b
+3#  d
+x   d
+x  b
+x  d
+b
+3# aba d
+x  a
+x   Qc
+x  a
+3#  b
+x  d
+x a
+x  d
+b
+3# aba d
+x  a
+x  b
+x  d
+3# b c
+x a
+x  d
+x  b
 b
 
-b3#  dax  ax  bx  d3#  b cx  dx ax  b
-b3#  d dx  bx  dx a3# daax bx ax  d
-b3# aba dx  dx ax b3# dx bx ax  d
 b
-1 aba dbQ
+3#  da
+x  a
+x  b
+x  d
+3#  b c
+x  d
+x a
+x  b
+b
+3#  d d
+x  b
+x  d
+x a
+3# daa
+x b
+x a
+x  d
+b
+3# aba d
+x  d
+x a
+x b
+3# d
+x b
+x a
+x  d
+b
+1 aba d
+bQ
 bQ
 1hd f d
 b3
-3#fhi fx ix hx f3#  ix fx hx i
+3#fhi f
+x i
+x h
+x f
+3#  i
+x f
+x h
+x i
 bX
-1fhi f1hd f d
+1fhi f
+1hd f d
 b
 
 b
-3#if Qhaxhxfx i3# hx ixfxh
-b3#fxhxixh3#fx ix hx f
-b3# hihfx ixfxh3#iff hxhxfx i
-b3# hihfx ix h
-x f3# ix h
-4# ix hx fx h
+3#if Qha
+xh
+xf
+x i
+3# h
+x i
+xf
+xh
+b
+3#f
+xh
+xi
+xh
+3#f
+x i
+x h
+x f
+b
+3# hihf
+x i
+xf
+xh
+3#iff h
+xh
+xf
+x i
+b
+3# hihf
+x i
+x h
+x f
+3# i
+x h
+4# i
+x h
+x f
+x h
 b
 2ddf  d
-3# gx f3# dx  gx  fx  d
+3# g
+x f
+3# d
+x  g
+x  f
+x  d
 b
 
 b
-1 dff dbQ
+1 dff d
+bQ
 bQ
 1hd f d
 bX
 2fhi f
-3#  ix f3# hx i
+3#  i
+x f
+3# h
+x i
 2f
-b2hd f d
-3# fx h3# ixf
+b
+2hd f d
+3# f
+x h
+3# i
+xf
 2h
-b2if ha
-3#  gx  i3# fx h
+b
+2if ha
+3#  g
+x  i
+3# f
+x h
 2 i
 b
-3# f fax  i.x fx h.3# ix fx hx i
-b3# hihfx  ix fx h3# iffhx fx hx i
+3# f fa
+x  i.
+x f
+x h.
+3# i
+x f
+x h
+x i
+b
+3# hihf
+x  i
+x f
+x h
+3# iffh
+x f
+x h
+x i
 b
 
-b3# hihfx ix hx f3# ix h
-4# ix hx fx h
+b
+3# hihf
+x i
+x h
+x f
+3# i
+x h
+4# i
+x h
+x f
+x h
 b
 2ddf  d
-3# gx f3# dx  gx  fx  d
+3# g
+x f
+3# d
+x  g
+x  f
+x  d
 b
-1 dff dbQ
+1 dff d
+bQ
 bQ
 1hd f d
 bX
 2fdaa
-3#dxf
+3#d
+xf
 2cdda
-3#axc
+3#a
+xc
 b
 2dabc
-3#cxd
+3#c
+xd
 2abb d
-3# dxa
+3# d
+xa
 b
 2cdda
-3#axc
+3#a
+xc
 2 daac
-3# cx d
+3# c
+x d
 b
 
 b
 2abb d
-3# dxa
+3# d
+xa
 2 bd a
-3# ax b
+3# a
+x b
 b
 2 daac
-3# cx d
+3# c
+x d
 2 aba d
-3#  dx a
+3#  d
+x a
 b
 2 bd a
-3# ax b
+3# a
+x b
 2  d  c
-3# ax b
-b3# aba dx  dx ax b3# dx bx ax  d
+3# a
+x b
 b
-1 aba dbQ
+3# aba d
+x  d
+x a
+x b
+3# d
+x b
+x a
+x  d
+b
+1 aba d
+bQ
 bQ
 1ddf  d
 bX
-3#fdaaxdxcxa3# daacxaxcx d
+3#fdaa
+xd
+xc
+xa
+3# daac
+xa
+xc
+x d
 b
 
-b3#abb dx dx bx a3# bd ax dxax b
-b3# daacx bx ax  d3# aba dx bx dx a
-b3# bd ax ax  dx  b3#  da cx ax bx  d
-b3# aba dx  d
-x  bx  a3#  b cx  dx ax  b
-b3#  d dx  bx  ax   c3#  aax  bx  dx  a
+b
+3#abb d
+x d
+x b
+x a
+3# bd a
+x d
+xa
+x b
+b
+3# daac
+x b
+x a
+x  d
+3# aba d
+x b
+x d
+x a
+b
+3# bd a
+x a
+x  d
+x  b
+3#  da c
+x a
+x b
+x  d
+b
+3# aba d
+x  d
+x  b
+x  a
+3#  b c
+x  d
+x a
+x  b
+b
+3#  d d
+x  b
+x  a
+x   c
+3#  aa
+x  b
+x  d
+x  a
 b
 
 b
 2 aba d
-3#   ax  a3#  bx  dx ax  d
+3#   a
+x  a
+3#  b
+x  d
+x a
+x  d
 b
-1 aba dbQ
+1 aba d
+bQ
 bQ
 1fbd  b
 bX
-3#fbd  bxdxbx f3# dx fxbxd
+3#fbd  b
+xd
+xb
+x f
+3# d
+x f
+xb
+xd
 b
 2fbd  b
-3#bxd3#fxbxdxf
-b3#hdf  dxfxdx h3# fx hxdxf
+3#b
+xd
+3#f
+xb
+xd
+xf
+b
+3#hdf  d
+xf
+xd
+x h
+3# f
+x h
+xd
+xf
 b
 
 b
 2hdf  d
-3#fxd3#fxdx hx f
+3#f
+xd
+3#f
+xd
+x h
+x f
 b
 2cdda
-3#axc3#db cx ax  dx  b
-b3#cddaxdxcxa3#dxc
-4#dxcxaxc
+3#a
+xc
+3#db c
+x a
+x  d
+x  b
+b
+3#cdda
+xd
+xc
+xa
+3#d
+xc
+4#d
+xc
+xa
+xc
 b
 2dab  d
-3#cxa3# dx bx ax  d
+3#c
+xa
+3# d
+x b
+x a
+x  d
 bX
-1 aba dbQ
+1 aba d
+bQ
 bQ
 1fbd  b
 b
-2#fbd  bxd2#bxd
+2#fbd  b
+xd
+2#b
+xd
 b
 
-b2#fbd  bxb2#dxf
-b2#hdf  dxf2#hxi
-b2#hdf  dx     f2#     hx     k
-b2# hihfx i2#f    hx i
-b2# Qh fax f2# i hfx h
-b2ddf  d
-3# gx f3# dx  gx  fx  d
+b
+2#fbd  b
+xb
+2#d
+xf
+b
+2#hdf  d
+xf
+2#h
+xi
+b
+2#hdf  d
+x     f
+2#     h
+x     k
+b
+2# hihf
+x i
+2#f    h
+x i
+b
+2# Qh fa
+x f
+2# i hf
+x h
+b
+2ddf  d
+3# g
+x f
+3# d
+x  g
+x  f
+x  d
 b
 1 dff d
 0Qddf  d
@@ -9427,112 +14171,206 @@ S3
 b
 
 b1
-%i1101cdda
-2# dxa2#cxd
+%i110
+1cdda
+2# d
+xa
+2#c
+xd
 b
-1cdda2#axc
+1cdda
+2#a
+xc
 1dabc
-b1abb d
-2#   cx a2# bx d
-b2#abb dx d2#axc
+b
+1abb d
+2#   c
+x a
+2# b
+x d
+b
+2#abb d
+x d
+2#a
+xc
 1dabc
-b1cdda
-2#axc
+b
+1cdda
+2#a
+xc
 1dabc
-b1aabc
-2# dxa
+b
+1aabc
+2# d
+xa
 1cdda
 b
 
-b1ddf  d
-2#   fx  g
+b
+1ddf  d
+2#   f
+x  g
 1 dff d
 b
-2#dab  dx  d2# ax c2# dxa
+2#dab  d
+x  d
+2# a
+x c
+2# d
+xa
 b
 bQ
 1cdda
-2#dxc2#ax d
+2#d
+xc
+2#a
+x d
 b
 1abb d
-2#cxa2# dx b
+2#c
+xa
+2# d
+x b
 b
 1 d   d
-2#a bx d2# bx a
+2#a b
+x d
+2# b
+x a
 b
 1 bd a
-2# dax b2# ax  d
+2# da
+x b
+2# a
+x  d
 b
 
 b
 1 ab  d
-2# b cx a2#  dx  b
+2# b c
+x a
+2#  d
+x  b
 b
 1  da
-2# ax  d2#  bax  a
+2# a
+x  d
+2#  ba
+x  a
 b
 1 aba d
-2#   ax  a2#  bx  d
+2#   a
+x  a
+2#  b
+x  d
 b
-1 aba d1   a1dab  d
-bbQ
+1 aba d
+1   a
+1dab  d
+b
+bQ
 1cdda
-2#d dxc2#ax d
+2#d d
+xc
+2#a
+x d
 b
 1abb d
-2#c bxa2# dx b
+2#c b
+xa
+2# d
+x b
 b
 1 d   d
-2#a bx d2# bx a
+2#a b
+x d
+2# b
+x a
 b
 
 b
 1 b  a
-2# dax b2# ax  d
+2# da
+x b
+2# a
+x  d
 b
 1 a   d
-2# b cx a2#  dx  b
+2# b c
+x a
+2#  d
+x  b
 b
 1  da
-2# ax  d2#  bax  a
+2# a
+x  d
+2#  ba
+x  a
 b
 1 aba d
-2#   ax  a2#  bx  d
+2#   a
+x  a
+2#  b
+x  d
 b
-1 aba d1   a
-2#  dx a
+1 aba d
+1   a
+2#  d
+x a
 b
 bQ
 1 bdd b
-2#   dx a2# bx d
+2#   d
+x a
+2# b
+x d
 b
 1 bdd b
-2# d dx b
-2# ax  d
+2# d d
+x b
+2# a
+x  d
 b
 
 b
 1 aba d
-2#   ax  a2#  bx  d
+2#   a
+x  a
+2#  b
+x  d
 b
 1 aba d
-2# b cx a2#  dx  b
+2# b c
+x a
+2#  d
+x  b
 b
 1  da
-2#  bx  d
+2#  b
+x  d
 1  b c
-b1  d d
-2#  bx  d2#  bax  a
+b
+1  d d
+2#  b
+x  d
+2#  ba
+x  a
 b
 1 aba d
-2#   ax  a2#  bx  d
+2#   a
+x  a
+2#  b
+x  d
 b
-1 aba d1   a
-2#  dcx a
+1 aba d
+1   a
+2#  dc
+x a
 b
 bQ
 1 bdd b
-2#   dx a
+2#   d
+x a
 2# b
 x d
 b
@@ -9540,326 +14378,925 @@ b
 b
 %i112 53v
 1 bdd b
-2# d dx b2# ax  d
+2# d d
+x b
+2# a
+x  d
 b
 1 aba d
-2#   ax  a3#  bx  ax  bx  d
+2#   a
+x  a
+3#  b
+x  a
+x  b
+x  d
 b
 1 aba d
-2# b cx a
-3# bx ax  dx  b
+2# b c
+x a
+3# b
+x a
+x  d
+x  b
 b
 1  da
-2#  bx  d
+2#  b
+x  d
 1  b c
 b
-2#  d dx a2#  dax  a
-3#  bx  ax  bx  d
+2#  d d
+x a
+2#  da
+x  a
+3#  b
+x  a
+x  b
+x  d
 b
 1 aba d
-2#   ax  a2#  bx  d
+2#   a
+x  a
+2#  b
+x  d
 b
 
 b
-1 aba d1   abQ
+1 aba d
+1   a
+bQ
 bQ
 1ddf  d
 b2
 2cdda
-3# dxa3#cxdxfxd2#cxa
+3# d
+xa
+3#c
+xd
+xf
+xd
+2#c
+xa
 bX
 2cdda
-3#dxc3#dxcxaxc
-2#dabcxc
+3#d
+xc
+3#d
+xc
+xa
+xc
+2#dabc
+xc
 b
-3#abb dx dx bx a3#  dx ax bx d3#axbxdxb
-b3#abb dx dx bx a3# bx dxaxc
+3#abb d
+x d
+x b
+x a
+3#  d
+x a
+x b
+x d
+3#a
+xb
+xd
+xb
+b
+3#abb d
+x d
+x b
+x a
+3# b
+x d
+xa
+xc
 1dabc
 b
 
 b
 2cdda
-3# dxa
+3# d
+xa
 2cdda
-3#axc
-2#dabcxc
-b2#abb dx a2#d dx  b
+3#a
+xc
+2#dabc
+xc
+b
+2#abb d
+x a
+2#d d
+x  b
 1cdda
-b1dab  d
-2#   ax a2#  bx  d
-b2# aba dx  d2dabbQ
+b
+1dab  d
+2#   a
+x a
+2#  b
+x  d
+b
+2# aba d
+x  d
+2dab
 bQ
-2    a2#    cx    e
-bX2cdda
-3# dxa3#cxd
+bQ
+2    a
+2#    c
+x    e
+bX
+2cdda
+3# d
+xa
+3#c
+xd
 2f
-3#  dx ax cx d
+3#  d
+x a
+x c
+x d
 b
 
 b
 2abb d
-3# bx d3#axc2d
-3#   cx  ax  bx  d
+3# b
+x d
+3#a
+xc
+2d
+3#   c
+x  a
+x  b
+x  d
 b
 2 aba d
-3#   cx  a3#  bx  dx ax b3# dx ax bx d
+3#   c
+x  a
+3#  b
+x  d
+x a
+x b
+3# d
+x a
+x b
+x d
 b
 2 bd a
-3# ax b
-2# d ax b2# a Qax  d
-b2# aba dx d2# bx a
-2#  dcx  b
+3# a
+x b
+2# d a
+x b
+2# a Qa
+x  d
+b
+2# aba d
+x d
+2# b
+x a
+2#  dc
+x  b
 b
 
-b2#  dax b2# ax  d2#  bax  a
 b
-%54r2 aba d
-3#   ax  a3#  bx  dx ax b3# dx bx ax  d
+2#  da
+x b
+2# a
+x  d
+2#  ba
+x  a
 b
-1 aba d1   abQ
+%54r
+2 aba d
+3#   a
+x  a
+3#  b
+x  d
+x a
+x b
+3# d
+x b
+x a
+x  d
+b
+1 aba d
+1   a
+bQ
 bQ
 1dab  d
 bX
 2cdda
-3#axc
-2#dxc2#a dx d
-b2abb d
-3# dxa
-2#bxa2# dbx b
+3#a
+xc
+2#d
+xc
+2#a d
+x d
+b
+2abb d
+3# d
+xa
+2#b
+xa
+2# db
+x b
 b
 
-b2 d   d
-3# bx d2#ax d2# bbx a
-b2 b  a
-3# ax b
-2# dx b2# aax  d
-b2 aba d
-3#  dx a
-2# bx a2#  dcx  b
-b2  da
-3#  bx  d
-2# ax  d2#  bax  a
+b
+2 d   d
+3# b
+x d
+2#a
+x d
+2# bb
+x a
+b
+2 b  a
+3# a
+x b
+2# d
+x b
+2# aa
+x  d
+b
+2 aba d
+3#  d
+x a
+2# b
+x a
+2#  dc
+x  b
+b
+2  da
+3#  b
+x  d
+2# a
+x  d
+2#  ba
+x  a
 b
 1 aba d
-2#   ax  a
-3#  bx  ax  bx  d
+2#   a
+x  a
+3#  b
+x  a
+x  b
+x  d
 b
 
 b
-1 aba d1   a
+1 aba d
+1   a
 bQ
 bQ
-2#  dx a
+2#  d
+x a
 bX
 1 bdd b
-2#   dx b2#  dx  e
-b3# bdd b
-x   ax   bx   d3#   bx   dx   ax    d3#   ax    dx    b
+2#   d
+x b
+2#  d
+x  e
+b
+3# bdd b
+x   a
+x   b
+x   d
+3#   b
+x   d
+x   a
+x    d
+3#   a
+x    d
+x    b
 x    a
 b
 1 aba d
-2#   ax  d2#  bx  a
-b2#  b  dx  d2# ax    a2#    cx    e
+2#   a
+x  d
+2#  b
+x  a
+b
+2#  b  d
+x  d
+2# a
+x    a
+2#    c
+x    e
 b
 
-b2 dda
-3#cxd3#fxdxcxa
-2# d  cxc
-b2abb d
-3#  dx a3# bx ax  dx  b
-2#cddaxf
-b2ddf  d
-3#   fx  g3# dx  gx  fx  d
+b
+2 dda
+3#c
+xd
+3#f
+xd
+xc
+xa
+2# d  c
+xc
+b
+2abb d
+3#  d
+x a
+3# b
+x a
+x  d
+x  b
+2#cdda
+xf
+b
+2ddf  d
+3#   f
+x  g
+3# d
+x  g
+x  f
+x  d
 1ddf
-bX1ddf  d
+bX
+1ddf  d
 bQ
 bQ
-2#   Qex  b2#  dx a
+2#   Qe
+x  b
+2#  d
+x a
 b
 
 b
 1 bdd b
-2#   dx b2# dxa
-b2#bbddx   c2#   ax    d2#    cx    a
+2#   d
+x b
+2# d
+xa
+b
+2#bbdd
+x   c
+2#   a
+x    d
+2#    c
+x    a
 b
 1 aba d
-2#   ax  a
-3#  bx  ax  bx  d
+2#   a
+x  a
+3#  b
+x  a
+x  b
+x  d
 b
-2# aba dx d2# b cx a3# bx ax  dx  b
+2# aba d
+x d
+2# b c
+x a
+3# b
+x a
+x  d
+x  b
 b
 %54v
 2.  da
 3 a
-2# bx a2#  dx    c
+2# b
+x a
+2#  d
+x    c
 b
 
-b2#    dxd2#cxd
+b
+2#    d
+xd
+2#c
+xd
 1cdda
 b
 2.ddf  d
 3  g
-2# dx  f2# dx  g
+2# d
+x  f
+2# d
+x  g
 b
-1ddf  d1   fbQ
+1ddf  d
+1   f
+bQ
 bQ
 1ddf  d
 b3
-3#fhi fx fx hx i3#fxhxixh3#fx ix hx f
+3#fhi f
+x f
+x h
+x i
+3#f
+xh
+xi
+xh
+3#f
+x i
+x h
+x f
 bX
-2# hihfx i2 hihf
-3# ixf
+2# hihf
+x i
+2 hihf
+3# i
+xf
 1hdf  d
 b
 
 b
 2if Qha
-3#fxh3#ixhxixh3#fxhxfx i
-b3#fx ix hx f3#  ix  hx  fx  h3#  ix fx hx i
-b3# hihfx  ix fx h3# ix hx fx h
-3# ihfhx  fx   hx   f
-b3# iihfx hx fx h3# ix hx ix h3# ix hx fx h
+3#f
+xh
+3#i
+xh
+xi
+xh
+3#f
+xh
+xf
+x i
+b
+3#f
+x i
+x h
+x f
+3#  i
+x  h
+x  f
+x  h
+3#  i
+x f
+x h
+x i
+b
+3# hihf
+x  i
+x f
+x h
+3# i
+x h
+x f
+x h
+3# ihfh
+x  f
+x   h
+x   f
+b
+3# iihf
+x h
+x f
+x h
+3# i
+x h
+x i
+x h
+3# i
+x h
+x f
+x h
 b
 
 b
 2ddf  d
-3#fxd3# gx fx gx f3# dx  gx  fx  d
+3#f
+xd
+3# g
+x f
+x g
+x f
+3# d
+x  g
+x  f
+x  d
 b
-2#ddf  dxf2#hxd2#f    dxh
-bbQ
+2#ddf  d
+xf
+2#h
+xd
+2#f    d
+xh
+b
+bQ
 2fhi f
-3#  ix f3# hx i
+3#  i
+x f
+3# h
+x i
 2 hi f
-3# fx hx ixf
+3# f
+x h
+x i
+xf
 b
 2hdf  d
-3#   fx  d3#  fx  g2  f3# hx ixfxh
+3#   f
+x  d
+3#  f
+x  g
+2  f
+3# h
+x i
+xf
+xh
 b
 
 b
 2if Qha
-3# fx hx ixf
+3# f
+x h
+x i
+xf
 2h
-3#dxcxaxc
+3#d
+xc
+xa
+xc
 b
 2dbb d
-3# bx dxaxc
+3# b
+x d
+xa
+xc
 2d
-3# bx ax  dx  b
+3# b
+x a
+x  d
+x  b
 b
 2cdda
-3# dxaxcxd
+3# d
+xa
+xc
+xd
 2f
-3# dxaxcxd
-b3# ddaxdxcxa3#dxcxdxc3#dxcxaxc
+3# d
+xa
+xc
+xd
+b
+3# dda
+xd
+xc
+xa
+3#d
+xc
+xd
+xc
+3#d
+xc
+xa
+xc
 b
 
 b
 1ddf  d
-2#   fx  g2#  fx  d
+2#   f
+x  g
+2#  f
+x  d
 b
-1 dff d1   fbQ
+1 dff d
+1   f
+bQ
 bQ
 1hdf  d
 bX
 2fdaa
-3# dxa
+3# d
+xa
 2c
-3#fxd
+3#f
+xd
 2c da
-3#axc
+3#a
+xc
 b
 2dab  d
-3#  bx  d
+3#  b
+x  d
 2 a
-3#cxd
+3#c
+xd
 2abb d
-3# dxa
+3# d
+xa
 b
 2cdda
-3#  ax  b
+3#  a
+x  b
 2  d
-3#axc
+3#a
+xc
 2 da c
-3# cx d
+3# c
+x d
 b
 
 b
 2abb d
-3#   cx  a
+3#   c
+x  a
 2  b
-3#ax d
+3#a
+x d
 2 bd a
 3# a
 x b
 b
 2 daac
-3#   ax   c
+3#   a
+x   c
 2   e
-3# dx b
+3# d
+x b
 2 aba d
-3#  dx a
+3#  d
+x a
 b
 2 bd a
-3#    dx   a
+3#    d
+x   a
 2   c
-3# ax b
+3# a
+x b
 2  d  c
-3#  bx  d
-b3# aba dx ax  bx  d3# ax  dx  bx  a3#   cx  ax  bx  d
+3#  b
+x  d
+b
+3# aba d
+x a
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+3#   c
+x  a
+x  b
+x  d
 b
 
 b
 2 aba d
-3# cx d3#ax dx ax c3# dxaxcxd
-bbQ
-3#fhi fx fx  ix f3# hx ixfx i3# hi fx ixfx h
-b3#dab  dxax dx b3# ax  dx  bx  a3#   cx  ax  bx  d
+3# c
+x d
+3#a
+x d
+x a
+x c
+3# d
+xa
+xc
+xd
+b
+bQ
+3#fhi f
+x f
+x  i
+x f
+3# h
+x i
+xf
+x i
+3# hi f
+x i
+xf
+x h
+b
+3#dab  d
+xa
+x d
+x b
+3# a
+x  d
+x  b
+x  a
+3#   c
+x  a
+x  b
+x  d
 bX
-1 dff d1   fbQ
+1 dff d
+1   f
+bQ
 bQ
 1ddf
 b
 
 b
-3#fdaaxdxcxa3#cxax dx c3# daacxaxcx d
-b3#a   dxbxax d3# bx dx bx a3# bd ax dxax b
-b3# da cxax dx b3# ax bx ax  d3# aba dx bx dx a
+3#fdaa
+xd
+xc
+xa
+3#c
+xa
+x d
+x c
+3# daac
+xa
+xc
+x d
+b
+3#a   d
+xb
+xa
+x d
+3# b
+x d
+x b
+x a
+3# bd a
+x d
+xa
+x b
+b
+3# da c
+xa
+x d
+x b
+3# a
+x b
+x a
+x  d
+3# aba d
+x b
+x d
+x a
 b
 
-b3# bd axax dx b3# ax dx bx a3#  d  cx ax bx  d
-b3# aba dx  dx  bx  a3#  bx  dx  bx  a3#  b cx  dx ax  b
-b3#  d dx  bx  ax   c3#  ax  bx  dx a3# c ax dxaxc
+b
+3# bd a
+xa
+x d
+x b
+3# a
+x d
+x b
+x a
+3#  d  c
+x a
+x b
+x  d
+b
+3# aba d
+x  d
+x  b
+x  a
+3#  b
+x  d
+x  b
+x  a
+3#  b c
+x  d
+x a
+x  b
+b
+3#  d d
+x  b
+x  a
+x   c
+3#  a
+x  b
+x  d
+x a
+3# c a
+x d
+xa
+xc
 b
 
 b
 2ddf  d
-3#   fx  g2# dx  g3# dx  gx  f
+3#   f
+x  g
+2# d
+x  g
+3# d
+x  g
+x  f
 x  d
 b
-1ddf  d1ddfbQ
+1ddf  d
+1ddf
+bQ
 bQ
 1ddf  d
 bX
-3#cddaxaxcxd3#fxdxcxa3# d  cxaxcx d
-b3#ab  dx dx bx a3#  dx ax bx d3#ab  ax dxax b
+3#cdda
+xa
+xc
+xd
+3#f
+xd
+xc
+xa
+3# d  c
+xa
+xc
+x d
+b
+3#ab  d
+x d
+x b
+x a
+3#  d
+x a
+x b
+x d
+3#ab  a
+x d
+xa
+x b
 b
 
-b3# dbacxaxbxa3# dx bx ax  d3# ab  dx dx bx a
-b3# bd ax dx bx a3#  dx  bx  ax  b3#  d  cx ax bx  d
-b3# aba dx  dx  bx  a3#   cx  ax  bx  d3#  b cx  dx ax  b
+b
+3# dbac
+xa
+xb
+xa
+3# d
+x b
+x a
+x  d
+3# ab  d
+x d
+x b
+x a
+b
+3# bd a
+x d
+x b
+x a
+3#  d
+x  b
+x  a
+x  b
+3#  d  c
+x a
+x b
+x  d
+b
+3# aba d
+x  d
+x  b
+x  a
+3#   c
+x  a
+x  b
+x  d
+3#  b c
+x  d
+x a
+x  b
 b
 
-b3#  d dx  bx   cx  a3#  bx  dx ax c3# dxaxcxd
-b3#cddaxdxcxa3#dxcxdxc3#dxcxaxc
+b
+3#  d d
+x  b
+x   c
+x  a
+3#  b
+x  d
+x a
+x c
+3# d
+xa
+xc
+xd
+b
+3#cdda
+xd
+xc
+xa
+3#d
+xc
+xd
+xc
+3#d
+xc
+xa
+xc
 b
 2Qddf  d
-3# gx f3# gx fx dx  g3# dx  gx  fx  d
+3# g
+x f
+3# g
+x f
+x d
+x  g
+3# d
+x  g
+x  f
+x  d
 b
 2ddf  d
-3#   fx  f
-2# dx  g
-3# dx  g.x  fx  d
+3#   f
+x  f
+2# d
+x  g
+3# d
+x  g.
+x  f
+x  d
 Yddf  d
 b
 B
@@ -9870,260 +15307,746 @@ bX
 Sc
 1dab  d
 b1
-2#cddaxa.2#c dxd.2#cddxa.2#dab  dxc.
-b2#abb dx a.2#  dx a.2#abbx d.2#dbb dx a.
-b2#cddax Qa.2#db cx a.2#d d dx  b.
+2#cdda
+xa.
+2#c d
+xd.
+2#cdd
+xa.
+2#dab  d
+xc.
+b
+2#abb d
+x a.
+2#  d
+x a.
+2#abb
+x d.
+2#dbb d
+x a.
+b
+2#cdda
+x Qa.
+2#db c
+x a.
+2#d d d
+x  b.
 1cdda
 bX
 2dab  d
-3#cxa.3# dx Qb.x ax  d.
-1 abbQ
+3#c
+xa.
+3# d
+x Qb.
+x a
+x  d.
+1 ab
+bQ
 bQ
 1dab  d
 b
 
 b
-3#cddaxa.xcxd.3#fxd.xcxa.3#c dax d.xaxc.3#dab  dxc.xax d.
-b3#abb dx d.x bx a.3#  dx a.x bx d.3# b  dx d.xaxc.3#dabcxa.xcxd.
+3#cdda
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xa.
+3#c da
+x d.
+xa
+xc.
+3#dab  d
+xc.
+xa
+x d.
+b
+3#abb d
+x d.
+x b
+x a.
+3#  d
+x a.
+x b
+x d.
+3# b  d
+x d.
+xa
+xc.
+3#dabc
+xa.
+xc
+xd.
 b
 2cdda
-3#axc.3#dabcxc.xax d.3#abb dxc.xdxa.3#cddaxa.xdxc.
+3#a
+xc.
+3#dabc
+xc.
+xa
+x d.
+3#abb d
+xc.
+xd
+xa.
+3#cdda
+xa.
+xd
+xc.
 b
 
 b
 2ddf  d
-3# Qdx f.3# dx  g.x  fx  d.
-1 dff dbQ
+3# Qd
+x f.
+3# d
+x  g.
+x  f
+x  d.
+1 dff d
+bQ
 bQ
 1ddf  d
 bX
-2#cddaxa.2# dfQecxc2#abb dx d.2# bdcaxa.
-b2# daacx b.2# a ax  d.2# aba dx b.2# daacx  b.
-b2#    ax bb.2#  ax   c.
+2#cdda
+xa.
+2# dfQec
+xc
+2#abb d
+x d.
+2# bdca
+xa.
+b
+2# daac
+x b.
+2# a a
+x  d.
+2# aba d
+x b.
+2# daac
+x  b.
+b
+2#    a
+x bb.
+2#  a
+x   c.
 2 bb a
-3#  ax   c.3#  bx  a.
-4#  bx  a.x   cx  a.
+3#  a
+x   c.
+3#  b
+x  a.
+4#  b
+x  a.
+x   c
+x  a.
 b
 
 b
-2# ab  dx   a.2# abx bd.
-1 aba dbQ
+2# ab  d
+x   a.
+2# ab
+x bd.
+1 aba d
+bQ
 bQ
 1dab  d
 bX
 3#cdda
-xa.x dx c.3# daacxa.xcx d.3#abb dx d.x bx a.3# bdcax d.xax b.
-bQ3# daacxa.xbxa.3# dx b.x ax  d.3# aba dx  d.x ax b.3# daacx a.x bx d.
-b
-
-b3# bdcQax a.x  dx a.3# bx  d.x ax b.3# d  axa.xbxa.3# dx b.x ax  d.
-bQ3# aba dx b.x dxa.3# dx b.
-4# dx b.x ax  d.
-1 aba dbQ
+xa.
+x d
+x c.
+3# daac
+xa.
+xc
+x d.
+3#abb d
+x d.
+x b
+x a.
+3# bdca
+x d.
+xa
+x b.
 bQ
-1 bdd b
-bX1 bdd b
-2# dxa.2# ddd bx b.2# add bx  d
+3# daac
+xa.
+xb
+xa.
+3# d
+x b.
+x a
+x  d.
+3# aba d
+x  d.
+x a
+x b.
+3# daac
+x a.
+x b
+x d.
 b
 
-b2# aba dx  d.2# a ax b.2# dff dx    a.2# dba dx    e.
-b2# ddefx a.2# b  cxa.2# d  dx b.2# a efx  d.
 b
-3#  fffdx  d.x  fx  g.3# dx  g.x  fx  d.
-1  fffdbQ
+3# bdcQa
+x a.
+x  d
+x a.
+3# b
+x  d.
+x a
+x b.
+3# d  a
+xa.
+xb
+xa.
+3# d
+x b.
+x a
+x  d.
+bQ
+3# aba d
+x b.
+x d
+xa.
+3# d
+x b.
+4# d
+x b.
+x a
+x  d.
+1 aba d
+bQ
 bQ
 1 bdd b
 bX
-3# bdd bx  b.x  dx  f.3# bx  d.x  fx b.3# dx f.x dx f.3# d   bx b.x  fx  d.
+1 bdd b
+2# d
+xa.
+2# ddd b
+x b.
+2# add b
+x  d
 b
 
-b3#  fffdx  d.x  fx  g.3# dx  g.x  f
+b
+2# aba d
 x  d.
-2# dff dx    a.2# dbacx    e
+2# a a
+x b.
+2# dff d
+x    a.
+2# dba d
+x    e.
+b
+2# ddef
+x a.
+2# b  c
+xa.
+2# d  d
+x b.
+2# a ef
+x  d.
+b
+3#  fffd
+x  d.
+x  f
+x  g.
+3# d
+x  g.
+x  f
+x  d.
+1  fffd
+bQ
+bQ
+1 bdd b
+bX
+3# bdd b
+x  b.
+x  d
+x  f.
+3# b
+x  d.
+x  f
+x b.
+3# d
+x f.
+x d
+x f.
+3# d   b
+x b.
+x  f
+x  d.
+b
+
+b
+3#  fffd
+x  d.
+x  f
+x  g.
+3# d
+x  g.
+x  f
+x  d.
+2# dff d
+x    a.
+2# dbac
+x    e
 b
 1 ddef
 2 cbc
-3# ax c.
+3# a
+x c.
 2 ddff
-3#   ex   c.3#   fx   e.x   cx   e.
+3#   e
+x   c.
+3#   f
+x   e.
+x   c
+x   e.
 bX
 2Q dff d
-3#   fx  g.3# dx  g.x  fx  d.
-1 dff dbQ
+3#   f
+x  g.
+3# d
+x  g.
+x  f
+x  d.
+1 dff d
+bQ
 bQ
 1hd f d
 b
 b2
 3#f ihf
-x f.x  ix  h.3#  ix f.x hx i.
-1fhi f1hd f d
+x f.
+x  i
+x  h.
+3#  i
+x f.
+x h
+x i.
+1fhi f
+1hd f d
 b
 
 b
-3#if fhxh.xfx i.3# hx i.
-xfxh.3#fxh.xixh.3#ff  hx i.x hx f.
-b3# hihfx i.xfxh.3#i  f ixh.xfx i.
+3#if fh
+xh.
+xf
+x i.
+3# h
+x i.
+xf
+xh.
+3#f
+xh.
+xi
+xh.
+3#ff  h
+x i.
+x h
+x f.
+b
+3# hihf
+x i.
+xf
+xh.
+3#i  f i
+xh.
+xf
+x i.
 2 i Qhf
-3# hx f.3# ix h.
-4# ix h.x fx h.
+3# h
+x f.
+3# i
+x h.
+4# i
+x h.
+x f
+x h.
 bX
 2ddf  d
-3# hx f.3# dx  g.
-4# dx  g.x  fx  d.
-1 dff dbQ
+3# h
+x f.
+3# d
+x  g.
+4# d
+x  g.
+x  f
+x  d.
+1 dff d
+bQ
 bQ
 1hd f d
 b
 
 b
 2fh hf
-3#  ix f.3# hx i.
+3#  i
+x f.
+3# h
+x i.
 2Qf
 2hd f d
-3# fx h.3#dxf.
+3# f
+x h.
+3#d
+xf.
 2h
-b2if fh
-3#  g
-x  i.3# fx h.
-2 i 2    h
-3# hx i.3# fx h. 
-4# ix f.x hx i.
 b
-3# h hfx  i.x fx h.3# i f hx f.x hx i.3#   hfx i.x hx f.3# ix h.
-4# ix h.x fx h.
+2if fh
+3#  g
+x  i.
+3# f
+x h.
+2 i 
+2    h
+3# h
+x i.
+3# f
+x h. 
+4# i
+x f.
+x h
+x i.
+b
+3# h hf
+x  i.
+x f
+x h.
+3# i f h
+x f.
+x h
+x i.
+3#   hf
+x i.
+x h
+x f.
+3# i
+x h.
+4# i
+x h.
+x f
+x h.
 b
 
 b
 2ddf  d
-3# hx Qf.3# dx  g.
-4# dx  g.x  fx  d.
-1 dff dbQ
+3# h
+x Qf.
+3# d
+x  g.
+4# d
+x  g.
+x  f
+x  d.
+1 dff d
+bQ
 bQ
 1hd f d
 b
-3#fh hfx i.
+3#fh hf
+x i.
 2f
-3#cddaxd.
+3#cdda
+xd.
 2f
-3#dab  dxc.
+3#dab  d
+xc.
 2d
-3#abb dxc.
+3#abb d
+xc.
 2d
-bX2cdda
-3#axc.
-2 daac
-3#axc.
-2abb d
-3# dxa.
-2 bdca
-3# dxa.
-b
-
-b
-2 daac
-3#ax d.
-2 abQa d
-3# bx d.
-2 bdca
-3# ax b.
-2  dd b
-3# ax b.
-bQ3# aba dx  a.
-x   cx   a.3#   cx  a.
-4#  bx  d.x ax b.
-1 aba dbQ
-bQ
-1hd f d
 bX
-2fdda
-3#dxf.
 2cdda
-3#axc.
-2dbbc
-3#cxd.
+3#a
+xc.
+2 daac
+3#a
+xc.
 2abb d
-3# dxa.
+3# d
+xa.
+2 bdca
+3# d
+xa.
 b
 
 b
-2cdda
-3#axc.
 2 daac
-3# bx d.
-2abb d
-3# dxa.
-2 bdca
-3# ax b.
-b
-2 da c
-3# bx d.
-2 aba d
-3#  dx a.
+3#a
+x d.
+2 abQa d
+3# b
+x d.
 2 bdca
 3# a
 x b.
 2  dd b
-3#  bx  d.
-bX3# aba dx b.
-x dxa.3#bxa.
-4# dx b.x ax  d.
-1 abQa dbQ
+3# a
+x b.
+bQ
+3# aba d
+x  a.
+x   c
+x   a.
+3#   c
+x  a.
+4#  b
+x  d.
+x a
+x b.
+1 aba d
+bQ
+bQ
+1hd f d
+bX
+2fdda
+3#d
+xf.
+2cdda
+3#a
+xc.
+2dbbc
+3#c
+xd.
+2abb d
+3# d
+xa.
+b
+
+b
+2cdda
+3#a
+xc.
+2 daac
+3# b
+x d.
+2abb d
+3# d
+xa.
+2 bdca
+3# a
+x b.
+b
+2 da c
+3# b
+x d.
+2 aba d
+3#  d
+x a.
+2 bdca
+3# a
+x b.
+2  dd b
+3#  b
+x  d.
+bX
+3# aba d
+x b.
+x d
+xa.
+3#b
+xa.
+4# d
+x b.
+x a
+x  d.
+1 abQa d
+bQ
 bQ
 1fb d b
 b
 
 b
-3#fb d bxd.xbx f.3# dx f.xbxd.3#fb d bxb.xdxf.3#dxf.xhxf.
-b3#hd f dxf.xdx h.3# fx h.xdxf.3#d    dxf.xhx-Qi.3#hxf.xdxf.
+3#fb d b
+xd.
+xb
+x f.
+3# d
+x f.
+xb
+xd.
+3#fb d b
+xb.
+xd
+xf.
+3#d
+xf.
+xh
+xf.
+b
+3#hd f d
+xf.
+xd
+x h.
+3# f
+x h.
+xd
+xf.
+3#d    d
+xf.
+xh
+x-Qi.
+3#h
+xf.
+xd
+xf.
 bQ
 2cdda
-3#axc.3#db cx a.x  dx  b.3# ddaxd.xcxa.3#dxc.xaxc.
+3#a
+xc.
+3#db c
+x a.
+x  d
+x  b.
+3# dda
+xd.
+xc
+xa.
+3#d
+xc.
+xa
+xc.
 b
 
 b
 2dab  d
-3#cxa.3# dx b.
-4# dx b.x ax  d.
-1dab  dbQ
+3#c
+xa.
+3# d
+x b.
+4# d
+x b.
+x a
+x  d.
+1dab  d
+bQ
 bQ
 1fb d b
 bX
-2#fb d bxd.2#b  dxd.2#fb d bxb.2#d  d bxf.
-b2#hd f dxf.2#d  fxf.2#dd f dx    l.
-2#    hx    d.
-b2# h hfx i.2#   h hx i.2# h fhx f.2# i hfx h.
+2#fb d b
+xd.
+2#b  d
+xd.
+2#fb d b
+xb.
+2#d  d b
+xf.
+b
+2#hd f d
+xf.
+2#d  f
+xf.
+2#dd f d
+x    l.
+2#    h
+x    d.
+b
+2# h hf
+x i.
+2#   h h
+x i.
+2# h fh
+x f.
+2# i hf
+x h.
 b
 
 b
 2ddf  d
-3#   fx  d.3#  fx  gx  fx  d.
+3#   f
+x  d.
+3#  f
+x  g
+x  f
+x  d.
 1Qddf  d
 bbX
 S3
 1dab  d
 b1
-2#cddaxa.2#dxc.2#aab  dx d.
-b2#abb dx d.2# bx d.2#abb dxc.
+2#cdda
+xa.
+2#d
+xc.
+2#aab  d
+x d.
+b
+2#abb d
+x d.
+2# b
+x d.
+2#abb d
+xc.
 b
 2#db c
-x a.2#cddaxa b2#dddaxc.
+x a.
+2#cdda
+xa b
+2#ddda
+xc.
 bX
 2dab  d
-3#cxa.3# dx Qb.x ax  d.
+3#c
+xa.
+3# d
+x Qb.
+x a
+x  d.
 bQ
 bQ
 1dab  d
 b
 
 b
-3#cddaxa.xcxd.3#fxd.xcxd.3#a  ax d.x bx a.
-b3#abb dx a.x  dx  b.3#  d
-x a.x bx d.3#axc.xdxa.b
+3#cdda
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xd.
+3#a  a
+x d.
+x b
+x a.
+b
+3#abb d
+x a.
+x  d
+x  b.
+3#  d
+x a.
+x b
+x d.
+3#a
+xc.
+xd
+xa.
+b
 2cdda
-3#axc.3#db cx a.x  dx  b.3#cddaxa.xdxc.
+3#a
+xc.
+3#db c
+x a.
+x  d
+x  b.
+3#cdda
+xa.
+xd
+xc.
 bX
 3#dab  d
-x  a.x  bx  d.3# ax  d.
+x  a.
+x  b
+x  d.
+3# a
+x  d.
 x a
 x b.
 bQ
@@ -10132,19 +16055,49 @@ bQ
 b
 
 b
-2#cddaxa.2#dxc.2#a   cx d.b2#abb dx d.2# bx a.2# b ca
+2#cdda
 xa.
-b2# Qdaacx b.2# aba dx d.
+2#d
+xc.
+2#a   c
+x d.
+b
+2#abb d
+x d.
+2# b
+x a.
 2# b ca
 xa.
 b
-2# ab  dx  d.2# ax b.
-2 aba dbQ
+2# Qdaac
+x b.
+2# aba d
+x d.
+2# b ca
+xa.
+b
+2# ab  d
+x  d.
+2# a
+x b.
+2 aba d
+bQ
 bQ
 2d.
 bX
 3#cdda
-xa.x dx c.3# dxa.xcxa.3#d   cxc.xax d.b
+xa.
+x d
+x c.
+3# d
+xa.
+xc
+xa.
+3#d   c
+xc.
+xa
+x d.
+b
 
 b
 3#abb d
@@ -10172,23 +16125,75 @@ x a.
 x  d.
 x a
 x b.
-b3# aba dx  a.x   cx   a3#   cx  a.
-x  bx  d.bQ
+b
+3# aba d
+x  a.
+x   c
+x   a
+3#   c
+x  a.
+x  b
+x  d.
 bQ
-1 aba dbX2# bdd b
-x  f.2# d
-x f.2# d d bx b.b
+bQ
+1 aba d
+bX
+2# bdd b
+x  f.
+2# d
+x f.
+2# d d b
+x b.
+b
 
-b2# aba dx  d.2# ax    a2# d acxd.
-b2#   ax db.2# b cx    d.2# d ffx   e.bX
-2# ab  dx   a2# abx bdbQ
+b
+2# aba d
+x  d.
+2# a
+x    a
+2# d ac
+xd.
+b
+2#   a
+x db.
+2# b c
+x    d.
+2# d ff
+x   e.
+bX
+2# ab  d
+x   a
+2# ab
+x bd
+bQ
 bQ
 1 aba d
 b
-3# bdd bx d.x fx b.3# dx f.x dx f.3# d   bx b.x  fx  d.
-b3# aba dx  d.x ax b.3# dx    Qc.x     d
+3# bdd b
+x d.
+x f
+x b.
+3# d
+x f.
+x d
+x f.
+3# d   b
+x b.
+x  f
+x  d.
+b
+3# aba d
+x  d.
+x a
+x b.
+3# d
+x    Qc.
+x     d
 x    a
-3# db cx    a.x    cx    e
+3# db c
+x    a.
+x    c
+x    e
 b
 
 b
@@ -10197,73 +16202,134 @@ xa.
 xb
 xd.
 3# d  c
-xa.x d
+xa.
+x d
 x b.
 3# d  c
-x b.x a a
+x b.
+x a a
 x  d.
 b
 2 aba d
-3# dxa.3# dx b.x ax  d.
+3# d
+xa.
+3# d
+x b.
+x a
+x  d.
 bQ
 bQ
 1hd f d
 b2
 3#fhi f
-x f.x hx i.3#f
-x i.x hxf.
-3#h  fx i.
+x f.
+x h
+x i.
+3#f
+x i.
+x h
+xf.
+3#h  f
+x i.
 xf
 xh.
 bX
 2if f i
-3#fxh.
+3#f
+xh.
 3#i
-xh.xf x i.3#fx i.
-x hx f
+xh.
+xf 
+x i.
+3#f
+x i.
+x h
+x f
 b
 
 b
 3# h hf
-x i.xfxh.3#i    hxh.xfx i.3# h hfx f.x ix h.
-b3#ddf  Qd
-x h.x fx d.3# f
-x h.xdxf.bQ
+x i.
+xf
+xh.
+3#i    h
+xh.
+xf
+x i.
+3# h hf
+x f.
+x i
+x h.
+b
+3#ddf  Qd
+x h.
+x f
+x d.
+3# f
+x h.
+xd
+xf.
+bQ
 bQ
 1hd f d
 bX
 2fh hf
-3#  ix f.3# hx i.
+3#  i
+x f.
+3# h
+x i.
 2f
 2hd f d
 3#f.
 xh
-b2if f i
+b
+2if f i
 3#  g
-x  i.3# fx h.
-2 i 2 f
-3# hx f.
+x  i.
+3# f
+x h.
+2 i 
+2 f
+3# h
+x f.
 b
 
 b
-2 h hf3# fx h.3# i f hx f.x hx i.2 hihf3# fx h.
+2 h hf
+3# f
+x h.
+3# i f h
+x f.
+x h
+x i.
+2 hihf
+3# f
+x h.
 b
 2ddf  d
-3# hx f.3# dx  g.
-x  fx  d.
+3# h
+x f.
+3# d
+x  g.
+x  f
+x  d.
 bQ
 bQ
 1hd f d
 bX
-2#fdaaxd.
+2#fdaa
+xd.
 2#c
 xa.
 2#d   c
 xc.
-b2abb d
-3#  dx a.
+b
+2abb d
+3#  d
+x a.
 3# b
-x d.xa
+x d.
+xa
 xc.
 3#a   a
 x b.
@@ -10273,64 +16339,149 @@ b
 
 b
 2 daac
-3# ax b.
+3# a
+x b.
 3# dba d
 x a.
 x b
 x d.
 3# b ca
-x  d.x a
+x  d.
+x a
 x b.
 b
 2 aba d
-3#   cx  a.
+3#   c
+x  a.
 3#  b
 x  d.
 x a
-x b.2 aba dbQ
+x b.
+2 aba d
+bQ
 bQ
 2d.
 bX
 3#cdda
-xa.xcxd.
+xa.
+xc
+xd.
 2c
-3#axc.
-2#a   cx d.
+3#a
+xc.
+2#a   c
+x d.
 b
-3#abb dx d.xaxb.
+3#abb d
+x d.
+xa
+xb.
 2a
-3# dxa.
-2# dd ax b.
+3# d
+xa.
+2# dd a
+x b.
 b
 
 b
-3# db cx b.x dxa.3# db  dxa.x dxa.3# dd ax b.x ax  d.
-b3# aba dx b.x dxa.3# dx b.x ax  d
+3# db c
+x b.
+x d
+xa.
+3# db  d
+xa.
+x d
+xa.
+3# dd a
+x b.
+x a
+x  d.
+b
+3# aba d
+x b.
+x d
+xa.
+3# d
+x b.
+x a
+x  d
 bQ
 1 aba d
 b
-3# bdd bx  f.x bx d.3# bx d.x fx d.
+3# bdd b
+x  f.
+x b
+x d.
+3# b
+x d.
+x f
+x d.
 2 bdd b
-3#  fx  d.
-bQ3# aba dx  d.x ax b.3# dx b.x ax  d.
+3#  f
+x  d.
+bQ
+3# aba d
+x  d.
+x a
+x b.
+3# d
+x b.
+x a
+x  d.
 2 aba d
-3#  dx a.
+3#  d
+x a.
 b
 
-b3#  dax a.x bx  d.3# a  cx b.x dxa.3# d  dx b.x a ax  d.
+b
+3#  da
+x a.
+x b
+x  d.
+3# a  c
+x b.
+x d
+xa.
+3# d  d
+x b.
+x a a
+x  d.
 b
 2 aba d
-3# dxa.3# dx b.x ax  d.
+3# d
+xa.
+3# d
+x b.
+x a
+x  d.
 bQ
 bQ
 1 aba d
 bX
-2#f dd bxd.2#f  dxb.2#d    bxf.
-b2#hQd f dxi.2#hx    l2#h   hx    d
-b2#fdd fx   a2#dabcx    d.2#dddaxc.
+2#f dd b
+xd.
+2#f  d
+xb.
+2#d    b
+xf.
+b
+2#hQd f d
+xi.
+2#h
+x    l
+2#h   h
+x    d
+b
+2#fdd f
+x   a
+2#dabc
+x    d.
+2#ddda
+xc.
 b
 1ddf  d
-2#   fx  g.
+2#   f
+x  g.
 Yddf  d
 b
 B
@@ -10341,162 +16492,403 @@ BX
 bX
 Sc
 1dab  d
-b11cdda
-2# dxa.
+b1
+1cdda
+2# d
+xa.
 b
-1Qcdda1Qdab  d
-b1Qabb d
-2#   cx d.
+1Qcdda
+1Qdab  d
 b
-1abb d1dabc
-b1cdda1dabc
-b1abb d1cdda
-b1dab  d
-2#   ax  a.
+1Qabb d
+2#   c
+x d.
+b
+1abb d
+1dabc
+b
+1cdda
+1dabc
+b
+1abb d
+1cdda
+b
+1dab  d
+2#   a
+x  a.
 bX
-1dab.bQ
+1dab.
+bQ
 bQ
 1dab  d
-b2cdda
-3# dx c.3# dxa.xcxd.
+b
+2cdda
+3# d
+x c.
+3# d
+xa.
+xc
+xd.
 b
 
 b
 2cdda
-3#dxc.3#dxc.xax d.
-b3#abb dx a.x  dx  b.3#  dx a.x bx d.
-b3#abb dx d.xaxc3#dxa.xcxd.
+3#d
+xc.
+3#d
+xc.
+xa
+x d.
 b
-2#   axcdd.2#dabcxabb d
-b2cdda
-3#dxc.3#dxc.xaxc.
+3#abb d
+x a.
+x  d
+x  b.
+3#  d
+x a.
+x b
+x d.
+b
+3#abb d
+x d.
+xa
+xc
+3#d
+xa.
+xc
+xd.
+b
+2#   a
+xcdd.
+2#dabc
+xabb d
+b
+2cdda
+3#d
+xc.
+3#d
+xc.
+xa
+xc.
 b
 
 b
 2dab  d
-3#cxa.3# dx b.x ax  d.
+3#c
+xa.
+3# d
+x b.
+x a
+x  d.
 bX
-1 ab  dbQ
+1 ab  d
+bQ
 bQ
 1dab  d
 b
-2#cddaxa.2# ddxc.
-b2#a   dx d.2# bbxa.
-b2# d   dx b.2# abx d.
-b2# b  ax a.2#  dex b.
-b2# a   dx  d.2#  bcx a.
-b2#  dax  b.2#  aax  d.
+2#cdda
+xa.
+2# dd
+xc.
+b
+2#a   d
+x d.
+2# bb
+xa.
+b
+2# d   d
+x b.
+2# ab
+x d.
+b
+2# b  a
+x a.
+2#  de
+x b.
+b
+2# a   d
+x  d.
+2#  bc
+x a.
+b
+2#  da
+x  b.
+2#  aa
+x  d.
 b
 
 b
 1 ab  d
-2#   ax  a.
-bX
-1 ab.bQ
-bQ
-1dab  d
-b
-2#cddaxa.2 dd
-3#axc.
-b
-2#a   dx d.2 bb
-3#cxa.
-b
-2# d   dx b.2 ab
-3# bx d.
-b
-2# b  ax a.2  de
-3# ax b.
-b
-2# a   dx  d.2  bc
-3# bx a.
-b
-2#  dax  b.2  aa
-3#  bx  d.
-b
-
-b
-1 ab  d
-2#   ax  a.
-bX
-1 ab
-bQ
-bQ
-2#  dcx a.
-b
-1 bd  b
-2#   dx a.
-b2# d   bx b.2# a   bx  d.
-b
-1 ab  d
-2#   ax a.
-b2# b   dx a.2#  d  dx  b.
-b2  da
-3#  bx  d.
-2  b c
-3#  ax  b.
-b
-2  d d
-3#  bx  d.
-2#  bax  a.
-b
-
-b
-1 ab  d
-2#   ax  a.
+2#   a
+x  a.
 bX
 1 ab.
 bQ
 bQ
-2#  dcx a.
+1dab  d
 b
-3# bd  bx a.x  dx a.3# bx  d.x ax b.
+2#cdda
+xa.
+2 dd
+3#a
+xc.
 b
-2 d   b
-3# ax b.3# dx b.x ax  d.
+2#a   d
+x d.
+2 bb
+3#c
+xa.
 b
-2 ab  d
-3#   ax  a.3#  bx  d.x ax b.
+2# d   d
+x b.
+2 ab
+3# b
+x d.
 b
-2 d   d
-3# bx a.3# bx a.x  dx  b.
+2# b  a
+x a.
+2  de
+3# a
+x b.
+b
+2# a   d
+x  d.
+2  bc
+3# b
+x a.
+b
+2#  da
+x  b.
+2  aa
+3#  b
+x  d.
 b
 
 b
-2#   ax dd.2#  bc
+1 ab  d
+2#   a
+x  a.
+bX
+1 ab
+bQ
+bQ
+2#  dc
+x a.
+b
+1 bd  b
+2#   d
+x a.
+b
+2# d   b
+x b.
+2# a   b
+x  d.
+b
+1 ab  d
+2#   a
+x a.
+b
+2# b   d
+x a.
+2#  d  d
+x  b.
+b
+2  da
+3#  b
+x  d.
+2  b c
+3#  a
+x  b.
+b
+2  d d
+3#  b
+x  d.
+2#  ba
+x  a.
+b
+
+b
+1 ab  d
+2#   a
+x  a.
+bX
+1 ab.
+bQ
+bQ
+2#  dc
+x a.
+b
+3# bd  b
+x a.
+x  d
+x a.
+3# b
+x  d.
+x a
+x b.
+b
+2 d   b
+3# a
+x b.
+3# d
+x b.
+x a
+x  d.
+b
+2 ab  d
+3#   a
+x  a.
+3#  b
+x  d.
+x a
+x b.
+b
+2 d   d
+3# b
+x a.
+3# b
+x a.
+x  d
+x  b.
+b
+
+b
+2#   a
+x dd.
+2#  bc
 x    d
 b
-3#   ax  b.x  a
+3#   a
+x  b.
+x  a
 x   c.
-2#  aax  b.
-b2 ab  d
-3#   ax  a.3#  bx  d.x ax b.
+2#  aa
+x  b.
 b
-2# ab  dx   a
+2 ab  d
+3#   a
+x  a.
+3#  b
+x  d.
+x a
+x b.
+b
+2# ab  d
+x   a
 bbX
 1dab  d
 b2
-3#   axa.xc
-xd.3#fxd.xcxa.
-b3#   a
-xc.xaxc.3#   cxd.xcxd.
+3#   a
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xa.
+b
+3#   a
+xc.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
 b
 
-b3#    dx a.x bx d.3#ax d.x bx a.
-b3#    dxab.x ax b.3#   cxd.xcxd.
-b3#   axc.xaxc.3#   cxd.xcxd.
-b3#    dxab.x dxa.3#   axc.xaxc.
+b
+3#    d
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
+b
+3#    d
+xab.
+x a
+x b.
+3#   c
+xd.
+xc
+xd.
+b
+3#   a
+xc.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
+b
+3#    d
+xab.
+x d
+xa.
+3#   a
+xc.
+xa
+xc.
 b
 2dab  d
-3#cxa.3# dx b.x ax  d.
+3#c
+xa.
+3# d
+x b.
+x a
+x  d.
 b
 
-b3#  bx  d.x ax b3# dxa.xcxd.
-bbQ
-3#   axa.xcxd.3#fxd.xcxa.
-b3#   axc.xaxc.3#   cxd.xcxd.
-b3#    dx a.x bx d.3#ax d.x bx a.
-b3#    Qdxab.x ax b.3#   cxd.xcxd.
+b
+3#  b
+x  d.
+x a
+x b
+3# d
+xa.
+xc
+xd.
+b
+bQ
+3#   a
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xa.
+b
+3#   a
+xc.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
+b
+3#    d
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
+b
+3#    Qd
+xab.
+x a
+x b.
+3#   c
+xd.
+xc
+xd.
 b
 
 b
@@ -10508,239 +16900,734 @@ xc.
 xd.
 xc
 xd.
-b3#    dxab.x dxa.3#   axc.xaxc.
+b
+3#    d
+xab.
+x d
+xa.
+3#   a
+xc.
+xa
+xc.
 b
 2dab  d
-3#c.xa3# d.x bx a.x  d.
-b3#  bx  d.x ax c.3# dxa.xcxd.
+3#c.
+xa
+3# d.
+x b
+x a.
+x  d.
 b
-bQ3#   axc.xaxc.3#d Qdxc.xax d.
+3#  b
+x  d.
+x a
+x c.
+3# d
+xa.
+xc
+xd.
 b
-
-b3#    dxab.x dxa.3#c bxa.x dx b.
-b3#     dx d.x bx d.3#a bx d.x bx a.
-b3#    ax b.x ax b.3# dax b.x ax  d.
-b3#     dx ab.x  dx a.3# b cx a.x  dx  b.
-b3#   ax  d.x  bx  d.3# ax  d.x  bx  a.
-b
-
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  ax  b.3#   cxd.xcxd.
 bQ
-b3#   axc.xaxc.3#d dxc.xax d.
-b3#    dxab.x dxa.3#c bxa.x d
+3#   a
+xc.
+xa
+xc.
+3#d Qd
+xc.
+xa
+x d.
+b
+
+b
+3#    d
+xab.
+x d
+xa.
+3#c b
+xa.
+x d
 x b.
-b3#     dx d.x bx d.3#a bx d.x bx a.
+b
+3#     d
+x d.
+x b
+x d.
+3#a b
+x d.
+x b
+x a.
+b
+3#    a
+x b.
+x a
+x b.
+3# da
+x b.
+x a
+x  d.
+b
+3#     d
+x ab.
+x  d
+x a.
+3# b c
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
 b
 
-b3#    ax b.x a
-x b.3# dax b.x ax  d.
-b3#     dx ab.x  dx a.3# b cx a.x  dx  b.
-b3#   ax  d.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx abx  ax  b.2#  dcx a.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  a
+x  b.
+3#   c
+xd.
+xc
+xd.
+bQ
+b
+3#   a
+xc.
+xa
+xc.
+3#d d
+xc.
+xa
+x d.
+b
+3#    d
+xab.
+x d
+xa.
+3#c b
+xa.
+x d
+x b.
+b
+3#     d
+x d.
+x b
+x d.
+3#a b
+x d.
+x b
+x a.
+b
+
+b
+3#    a
+x b.
+x a
+x b.
+3# da
+x b.
+x a
+x  d.
+b
+3#     d
+x ab.
+x  d
+x a.
+3# b c
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab
+x  a
+x  b.
+2#  dc
+x a.
 bQ
 b
 
 b
 bQ
-3# bd  bx a.x bx d.3#a bx d.x bx a.
-b3#     bx b.x ax b.3# dax b.x ax  d.
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  dx a.3# b cx a.x  dx  b.
-b3#   ax  d.x  bx  d.3#    cx  b.x  ax  b.
+3# bd  b
+x a.
+x b
+x d.
+3#a b
+x d.
+x b
+x a.
+b
+3#     b
+x b.
+x a
+x b.
+3# da
+x b.
+x a
+x  d.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  d
+x a.
+3# b c
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  b
+x  d.
+3#    c
+x  b.
+x  a
+x  b.
 b
 
-b3#    dx  d.x  bx  d.3#   ax  a.x  bx  d.
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  ax  b.
-2#  dcx a.
+b
+3#    d
+x  d.
+x  b
+x  d.
+3#   a
+x  a.
+x  b
+x  d.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  a
+x  b.
+2#  dc
+x a.
 b
 bQ
-3# bd  bx a.x bx d.3#a bx d.x bx a.
-b3#     bx b.x ax b.3# dax b.x ax  d.
+3# bd  b
+x a.
+x b
+x d.
+3#a b
+x d.
+x b
+x a.
+b
+3#     b
+x b.
+x a
+x b.
+3# da
+x b.
+x a
+x  d.
 b
 
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  dx a.3# b cx a.x  dx  b.
-b3#   ax  d.x  bx  d.3#    cx  b.x  ax  b.
-b3#    dx  d.x  bx  d.3#   ax  a.x  bx  d.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  d
+x a.
+3# b c
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  b
+x  d.
+3#    c
+x  b.
+x  a
+x  b.
+b
+3#    d
+x  d.
+x  b
+x  d.
+3#   a
+x  a.
+x  b
+x  d.
 b
 2 ab  d
-3#  ax   c.3#   ax    d.x    cx    a.
+3#  a
+x   c.
+3#   a
+x    d.
+x    c
+x    a.
 b
 Y ab  d
 b
 B
 
-{H12ji. Pass’e mezo detto L`ongaro GPP - Saltarello - Soprano AABBCC8x2-AABBCC8x2/I-CFVd, ff. 91v-93r}
+{H12ji. Pass'e mezo detto L`ongaro GPP - Saltarello - Soprano AABBCC8x2-AABBCC8x2/I-CFVd, ff. 91v-93r}
 BX
 bX
 Sc
 1dab  d
-b11cdda
-2# dxa.
+b1
+1cdda
+2# d
+xa.
 b
-1cdda1dab  d
-b1abb d
-2#   cx d.
+1cdda
+1dab  d
 b
-1abb d1dabc
-b1cdda1dabc
-b1abb d1cdda
-b1dab  d
-2#   ax  a.
+1abb d
+2#   c
+x d.
+b
+1abb d
+1dabc
+b
+1cdda
+1dabc
+b
+1abb d
+1cdda
+b
+1dab  d
+2#   a
+x  a.
 bX
-1dab.bQ
+1dab.
+bQ
 bQ
 1dab  d
 b
 
-b3#cdda
+b
+3#cdda
 xa.
-x dx c.3# dxa.xcxd.
+x d
+x c.
+3# d
+xa.
+xc
+xd.
 b
 2cdda
-3#dxc.3#dxc.xax d.
-b3#abb dx a.x  dx  b.3#  dx a.x bx d.
-b3#abb dx d.xaxc3#dxa.xcxd.
+3#d
+xc.
+3#d
+xc.
+xa
+x d.
 b
-2#   axcdd.2#dabcxabb d
-b2cdda
-3#dxc.3#dxc.xaxc.
+3#abb d
+x a.
+x  d
+x  b.
+3#  d
+x a.
+x b
+x d.
+b
+3#abb d
+x d.
+xa
+xc
+3#d
+xa.
+xc
+xd.
+b
+2#   a
+xcdd.
+2#dabc
+xabb d
+b
+2cdda
+3#d
+xc.
+3#d
+xc.
+xa
+xc.
 b
 
 b
 2dab  d
-3#cxa.3# dx b.x ax  d.
+3#c
+xa.
+3# d
+x b.
+x a
+x  d.
 bX
-1 ab  dbQ
+1 ab  d
+bQ
 bQ
 1dab  d
 b
-2#cddaxa.2# ddxc.
-b2#a   dx d.2# bbxa.
-b2# d   dx b.2# abx d.
-b2# b  ax a.2#  dex b.
-b2# a   dx  d.2#  bcx a.
-b2#  dax  b.2#  aax  d.
+2#cdda
+xa.
+2# dd
+xc.
+b
+2#a   d
+x d.
+2# bb
+xa.
+b
+2# d   d
+x b.
+2# ab
+x d.
+b
+2# b  a
+x a.
+2#  de
+x b.
+b
+2# a   d
+x  d.
+2#  bc
+x a.
+b
+2#  da
+x  b.
+2#  aa
+x  d.
 b
 
 b
 1 ab  d
-2#   ax  d.
+2#   a
+x  d.
 bX
-1 ab  dbQ
+1 ab  d
+bQ
 bQ
 1dab  d
 b
-2#cddaxa.2 dd
-3#axc.
+2#cdda
+xa.
+2 dd
+3#a
+xc.
 b
-2#a   dx d.2 bb
-3#cxa.
+2#a   d
+x d.
+2 bb
+3#c
+xa.
 b
-2# d   dx b.2 ab
-3# bx d.
+2# d   d
+x b.
+2 ab
+3# b
+x d.
 b
-2# b  ax a.2  de
-3# ax b.
+2# b  a
+x a.
+2  de
+3# a
+x b.
 b
-2# a   dx  d.2  bc
-3# bx a.
+2# a   d
+x  d.
+2  bc
+3# b
+x a.
 b
-2#  dax  b.2  aa
-3#  bx  d.
+2#  da
+x  b.
+2  aa
+3#  b
+x  d.
 b
 
 b
 1 ab  d
-2#   ax  d.
+2#   a
+x  d.
 bX
 1 ab  d
 bQ
 bQ
-2#  dcx a.
+2#  dc
+x a.
 b
 1 bd  b
-2#   dx a.
-bQ2# d   bx b.2# a   bx  d.
+2#   d
+x a.
+bQ
+2# d   b
+x b.
+2# a   b
+x  d.
 b
 1 ab  d
-2#   ax d.
-b2# b   dx a.2#  d  dx  b.
-b2  da
-3#  bx  d.
+2#   a
+x d.
+b
+2# b   d
+x a.
+2#  d  d
+x  b.
+b
+2  da
+3#  b
+x  d.
 2  b c
-3#  ax  b.
+3#  a
+x  b.
 b
 2  d d
-3#  bx  d.
-2#  bax  a.
+3#  b
+x  d.
+2#  ba
+x  a.
 b
 
 b
 1 ab  d
-2#   ax  d.
+2#   a
+x  d.
 bX
 1 ab  d
 bQ
 bQ
-2#  dcx a.
+2#  dc
+x a.
 b
-3# bd  bx a.x  dx a.3# bx  d.x ax b.
+3# bd  b
+x a.
+x  d
+x a.
+3# b
+x  d.
+x a
+x b.
 b
 2 d   b
-3# ax b.3# dx b.x ax  d.
+3# a
+x b.
+3# d
+x b.
+x a
+x  d.
 b
 2 ab  d
-3#   ax  a.3#  bx  d.x ax b.
+3#   a
+x  a.
+3#  b
+x  d.
+x a
+x b.
 b
 2 db  d
-3# bx a.3# bx a.x  dx  b.
+3# b
+x a.
+3# b
+x a.
+x  d
+x  b.
 b
 
 b
-2#   ax dd.2#  bc
+2#   a
+x dd.
+2#  bc
 x    d
 b
-3#   ax  b.x  a
+3#   a
+x  b.
+x  a
 x   c.
-3#  aax  b.
+3#  aa
+x  b.
 x   c
 x  a.
-b3# ab  d
+b
+3# ab  d
 x b.
 x d
 x b.
-3# ax  d.x  b
+3# a
+x  d.
+x  b
 x  a.
 b
-2# ab  dx   a
+2# ab  d
+x   a
 bbX
 1dab  d
 b2
-3#   axa.xc
-xd.3#fxd.xcxa.
-b3#   a
-xc.xaxc.3#   cxd.xcxd.
+3#   a
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xa.
+b
+3#   a
+xc.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
 b
 
-b3#    dx a.x bx d.3#ax d.x bx a.
-b3#    dxab.x ax b.3#   cxd.xcxd.
-b3#   axc.xaxc.3#   cxd.xcxd.
-b3#    dxab.x dxa.3#   axc.xaxc.
+b
+3#    d
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
+b
+3#    d
+xab.
+x a
+x b.
+3#   c
+xd.
+xc
+xd.
+b
+3#   a
+xc.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
+b
+3#    d
+xab.
+x d
+xa.
+3#   a
+xc.
+xa
+xc.
 b
 2dab  d
-3#cxa.3# dx b.x ax  d.
+3#c
+xa.
+3# d
+x b.
+x a
+x  d.
 b
 
-b3#  bx  d.x ax c.3# dxa.xcxd.
-bbQ
-3#   axa.xcxd.3#fxd.xcxa.
-b3#   axc.xaxc.3#   cxd.xcxd.
-b3#    dx a.x bx d.3#ax d.x bx a.
-b3#    dxab.x ax b.3#   cxd.xcxd.
+b
+3#  b
+x  d.
+x a
+x c.
+3# d
+xa.
+xc
+xd.
+b
+bQ
+3#   a
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xa.
+b
+3#   a
+xc.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
+b
+3#    d
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
+b
+3#    d
+xab.
+x a
+x b.
+3#   c
+xd.
+xc
+xd.
 b
 
 b
@@ -10752,67 +17639,323 @@ xc.
 xd.
 xc
 xd.
-b3#    dxab.x dxa.3#   axc.xaxc.
+b
+3#    d
+xab.
+x d
+xa.
+3#   a
+xc.
+xa
+xc.
 b
 2dab  d
-3#c.xa3# d.x bx a.x  d.
-b3#  bx  d.x ax c.3# dxa.xcxd.
+3#c.
+xa
+3# d.
+x b
+x a.
+x  d.
+b
+3#  b
+x  d.
+x a
+x c.
+3# d
+xa.
+xc
+xd.
 bQ
 b
-3#   axc.xaxc.3#daxc.xax d.
+3#   a
+xc.
+xa
+xc.
+3#da
+xc.
+xa
+x d.
 b
 
-b3#    dxab.x dxa.3#caxa.x dx b.
-b3#     dx d.x bx d.3#abx d.x bx a.
-b3#    ax b.x ax b.3# dax b.x ax  d.
-b3#     dx ab.x  dx a.3# bbx a.x  dx  b.
-b3#   ax  d.x  bx  d.3# abx  d.x  bx  a.
 b
-
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  ax  b.3#   cxd.xcxd.
-bbQ
-3#   axc.xaxc.3#daxc.xax d.
-b3#    dxab.x dxa.3#caxa.x d
+3#    d
+xab.
+x d
+xa.
+3#ca
+xa.
+x d
 x b.
-b3#     dx d.x bx d.3#abx d.x bx a.
+b
+3#     d
+x d.
+x b
+x d.
+3#ab
+x d.
+x b
+x a.
+b
+3#    a
+x b.
+x a
+x b.
+3# da
+x b.
+x a
+x  d.
+b
+3#     d
+x ab.
+x  d
+x a.
+3# bb
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  b
+x  d.
+3# ab
+x  d.
+x  b
+x  a.
 b
 
-b3#    ax b.x a
-x b.3# dax b.x ax  d.
-b3#     dx ab.x  dx a.3# bbx a.x  dx  b.
-b3#   ax  d.x  bx  d.3# abx  d.x  bx  a.
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  ax  b.2#  dcx a.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  a
+x  b.
+3#   c
+xd.
+xc
+xd.
+b
+bQ
+3#   a
+xc.
+xa
+xc.
+3#da
+xc.
+xa
+x d.
+b
+3#    d
+xab.
+x d
+xa.
+3#ca
+xa.
+x d
+x b.
+b
+3#     d
+x d.
+x b
+x d.
+3#ab
+x d.
+x b
+x a.
+b
+
+b
+3#    a
+x b.
+x a
+x b.
+3# da
+x b.
+x a
+x  d.
+b
+3#     d
+x ab.
+x  d
+x a.
+3# bb
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  b
+x  d.
+3# ab
+x  d.
+x  b
+x  a.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  a
+x  b.
+2#  dc
+x a.
 bQ
 b
 
 b
 bQ
-3# bd  bx a.x bx d.3#ax d.x bx a.
-b3#     bx b.x ax b.3# dx b.x ax  d.
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  dx a.3# bx a.x  dx  b.
-b3#   ax  d.x  bx  d.3#    cx  b.x  ax  b.
+3# bd  b
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
+b
+3#     b
+x b.
+x a
+x b.
+3# d
+x b.
+x a
+x  d.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  d
+x a.
+3# b
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  b
+x  d.
+3#    c
+x  b.
+x  a
+x  b.
 b
 
-b3#    dx  d.x  bx  d.3#   ax  a.x  bx  d.
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  ax  b.
-2#  dcx a.
+b
+3#    d
+x  d.
+x  b
+x  d.
+3#   a
+x  a.
+x  b
+x  d.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  a
+x  b.
+2#  dc
+x a.
 b
 bQ
-3# bd  bx a.x bx d.3#ax d.x bx a.
-b3#     bx b.x ax b.3# dx b.x ax  d.
+3# bd  b
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
+b
+3#     b
+x b.
+x a
+x b.
+3# d
+x b.
+x a
+x  d.
 b
 
-b3#     dx aa.x  bx  d.3# ax  d.x  bx  a.
-b3#     dx ab.x  dx a.3# bx a.x  dx  b.
-b3#   ax  d.x  bx  d.3#    cx  b.x  ax  b.
-b3#    dx  d.x  bx  d.3#   ax  a.x  bx  d.
+b
+3#     d
+x aa.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x ab.
+x  d
+x a.
+3# b
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  b
+x  d.
+3#    c
+x  b.
+x  a
+x  b.
+b
+3#    d
+x  d.
+x  b
+x  d.
+3#   a
+x  a.
+x  b
+x  d.
 b
 2 ab  d
-3#  ax   c.3#   ax    d.x    cx    a.
+3#  a
+x   c.
+3#   a
+x    d.
+x    c
+x    a.
 b
 1Q ab  d
 bbX
@@ -10820,14 +17963,19 @@ S3
 1dab  d
 b
 
-b11.cdda
-2cd.1  d.
+b1
+1.cdda
+2cd.
+1  d.
 b
 1cdda
-1c.1dab  d
-b1.abb d
+1c.
+1dab  d
+b
+1.abb d
 2# a.
-x bx d.
+x b
+x d.
 b
 1abb d
 1   c
@@ -10837,140 +17985,230 @@ b
 2# d
 xa.
 1cdda
-b1dabc
-1abb d1cdda
-b1.dab  d
-2dab.1   a.
+b
+1dabc
+1abb d
+1cdda
+b
+1.dab  d
+2dab.
+1   a.
 b
 
 b
 1dab  d
-1   abQ
+1   a
+bQ
 bQ
 1dab  d
-bX1cdda
-2# dxa.2#cxd.
+bX
+1cdda
+2# d
+xa.
+2#c
+xd.
 b
 1cdda
-2#dxc.2#ax d.
-b1abb d2#  dx a.2# bx d.
-b2#abb dx d.2#axc2#dxa.b
+2#d
+xc.
+2#a
+x d.
+b
+1abb d
+2#  d
+x a.
+2# b
+x d.
+b
+2#abb d
+x d.
+2#a
+xc
+2#d
+xa.
+b
 2#cdda
 xa.
 2#c
-xd.1cdda
-b1dabc1abb d
+xd.
+1cdda
+b
+1dabc
+1abb d
 1cdda
 b
 
 b
 1dab  d
-2#cxa.2# dx b.bX
+2#c
+xa.
+2# d
+x b.
+bX
 1 ab  d
-1   abQ
+1   a
+bQ
 bQ
 1dab  d
 b
 2#cdda
 xd.
-2#cxa.2# ddxc.
-b2#abb d
-xc.
-2#ax d.2# bbxa.
-b2# d   d
+2#c
 xa.
-2# dx b.2# abx d.
-b2# b  a
+2# dd
+xc.
+b
+2#abb d
+xc.
+2#a
 x d.
-2# bx a.2#  dex b.
+2# bb
+xa.
+b
+2# d   d
+xa.
+2# d
+x b.
+2# ab
+x d.
+b
+2# b  a
+x d.
+2# b
+x a.
+2#  de
+x b.
 b
 
-b2# ab  d
+b
+2# ab  d
 x b.
-2# ax  d.2#  bcx a.
-b2#  da
+2# a
+x  d.
+2#  bc
 x a.
-2#  dx  b.2#  aax  d.
+b
+2#  da
+x a.
+2#  d
+x  b.
+2#  aa
+x  d.
 b
 1 ab  d
 2#   a
 x  a.
-2#  bx  d.
+2#  b
+x  d.
 bX
 1 ab  d
-1   abQ
+1   a
+bQ
 bQ
 1dab  d
 b
 2#cdda
 xd.
-2#cxa.2 dd
+2#c
+xa.
+2 dd
 3#a
-xc.b
+xc.
+b
 2#abb d
 xc.
-2#ax d.2 bb
-3#cxa.
+2#a
+x d.
+2 bb
+3#c
+xa.
 b
 
 b
-2# d   dx b.
+2# d   d
+x b.
 2# a
-x  d.2 ab
-3# bx d.
+x  d.
+2 ab
+3# b
+x d.
 b
 2# b  a
 x d.
-2# bx a.2  de
-3# ax b.
+2# b
+x a.
+2  de
+3# a
+x b.
 b
 2# ab  d
 x b.
-2# ax  d.2  bc
-3# bx a.
+2# a
+x  d.
+2  bc
+3# b
+x a.
 b
 2#  da
 x a.
-2#  dx  b.2  aa
-3#  bx  d.
+2#  d
+x  b.
+2  aa
+3#  b
+x  d.
 b
 1 ab  d
 2#   a
 x  a.
 3#  b
 x  a.
-x  bx  d.
+x  b
+x  d.
 bX
 1 ab  d
 1   a
 bQ
 bQ
-2#  dcx a.
+2#  dc
+x a.
 b
 
 b
 1. bd  b
-2 bd.1   d.
-b2# bd  b
+2 bd.
+1   d.
+b
+2# bd  b
 x a.
-2# d   bx b.2# a   bx  d.
+2# d   b
+x b.
+2# a   b
+x  d.
 b
 1. ab  d
-2 ab.1   a.
-b2# ab  d
+2 ab.
+1   a.
+b
+2# ab  d
 x d.
-2# bx a.2#  dx  b.
-b1  da
+2# b
+x a.
+2#  d
+x  b.
+b
+1  da
 1 d.
 1 abc
 b
 1 bb d
-1  dff1   e.
+1  dff
+1   e.
 b
 1 ab  d
 2#   a
 x  a.
-2#  bx  d.
+2#  b
+x  d.
 b
 
 b
@@ -10978,96 +18216,86 @@ b
 1   a
 bQ
 bQ
-2#  dcx a.
+2#  dc
+x a.
 bX
-2# bd  bx  b.2#  dx a.3# bx a.x bx d.
+2# bd  b
+x  b.
+2#  d
+x a.
+3# b
+x a.
+x b
+x d.
 b
 2 bd  b
-3# ax b.2# dx b.
+3# a
+x b.
+2# d
+x b.
 3# d
-x b.x ax  d.
+x b.
+x a
+x  d.
 b
 2# ab  d
 x  a.
-2#   cx  a.3#  bx  a.x  bx  d.
-b
-2# ab  d
-x  a.
-3#  bx  a.x  bx  d.2# ax  b.
-b
-
-b
-2#  da
-x a.2#  dx  b.
-2#  a
-x   c.
-b
-2#  aax  b.2#  d
+2#   c
 x  a.
 3#  b
 x  a.
 x  b
 x  d.
-b2# ab  d
-xd.
-2#cxa.3# dx b.x ax  d.
 b
-1 ab  d1   a
+2# ab  d
+x  a.
+3#  b
+x  a.
+x  b
+x  d.
+2# a
+x  b.
+b
+
+b
+2#  da
+x a.
+2#  d
+x  b.
+2#  a
+x   c.
+b
+2#  aa
+x  b.
+2#  d
+x  a.
+3#  b
+x  a.
+x  b
+x  d.
+b
+2# ab  d
+xd.
+2#c
+xa.
+3# d
+x b.
+x a
+x  d.
+b
+1 ab  d
+1   a
 bbX
 1dab  d
 b2
-3#   axa.xc
-xd.3#fxd.xcxa.
-3# d
-x c.
-x d
-xa.
-b
-
-b3#   a
-x c.x dxa.
 3#   a
-xc.
-xa
-xc.3#   cxd.xcxd.
-b3#    dx a.x bx d.
-3#a
-xc.
-xd
-xc.3#ax d.x bx a.
-b3#    dx a.x b
-x d.
-3#a
-x d.
-xa
-xc.3#   cxd.xcxd.
-b3#   a
-x c.
-x d
-xa.3#c
-x d.xaxc.3#   cxd.xcxd.
-b
-
-b3#    dx a.
-x bx d.3#a
-xc.
-xd
-xa.3#   axc.xaxc.
-b
-2dab  d
-3#cxa.
-3#c
-xa.x dx b.
-3# d
-x b.x ax  d.
-b3#  b
-x  a.
-x  b
-x  d.3# a
-x  d.
-x ax c.3# dxa.xcxd.
-bbQ
-3#   axa.xcxd.3#fxd.xcxa.
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xa.
 3# d
 x c.
 x d
@@ -11078,19 +18306,41 @@ b
 3#   a
 x c.
 x d
-xa.3#   axc.xaxc.3#   cxd.xcxd.
-b3#    dx a.x bx d.
+xa.
+3#   a
+xc.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
+b
+3#    d
+x a.
+x b
+x d.
 3#a
 xc.
 xd
-xc.3#ax d.x bx a.
+xc.
+3#a
+x d.
+x b
+x a.
 b
-3#    dx a.x b
+3#    d
+x a.
+x b
 x d.
 3#a
 x d.
 xa
-xc.3#   cxd.xcxa.
+xc.
+3#   c
+xd.
+xc
+xd.
 b
 3#   a
 x c.
@@ -11106,191 +18356,537 @@ xc
 xd.
 b
 
-b3#    dx a.
-x bx d.3#a
+b
+3#    d
+x a.
+x b
+x d.
+3#a
 xc.
 xd
-xa.3#   axc.xaxc.
+xa.
+3#   a
+xc.
+xa
+xc.
 b
 2dab  d
-3#cxa.
 3#c
-xa.x dx b.3# d
+xa.
+3#c
+xa.
+x d
 x b.
-x ax  d.
-b3#  b
+3# d
+x b.
+x a
+x  d.
+b
+3#  b
 x  a.
-x  bx  d.3# ax  d.x a
+x  b
+x  d.
+3# a
+x  d.
+x a
 x c.
-3# dxa.xcxd.
-bbQ
+3# d
+xa.
+xc
+xd.
+b
+bQ
+3#   a
+xa.
+xc
+xd.
+3#f
+xd.
+xc
+xa.
+3# d
+x c.
+x d
+xa.
+b
+
+b
 3#   a
 x c.
 x d
-xa.3#c.
-x d.xaxc.3#dxc.xax d.
+xa.
+3#   a
+xc.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
 b
-
-b3#    dx a.
-x bx d.3#axc.
-xdxa.
-3#c
-xa.x dx b.
-b3#     dx d.
-x a
-x b.3# dx a.
-x bx d.
+3#    d
+x a.
+x b
+x d.
 3#a
-x d.x bx a.
-b3#    ax b.x ax b.3# dx b.x ax  d.
-3# a
-x  d.
-x  b
-x  a.
-b3#     dx  a.
-x  bx  d.3# ax  b.
-x  dx a.
-3# b
-x a.x  dx  b.
+xc.
+xd
+xc.
+3#a
+x d.
+x b
+x a.
 b
-
-b3#   ax  d.
-x  ax  b.3#  d.x  a.
-x  bx  d.
-3# a
-x  d.x  bx  a.
+3#    d
+x a.
+x b
+x d.
+3#a
+x d.
+xa
+xc.
+3#   c
+xd.
+xc
+xa.
 b
-3#     dx  a.x  bx  d.3# a
-x b.
+3#   a
+x c.
 x d
-x b.
-3# ax  d.x  bx  a.
-b3#     dx  a.
-x  b
-x  d.3# a
-x  d.x  b
-x  a.3#   cxd.xcxd.
-b
-bQ
-3#   ax c.x d
-xa.3#cx d.
-xaxc.
-3#d
-xc.xax d.
+xa.
+3#c
+x d.
+xa
+xc.
+3#   c
+xd.
+xc
+xd.
 b
 
-b3#    dx a.
-x bx d.3#axc.
+b
+3#    d
+x a.
+x b
+x d.
+3#a
+xc.
 xd
 xa.
-3#cxa.x d
-x b.
+3#   a
+xc.
+xa
+xc.
 b
-3#     dx d.
-x ax b.3# dx a.
-x bx d.
-3#a
-x d.x bx a.
-b3#    ax b.x a
-x b.3# d
+2dab  d
+3#c
+xa.
+3#c
+xa.
+x d
+x b.
+3# d
 x b.
 x a
-x  d.3# ax  d.
+x  d.
+b
+3#  b
+x  a.
+x  b
+x  d.
+3# a
+x  d.
+x a
+x c.
+3# d
+xa.
+xc
+xd.
+b
+bQ
+3#   a
+x c.
+x d
+xa.
+3#c.
+x d.
+xa
+xc.
+3#d
+xc.
+xa
+x d.
+b
+
+b
+3#    d
+x a.
+x b
+x d.
+3#a
+xc.
+xd
+xa.
+3#c
+xa.
+x d
+x b.
+b
+3#     d
+x d.
+x a
+x b.
+3# d
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
+b
+3#    a
+x b.
+x a
+x b.
+3# d
+x b.
+x a
+x  d.
+3# a
+x  d.
 x  b
 x  a.
-b3#     dx  a.
-x  bx  d.3# a.x  b.
-x  dx a.
+b
+3#     d
+x  a.
+x  b
+x  d.
+3# a
+x  b.
+x  d
+x a.
 3# b
-x a.x  dx  b.
+x a.
+x  d
+x  b.
 b
 
-b3#   ax  d.
-x  ax  b.3#  dx  a.
-x  bx  d.
+b
+3#   a
+x  d.
+x  a
+x  b.
+3#  d.
+x  a.
+x  b
+x  d.
 3# a
-x  d.x  bx  a.
-b3#     dx  a.x  bx  d.3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x  a.
+x  b
+x  d.
+3# a
 x b.
 x d
 x b.
-3# ax  d.x  bx  a.
-b2#     dx ab.2#   ax ab.bQ
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x  a.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+3#   c
+xd.
+xc
+xd.
+b
 bQ
-2#  dcx a.
+3#   a
+x c.
+x d
+xa.
+3#c
+x d.
+xa
+xc.
+3#d
+xc.
+xa
+x d.
+b
+
+b
+3#    d
+x a.
+x b
+x d.
+3#a
+xc.
+xd
+xa.
+3#c
+xa.
+x d
+x b.
+b
+3#     d
+x d.
+x a
+x b.
+3# d
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
+b
+3#    a
+x b.
+x a
+x b.
+3# d
+x b.
+x a
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x  a.
+x  b
+x  d.
+3# a.
+x  b.
+x  d
+x a.
+3# b
+x a.
+x  d
+x  b.
+b
+
+b
+3#   a
+x  d.
+x  a
+x  b.
+3#  d
+x  a.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3#     d
+x  a.
+x  b
+x  d.
+3# a
+x b.
+x d
+x b.
+3# a
+x  d.
+x  b
+x  a.
+b
+2#     d
+x ab.
+2#   a
+x ab.
+bQ
+bQ
+2#  dc
+x a.
 bX
-3# bd  bx a.x bx d.3#ax d.x bx a.
+3# bd  b
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
 3#  d
 x a.
 x b
 x d.
 b
 
-b3#     bx b.x ax b.3# dx b.x ax  d.
+b
+3#     b
+x b.
+x a
+x b.
+3# d
+x b.
+x a
+x  d.
 3# a
 x  d.
 x  b
 x  a.
-b3# ab  dx  d.x  b
+b
+3# ab  d
+x  d.
+x  b
 x  a.
 3#   c
 x  a.
-x  bx  d.3# ax  d.x  bx  a.
-b3# ab  dx  a.
-x  bx  d.3# a.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
+b
+3# ab  d
+x  a.
+x  b
+x  d.
+3# a.
 x  b.
 x  d
-x a.3# bx a.x  dx  b.
+x a.
+3# b
+x a.
+x  d
+x  b.
 b
-3#   ax  d.
-x  ax  b.3#  d
+3#   a
+x  d.
+x  a
+x  b.
+3#  d
 x  a.
 x  b
-x  d.3#    cx  b.x  ax  b.
-b3#    dx  d.
-x  ax  b.3#  d
+x  d.
+3#    c
+x  b.
+x  a
+x  b.
+b
+3#    d
+x  d.
+x  a
+x  b.
+3#  d
 x  a.
 x  b
-x  d.3#   ax  a.x  bx  d.
+x  d.
+3#   a
+x  a.
+x  b
+x  d.
 b
 
-b3#     dx  a.x  bx  d.3# a
+b
+3#     d
+x  a.
+x  b
+x  d.
+3# a
 x b.
 x d
 x b.
-3# ax  d.x  bx  a.
-b2#     dx ab.2#   ax ab.
+3# a
+x  d.
+x  b
+x  a.
+b
+2#     d
+x ab.
+2#   a
+x ab.
 bQ
 bQ
-2#  dcx a.
+2#  dc
+x a.
 bX
-3# bd  bx a.x bx d.3#ax d.x bx a.
+3# bd  b
+x a.
+x b
+x d.
+3#a
+x d.
+x b
+x a.
 3#  d
 x a.
 x b
 x d.
-b3#     bx b.x ax b.3# dx b.x ax  d.
+b
+3#     b
+x b.
+x a
+x b.
+3# d
+x b.
+x a
+x  d.
 3# a
 x  d.
 x  b
 x  a.
-b3# ab  dx  d.x  b
+b
+3# ab  d
+x  d.
+x  b
 x  a.
 3#   c
 x  a.
-x  bx  d.3# ax  d.x  bx  a.
+x  b
+x  d.
+3# a
+x  d.
+x  b
+x  a.
 b
 
-b3# ab  dx  a.
-x  bx  d.3# a.
+b
+3# ab  d
+x  a.
+x  b
+x  d.
+3# a.
 x  b.
 x  d
 x a.
-3# bx a.x  dx  b.
-b3#   ax  d.x  ax  b.3#  d.
+3# b
+x a.
+x  d
+x  b.
+b
+3#   a
+x  d.
+x  a
+x  b.
+3#  d.
 x  a.
 x  b
-x  d.3#    cx  b.x  ax  b.
+x  d.
+3#    c
+x  b.
+x  a
+x  b.
 b
 3#    d
 x  d.
@@ -11306,10 +18902,15 @@ x  b
 x  d.
 b
 2 ab  d
-3#   ax  a.
+3#   a
+x  a.
 3#  b
-x  d.x a
-x b.3# dx b.x a
+x  d.
+x a
+x b.
+3# d
+x b.
+x a
 x  d.
 b
 1 ab  d
@@ -11324,29 +18925,63 @@ Sc
 1 bbcd
 b
 1 ab  d
-2#   ax  d.
+2#   a
+x  d.
 b
-1 ab  d1 bbcd
-b1  d db
-2#  d d.x     a
+1 ab  d
+1 bbcd
 b
-1  d db1 bbcd
-b1 aba d1 bbcd
-b1  d db1 aba d
-b1 bbcd
-2# bbc.x    c
+1  d db
+2#  d d.
+x     a
+b
+1  d db
+1 bbcd
+b
+1 aba d
+1 bbcd
+b
+1  d db
+1 aba d
 b
 1 bbcd
-bbX1 bbcd
+2# bbc.
+x    c
 b
-2# ab  dx  d.2#  b  dx a.
+1 bbcd
+bbX
+1 bbcd
+b
+2# ab  d
+x  d.
+2#  b  d
+x a.
 b
 
-b2#  d dbx     a2#     bx  d d
-b2#  bcdx   d.2#   cdx  b.
-b2#bbddxa.2# ddx b.
-b2#a   dx d.2# bbxa.
-b2# d   dx b.2# ab
+b
+2#  d db
+x     a
+2#     b
+x  d d
+b
+2#  bcd
+x   d.
+2#   cd
+x  b.
+b
+2#bbdd
+xa.
+2# dd
+x b.
+b
+2#a   d
+x d.
+2# bb
+xa.
+b
+2# d   d
+x b.
+2# ab
 x d.
 b
 1abb d
@@ -11355,24 +18990,35 @@ x d.
 b
 1abb d
 bbX
-2# dxa.
+2# d
+xa.
 b
 1bde b
-2#bde.x    a
+2#bde.
+x    a
 b
-1bde b1bde b
+1bde b
+1bde b
 b
 
-b1abb d
-2#abb.x    c
 b
 1abb d
-2#    cx    a
+2#abb.
+x    c
 b
-1 aba d1 bdca
-b1 bba d1 aba d
-b1abb d
-2#   cx d.
+1abb d
+2#    c
+x    a
+b
+1 aba d
+1 bdca
+b
+1 bba d
+1 aba d
+b
+1abb d
+2#   c
+x d.
 b
 1abb d
 bbX
@@ -11382,66 +19028,126 @@ b
 1. aba d
 2 ab.
 1   a
-b1 aba d1 aba.1 bbcd
-b1.  dddb
+b
+1 aba d
+1 aba.
+1 bbcd
+b
+1.  dddb
 2  ddd.
 1     b
 b
 
-b1  dddb1  ddd.1 bbcd
-b1 ab  d
-2#   ax  d.
+b
+1  dddb
+1  ddd.
+1 bbcd
+b
 1 ab  d
-b1 bbcd1  dddb1 aba d
+2#   a
+x  d.
+1 ab  d
+b
+1 bbcd
+1  dddb
+1 aba d
 b
 1. bbcd
 2 bbc.
 1    d
-b1 bbcd1 bbc.
-bbX1 bbcd
 b
-2# aba dx  a.2#  bx  d.
+1 bbcd
+1 bbc.
+bbX
+1 bbcd
+b
+2# aba d
+x  a.
+2#  b
+x  d.
 1 aba d
-b1  d db
-2#  d d.x     a2#     bx  d d.
+b
+1  d db
+2#  d d.
+x     a
+2#     b
+x  d d.
 b
 
 b
 1  bcd
-2#  bc.x   d.2#   cdx  b.
-b2#bbddxd.2#bxa.2# ddxb.
-b2#a   dxb.2#ax d.2# bbxa.
-b2# d   dxa.2# dx b.2# abx d.
+2#  bc.
+x   d.
+2#   cd
+x  b.
+b
+2#bbdd
+xd.
+2#b
+xa.
+2# dd
+xb.
+b
+2#a   d
+xb.
+2#a
+x d.
+2# bb
+xa.
+b
+2# d   d
+xa.
+2# d
+x b.
+2# ab
+x d.
 b
 1abb d
-2#abb.x   d2#   c
+2#abb.
+x   d
+2#   c
 x   a
 b
 1abb d
 1abb.
 bbX
-2# dxa.
+2# d
+xa.
 b
 
 b
 1.bde b
 2bde
 1   d
-b1bde b1bde b
-2#ax d.
+b
+1bde b
+1bde b
+2#a
+x d.
 b
 1.abb d
 2abb.
 1   c
-b1abb d1abb d
-2#    cx    a
+b
+1abb d
+1abb d
+2#    c
+x    a
 b
 1 aba d
-2#   ax d.
+2#   a
+x d.
 1 bdca
-b1 bdd b1 bba d1 aba d
-b1abb d
-2#  dx a.2# bx d.
+b
+1 bdd b
+1 bba d
+1 aba d
+b
+1abb d
+2#  d
+x a.
+2# b
+x d.
 b
 1abb d
 Yabb.
@@ -11454,56 +19160,108 @@ BX
 bX
 Sc
 1 dda
-b1 cd a
-2#   cx a.
 b
-1 cd a1 dda
-b1 ab  d
-2#   ax  d.
+1 cd a
+2#   c
+x a.
 b
-1 ab  d1 dda
-b1 cd a1 dda
-b1 ab  d1 cd a
-b1 dda
-2#     cx c.
+1 cd a
+1 dda
+b
+1 ab  d
+2#   a
+x  d.
+b
+1 ab  d
+1 dda
+b
+1 cd a
+1 dda
+b
+1 ab  d
+1 cd a
 b
 1 dda
-bbX1 dda
+2#     c
+x c.
 b
-2# cd ax a.2#  d ax c.
+1 dda
+bbX
+1 dda
+b
+2# cd a
+x a.
+2#  d a
+x c.
 b
 
-b2# ab  dx  d.2#  b  dx a.
-b2#  def
-x   f.2#   efx  d.
+b
+2# ab  d
+x  d.
+2#  b  d
+x a.
+b
+2#  def
+x   f.
+2#   ef
+x  d.
 b
 2#dab  d
-xc.2#a    dxd.
-b2#cddaxa.2# ddxc.
-b2#acd ax d.2# cdxa.
+xc.
+2#a    d
+xd.
+b
+2#cdda
+xa.
+2# dd
+xc.
+b
+2#acd a
+x d.
+2# cd
+xa.
 b
 1cdda
-2# dxa.
+2# d
+xa.
 b
 1cdda
 bbX
-2#axc.
+2#a
+xc.
 b
 
 b
 1db cd
-2#db c.x    c
+2#db c.
+x    c
 b
-1db cd1db cd
+1db cd
+1db cd
 b
-2#cddaxa.2#cxd.
-b2#   axcdd.2#ax d.
+2#cdda
+xa.
+2#c
+xd.
+b
+2#   a
+xcdd.
+2#a
+x d.
 b
 1acd a
-2# da cx     d
-b2#acd ax d.2#    axacd.
+2# da c
+x     d
 b
-2#   ax d.2#  d.x   c
+2#acd a
+x d.
+2#    a
+xacd.
+b
+2#   a
+x d.
+2#  d.
+x   c
 b
 1 dda
 bbX
@@ -11515,71 +19273,121 @@ b
 1. cdca
 2 cd.
 1   c
-b1 cd a1   c1 dda
+b
+1 cd a
+1   c
+1 dda
 b
 1. aba d
 2 ab.
 1   a
-b1 aba d1 aba.1 dda
-b1 cd a
-2#   cx a.
+b
+1 aba d
+1 aba.
+1 dda
+b
 1 cd a
-b1 dda1 aba d1acd a
+2#   c
+x a.
+1 cd a
+b
+1 dda
+1 aba d
+1acd a
 b
 1. dda
 2 d.
 1  d
-b1 dda1 dd.
-bbX1 dda
+b
+1 dda
+1 dd.
+bbX
+1 dda
 b
 
 b
-2# cdcax  c.2#  dx a.
+2# cdca
+x  c.
+2#  d
+x a.
 1 cdca
-b1 aba d
-2# aba.x  d.
+b
 1 aba d
-b1  def
-2#  de.x   f.
+2# aba.
+x  d.
+1 aba d
+b
+1  def
+2#  de.
+x   f.
 1  def
 b
-2# ab  dx  d.2# a   dx c.2# d   dxa.
-b2#c  axd.2#cxa.2# dd.xc.
+2# ab  d
+x  d.
+2# a   d
+x c.
+2# d   d
+xa.
+b
+2#c  a
+xd.
+2#c
+xa.
+2# dd.
+xc.
 b
 1acd a
-2#   cx d.
+2#   c
+x d.
 2# QcQd.
 x-Qa.
-bQ1 dda
-2# dd.x   a2# dd.x   c
+bQ
+1 dda
+2# dd.
+x   a
+2# dd.
+x   c
 b
 
 b
-1 dda1 dd
+1 dda
+1 dd
 bbX
-2#axc.
+2#a
+xc.
 b
 1.db cd
 2db.
 1   c
-b1db cd1db cd
-2#cxa.
+b
+1db cd
+1db cd
+2#c
+xa.
 b
 1.cdda
 2cd.
 1  d
-b1cdda1cdda
-2#ax d.
+b
+1cdda
+1cdda
+2#a
+x d.
 b
 1acd a
-2#   cx d.
+2#   c
+x d.
 1acd a
-b1 dda1 ddca1 c.
+b
+1 dda
+1 ddca
+1 c.
 b
 1. dda
 2 d.
 1  d
-b1 dda
+b
+1 dda
 Y dd.
 b
 B
@@ -11588,200 +19396,812 @@ p
 {H12ki. Passemezo Vngaro - Saltarello - Superius AABBCC4x2-ABC8/Pacoloni S 1564, ff. 29r-30v}
 BX
 bX
-Sc1dab  d
-b11cd a1  d1cd a1dab  dbQ1ab  d1  b1ab  d1dabcbQ1cdda1dabc1abb d1cddabQ1dab  d1   a1     dbQ
+Sc
+1dab  d
+b1
+1cd a
+1  d
+1cd a
+1dab  d
+bQ
+1ab  d
+1  b
+1ab  d
+1dabc
+bQ
+1cdda
+1dabc
+1abb d
+1cdda
 bQ
 1dab  d
-bX2#cd ax c2# dxa2cd a
-3#axc3#dxcxax dbQbQ
-3#ab  dx ax  dx a3# bx dxaxb3#ab  dx dxaxc3#dxaxcxdbQ2#   axcdd2#dabcxabb d2cdda
-3#dxc3#dxcxaxc
-bQ2dab  d
-3#cxa3# dx bx ax  d
-2# ab  dx   c
+1   a
+1     d
 bQ
 bQ
 1dab  d
-bX2#cd axa2# d axc2#abb dx d2# bbxabQbQ
-2# d   dx b2# abx d2# b  ax a2#  dex bbQ2# a   dx  d2#  bcx a2#  d ax  b2#  aax  dbQ1 ab  d
-2#   ax  d
-1 ab  dbQ
-bQ
-1dab  d
-bX2#cd axa2 d a
-3#axc
-2#ab  dx d2 bb
-3#cxa
-bQ2# d   dx b2 ab
-3# bx d
-2# b  ax a2  de
-3# ax b
-bQbQ
-2# a   dx  d2  bc
-3# bx a
-2#  d ax  b2  aa
-3#  bx  d
-bQ1 ab  d
-2#   ax  d
-1 aba d
-bQ
-bQ
-2#  dex a
-bX1 bd  b
-2#   dx a2# d   bx b2# a d 
-x  d
-bQ1 ab  d
-2#   ax d2# b   dx a2#  dcx  bbQ2  da
-3#  bx  d
-2  b c
-3#  ax  b
-2  d d
-3#  bx  d
-2#  bax  a
-bQbQ
-1 ab  d
-2#   ax  d
-1 ab  d
-bQ
-bQ
-2#  dex a
-bX3# bd  bx ax  dx a3# bx  dx ax b2 d   b
-3# ax b3# dx bx ax  dbQ3# aba dx  ax   cx  a3#  bx  dx ax b3# a   dx  bx  dx a3# bx ax  dx  b
-bQ2#   ax  d2#  bcx    d
-3#   ax  bx  ax   c3#  ax  bx   cx  a
-bQbQ
-1 ab  d
-2#   ax  d
-1 aba d
-bbX1dab  d
-b2
-3#   axaxcxd3#fxdxcxa3#   axcxaxc3#   cxdxcxd
-b3#    dx ax bx d3#ax dx bx a3#    dxabx ax b3#   cxdxcxd
-b3#   axcxaxc3#   cxdxcxd3#    dxabx ax b3#   cxdxcxd
-bQ
-
-bQ
-2dab  d
-3#cxa3# dx bx ax  d3#  bx  dx ax b3# dxaxcxd
-bbQ
-3#   axaxcxd3#fxdxcxa3#   axcxaxc3#   Qcxdxcxd
-b3#    dx ax bx d
-3#ax dx bx a3#    dxabx ax b3#   cxdxcxd
-b3#   axcxaxc3#   cxdxcxd4!
-3#    dxabx dxa3#   axcxaxc
-b
-2dab  d
-3#cxa3# dx bx ax  d3#  bx  dx ax b3# dxaxcxd
-bbQ
-3#   axcxaxc3#d bxcxax d3#    dx bx dxa3#c dxax dx b
-bQ3#     dx dx bx d3#a bx dx bx a3#    ax bx ax b3# dax bx ax  d
-bb
-3#     dx ax  dx a3# b cx ax  dx  b3#   ax  dx  bx  d3# ax  dx  bx  a
-b3#     dx ax  bx  d3# ax  dx  bx  a3#     dx abx  ax  b3#   cxdxcxd
-bQbQ
-3#   axcxaxc3#d  cxcxax d3#    dxabx dxa3#c dxax dx b
-b3#     dx dx bx d3#a bx dx bx a
-
-4!3#    ax bx ax b3# dax bx ax  d
-b3#     dx ax  dx a3# b cx ax  dx  b3#   ax  dx  bx  d3# ax  dx  bx  a
-bQ3#     dx ax  bx  d3# ax  dx  bx  a3#     dx abx  ax  b
-2#  dcx a
-b
-3# b  ax ax bx d3#a dx dx bx a3#     bx bx ax b3# d dx bx ax  d
-b
-
-b3# ab  dx  ax  bx  d3# ax  dx  bx  a3#     dx abax  dx a3# b cx ax  dx  b
-bQ3#   ax  dx  bx  d3#    cx  bx  ax  b3#    dx  dx  bx  d3#   ax  ax  bx  d
-b3#     dx abax  bx  d3# ax  dx  bx  a3#     dx abx  ax  b
-bQ
-bQ
-2#  dcx a
 bX
-3# bd  bx ax bx d3#a   dx dx bx a
+2#cd a
+x c
+2# d
+xa
+2cd a
+3#a
+xc
+3#d
+xc
+xa
+x d
+bQ
 
-4!3#     bx bx ax b3# d dx bx ax  d
-bQ3#     dx abax  bx  d3# ax  dx  bx  a3#     dx abax  dx a3# b cx ax  dx  b
-b3#   ax  dx  bx  d3#    cx  bx  ax  b3#    dx  dx  bx  d3#   ax  ax  bx  d
+bQ
+3#ab  d
+x a
+x  d
+x a
+3# b
+x d
+xa
+xb
+3#ab  d
+x d
+xa
+xc
+3#d
+xa
+xc
+xd
+bQ
+2#   a
+xcdd
+2#dabc
+xabb d
+2cdda
+3#d
+xc
+3#d
+xc
+xa
+xc
+bQ
+2dab  d
+3#c
+xa
+3# d
+x b
+x a
+x  d
+2# ab  d
+x   c
+bQ
+bQ
+1dab  d
+bX
+2#cd a
+xa
+2# d a
+xc
+2#abb d
+x d
+2# bb
+xa
+bQ
+
+bQ
+2# d   d
+x b
+2# ab
+x d
+2# b  a
+x a
+2#  de
+x b
+bQ
+2# a   d
+x  d
+2#  bc
+x a
+2#  d a
+x  b
+2#  aa
+x  d
+bQ
+1 ab  d
+2#   a
+x  d
+1 ab  d
+bQ
+bQ
+1dab  d
+bX
+2#cd a
+xa
+2 d a
+3#a
+xc
+2#ab  d
+x d
+2 bb
+3#c
+xa
+bQ
+2# d   d
+x b
+2 ab
+3# b
+x d
+2# b  a
+x a
+2  de
+3# a
+x b
+bQ
+
+bQ
+2# a   d
+x  d
+2  bc
+3# b
+x a
+2#  d a
+x  b
+2  aa
+3#  b
+x  d
+bQ
+1 ab  d
+2#   a
+x  d
+1 aba d
+bQ
+bQ
+2#  de
+x a
+bX
+1 bd  b
+2#   d
+x a
+2# d   b
+x b
+2# a d 
+x  d
+bQ
+1 ab  d
+2#   a
+x d
+2# b   d
+x a
+2#  dc
+x  b
+bQ
+2  da
+3#  b
+x  d
+2  b c
+3#  a
+x  b
+2  d d
+3#  b
+x  d
+2#  ba
+x  a
+bQ
+
+bQ
+1 ab  d
+2#   a
+x  d
+1 ab  d
+bQ
+bQ
+2#  de
+x a
+bX
+3# bd  b
+x a
+x  d
+x a
+3# b
+x  d
+x a
+x b
+2 d   b
+3# a
+x b
+3# d
+x b
+x a
+x  d
+bQ
+3# aba d
+x  a
+x   c
+x  a
+3#  b
+x  d
+x a
+x b
+3# a   d
+x  b
+x  d
+x a
+3# b
+x a
+x  d
+x  b
+bQ
+2#   a
+x  d
+2#  bc
+x    d
+3#   a
+x  b
+x  a
+x   c
+3#  a
+x  b
+x   c
+x  a
+bQ
+
+bQ
+1 ab  d
+2#   a
+x  d
+1 aba d
+bbX
+1dab  d
+b2
+3#   a
+xa
+xc
+xd
+3#f
+xd
+xc
+xa
+3#   a
+xc
+xa
+xc
+3#   c
+xd
+xc
+xd
+b
+3#    d
+x a
+x b
+x d
+3#a
+x d
+x b
+x a
+3#    d
+xab
+x a
+x b
+3#   c
+xd
+xc
+xd
+b
+3#   a
+xc
+xa
+xc
+3#   c
+xd
+xc
+xd
+3#    d
+xab
+x a
+x b
+3#   c
+xd
+xc
+xd
+bQ
+
+bQ
+2dab  d
+3#c
+xa
+3# d
+x b
+x a
+x  d
+3#  b
+x  d
+x a
+x b
+3# d
+xa
+xc
+xd
+b
+bQ
+3#   a
+xa
+xc
+xd
+3#f
+xd
+xc
+xa
+3#   a
+xc
+xa
+xc
+3#   Qc
+xd
+xc
+xd
+b
+3#    d
+x a
+x b
+x d
+3#a
+x d
+x b
+x a
+3#    d
+xab
+x a
+x b
+3#   c
+xd
+xc
+xd
+b
+3#   a
+xc
+xa
+xc
+3#   c
+xd
+xc
+xd
+
+4!
+3#    d
+xab
+x d
+xa
+3#   a
+xc
+xa
+xc
+b
+2dab  d
+3#c
+xa
+3# d
+x b
+x a
+x  d
+3#  b
+x  d
+x a
+x b
+3# d
+xa
+xc
+xd
+b
+bQ
+3#   a
+xc
+xa
+xc
+3#d b
+xc
+xa
+x d
+3#    d
+x b
+x d
+xa
+3#c d
+xa
+x d
+x b
+bQ
+3#     d
+x d
+x b
+x d
+3#a b
+x d
+x b
+x a
+3#    a
+x b
+x a
+x b
+3# da
+x b
+x a
+x  d
+b
+
+b
+3#     d
+x a
+x  d
+x a
+3# b c
+x a
+x  d
+x  b
+3#   a
+x  d
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+b
+3#     d
+x a
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+3#     d
+x ab
+x  a
+x  b
+3#   c
+xd
+xc
+xd
+bQ
+bQ
+3#   a
+xc
+xa
+xc
+3#d  c
+xc
+xa
+x d
+3#    d
+xab
+x d
+xa
+3#c d
+xa
+x d
+x b
+b
+3#     d
+x d
+x b
+x d
+3#a b
+x d
+x b
+x a
+
+4!
+3#    a
+x b
+x a
+x b
+3# da
+x b
+x a
+x  d
+b
+3#     d
+x a
+x  d
+x a
+3# b c
+x a
+x  d
+x  b
+3#   a
+x  d
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+bQ
+3#     d
+x a
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+3#     d
+x ab
+x  a
+x  b
+2#  dc
+x a
+b
+3# b  a
+x a
+x b
+x d
+3#a d
+x d
+x b
+x a
+3#     b
+x b
+x a
+x b
+3# d d
+x b
+x a
+x  d
+b
+
+b
+3# ab  d
+x  a
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+3#     d
+x aba
+x  d
+x a
+3# b c
+x a
+x  d
+x  b
+bQ
+3#   a
+x  d
+x  b
+x  d
+3#    c
+x  b
+x  a
+x  b
+3#    d
+x  d
+x  b
+x  d
+3#   a
+x  a
+x  b
+x  d
+b
+3#     d
+x aba
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+3#     d
+x ab
+x  a
+x  b
+bQ
+bQ
+2#  dc
+x a
+bX
+3# bd  b
+x a
+x b
+x d
+3#a   d
+x d
+x b
+x a
+
+4!
+3#     b
+x b
+x a
+x b
+3# d d
+x b
+x a
+x  d
+bQ
+3#     d
+x aba
+x  b
+x  d
+3# a
+x  d
+x  b
+x  a
+3#     d
+x aba
+x  d
+x a
+3# b c
+x a
+x  d
+x  b
+b
+3#   a
+x  d
+x  b
+x  d
+3#    c
+x  b
+x  a
+x  b
+3#    d
+x  d
+x  b
+x  d
+3#   a
+x  a
+x  b
+x  d
 b
 2 aba d
-3#  ax   c3#   ax    dx    cx    a
+3#  a
+x   c
+3#   a
+x    d
+x    c
+x    a
 1Q aba d
 bbX
 S3
 1da   d
 b
 
-b1cd a
-2#  dxa2#cxd
+b
+1cd a
+2#  d
+xa
+2#c
+xd
 b
 1cdda
-2#axc
+2#a
+xc
 1dabc
-b1ab  d
-2#  bx a2# bx d
-b2#ab  dx d2#axc
+b
+1ab  d
+2#  b
+x a
+2# b
+x d
+b
+2#ab  d
+x d
+2#a
+xc
 1dabc
-b1cdda
-2#axc
+b
+1cdda
+2#a
+xc
 1dabc
-b1abb d
-2# dxa
+b
+1abb d
+2# d
+xa
 1cdda
 b
 1.dab  d
 2dab
 1   a
-b1dab  d1   a
-bbX1dab  d
+b
+1dab  d
+1   a
+bbX
+1dab  d
 b
 
-b1cdda
-2#dxc2#ax d
+b
+1cdda
+2#d
+xc
+2#a
+x d
 b
 1abb d
-2#cxa2# dx b
+2#c
+xa
+2# d
+x b
 bQ
 1 d   d
-2#ax d2# bx a
+2#a
+x d
+2# b
+x a
 b
 1 b  a
-2# dx b2# ax  d
+2# d
+x b
+2# a
+x  d
 bQ
 1 a   d
-2# bx a2#  dx  b
+2# b
+x a
+2#  d
+x  b
 b
 1  da
-2# ax  d2#  bx  a
+2# a
+x  d
+2#  b
+x  a
 b
 1 ab  d
-2#   ax  d2#  bx  a
+2#   a
+x  d
+2#  b
+x  a
 b
-1 ab  d1   a
+1 ab  d
+1   a
 bbX
-2#  dx a
+2#  d
+x a
 b
 
 b
 1 bd  b
-2#   dx a2# bx d
+2#   d
+x a
+2# b
+x d
 b
 1 bd  b
-2# d dx b2# ax  d
+2# d d
+x b
+2# a
+x  d
 b
 1 ab  d
-2#   ax  a2#  bx  d
+2#   a
+x  a
+2#  b
+x  d
 bQ
 1 ab  d
-2# b cx a2#  dx  b
+2# b c
+x a
+2#  d
+x  b
 b
 1  da
-2#  bx  d
+2#  b
+x  d
 1  b c
-b1  d d
-2#  bx  d2#  bax  a
+b
+1  d d
+2#  b
+x  d
+2#  ba
+x  a
 b
 1 ab  d
-2#   ax  d2#  bx  a
+2#   a
+x  d
+2#  b
+x  a
 b
 1 ab  d
 Y   a
@@ -11793,29 +20213,81 @@ B
 BX
 bX
 Sc
-1cddabQ1acd a1   c1acd a1cddabQ1dab  d1   a1dab  d1cddabQ1acd a1 dda1 aba d1acd abQ1 d a1  d1   a
-bbX1cdda
-b1acd a
-2# dx c2# aba dx    a2#    cx    e
+1cdda
+bQ
+1acd a
+1   c
+1acd a
+1cdda
+bQ
+1dab  d
+1   a
+1dab  d
+1cdda
+bQ
+1acd a
+1 dda
+1 aba d
+1acd a
+bQ
+1 d a
+1  d
+1   a
+bbX
+1cdda
+b
+1acd a
+2# d
+x c
+2# aba d
+x    a
+2#    c
+x    e
 b
 1 ddef
-2#   fx   e
-1aabc1   ce
+2#   f
+x   e
+1aabc
+1   ce
 b
 
-b1 dda1   ac
-2#  d ax  b2#  a ax   c
 b
-1 dd f1   e1 dd
+1 dda
+1   ac
+2#  d a
+x  b
+2#  a a
+x   c
+b
+1 dd f
+1   e
+1 dd
 bbX
-2#    dx    c
-bQ2#abb dx a2# b  dx d2#abb dxd2#cxa
+2#    d
+x    c
+bQ
+2#abb d
+x a
+2# b  d
+x d
+2#abb d
+xd
+2#c
+xa
 b
-1 dd f1   e1 dd f
-2#    ex    c
+1 dd f
+1   e
+1 dd f
+2#    e
+x    c
 b
-1 cdca1  da c1 aba d1 cdca
-b1 dd f1   e
+1 cdca
+1  da c
+1 aba d
+1 cdca
+b
+1 dd f
+1   e
 1 dd f
 bbX
 S3
@@ -11826,7 +20298,8 @@ b
 1.acd a
 2acd
 1   c
-b1acd a
+b
+1acd a
 2# d
 xa
 1cdda
@@ -11834,53 +20307,98 @@ b
 1. ab  d
 2 ab
 1   a
-b1 ab  d1   a1cdda
-b1acd a1   c1cdda
-b1 ab  d1   a1 ab  d
+b
+1 ab  d
+1   a
+1cdda
+b
+1acd a
+1   c
+1cdda
+b
+1 ab  d
+1   a
+1 ab  d
 b
 1. dd f
 2 dd
 1   e
-b1 dd f1   e
-bbX1cdda
+b
+1 dd f
+1   e
+bbX
+1cdda
 b
 
-b1acd a1   c1acd a
-b1 ab  d1   a1 ab  d
-b1 dda1     c1 dda
-b1 abc1     a1 abc
-b1 dda1     c1 dda
-b1acd a1 aba d1acd a
+b
+1acd a
+1   c
+1acd a
+b
+1 ab  d
+1   a
+1 ab  d
+b
+1 dda
+1     c
+1 dda
+b
+1 abc
+1     a
+1 abc
+b
+1 dda
+1     c
+1 dda
+b
+1acd a
+1 aba d
+1acd a
 b
 1. dda
 2 d
 1  d
-b1 d a1  d
-bbX1abb d
+b
+1 d a
+1  d
+bbX
+1abb d
 b
 
 b
 1.abb d
 2ab
 1  b
-b1abb d1 d  c1ab  d
+b
+1abb d
+1 d  c
+1ab  d
 b
 1.cd a
 2cd
 1  d
-b1cd a1a c e1 da c
+b
+1cd a
+1a c e
+1 da c
 b
 1.acd a
 2acd
 1   c
 b
-2# aba dx     c2#     dx    a2#    cx    e
+2# aba d
+x     c
+2#     d
+x    a
+2#    c
+x    e
 b
 1. dd f
 2 dd
 1   e
 b
-1 dd fY   e
+1 dd f
+Y   e
 b
 B
 
@@ -11888,85 +20406,233 @@ B
 BX
 bX
 Sc
-1abb dbQ1 db  d1   a1 db  d1abb dbQ1bbd  b1   d1bbd  b1abb dbQ1 dba d1abb d1bbd  b1 aba dbQ1abb d1   c1    d
-bbX1abb d
-bQ2# dba dx b2# aba dx d2# bd  bx a2#  d  bxbbQ
-
-bQ2#abb dxb2#abbxd2#bddaxa2# d axbbQ2#abb dx d2# b  dxa2# dax b2# aa
+1abb d
+bQ
+1 db  d
+1   a
+1 db  d
+1abb d
+bQ
+1bbd  b
+1   d
+1bbd  b
+1abb d
+bQ
+1 dba d
+1abb d
+1bbd  b
+1 aba d
+bQ
+1abb d
+1   c
+1    d
+bbX
+1abb d
+bQ
+2# dba d
+x b
+2# aba d
 x d
-bQ1ab  d
+2# bd  b
+x a
+2#  d  b
+xb
+bQ
+
+bQ
+2#abb d
+xb
+2#abb
+xd
+2#bdda
+xa
+2# d a
+xb
+bQ
+2#abb d
+x d
+2# b  d
+xa
+2# da
+x b
+2# aa
+x d
+bQ
+1ab  d
 2#  b
 x d
 1 bb d
 bbX
-2# dxa
-bQ2#bbd  bx     a2#     bx     d2#bbd  bx     d2#    ax    cbQ2#ab  dx a2# bx d2#abb dxb2#d   dxabQ
+2# d
+xa
+bQ
+2#bbd  b
+x     a
+2#     b
+x     d
+2#bbd  b
+x     d
+2#    a
+x    c
+bQ
+2#ab  d
+x a
+2# b
+x d
+2#abb d
+xb
+2#d   d
+xa
+bQ
 
-bQ2# dbx a2# b cxa2# d dx b2# abx d
-bQ1ab  d
-2#  bx d
+bQ
+2# db
+x a
+2# b c
+xa
+2# d d
+x b
+2# ab
+x d
+bQ
+1ab  d
+2#  b
+x d
 1 bb d
 bbX
 S3
 1abb d
 bQ
-2# aba dx  a2#  bx  d2# ax b
+2# aba d
+x  a
+2#  b
+x  d
+2# a
+x b
 b
 1 aba d
-2# bx d
+2# b
+x d
 1abb d
 b
 1.bbd  b
 2bbd
 1   d
-b1bbd  b1   d1abb d
+b
+1bbd  b
+1   d
+1abb d
 b
 
-b1 aba d
-2# bx d
+b
+1 aba d
+2# b
+x d
 1abb d
-bQ1bbd  b1   d1 aba d
+bQ
+1bbd  b
+1   d
+1 aba d
 bQ
 1.abb d
 2ab
 1  b
-b1ab  d1  b
+b
+1ab  d
+1  b
 bbX
 1abb d
 b
-2# aba dx  d2# ax b2# dxa
-b2#bbd  bx     a2#     b
+2# aba d
+x  d
+2# a
+x b
+2# d
+xa
+b
+2#bbd  b
+x     a
+2#     b
 x     d
-2#    ax    c
-bQ2#abb dx d2#axb2#dxa
+2#    a
+x    c
+bQ
+2#abb d
+x d
+2#a
+xb
+2#d
+xa
 b
 
 b
 1bdda
-2#dxb2#ax d
-b2#abb dxd2#cxa2# dx b
-b2# aba dx  d2# ax b2# dx a
+2#d
+xb
+2#a
+x d
+b
+2#abb d
+xd
+2#c
+xa
+2# d
+x b
+b
+2# aba d
+x  d
+2# a
+x b
+2# d
+x a
 bQ
 1.abb d
 2ab
 1  b
-b1ab  d1  b
+b
+1ab  d
+1  b
 bbX
-2# dxa
-b2#bbd  bx     a2#     bx     d2#    ax     d
+2# d
+xa
+b
+2#bbd  b
+x     a
+2#     b
+x     d
+2#    a
+x     d
 b
 
-b2#bbd  bx     a2#     bx     d2#    ax    c
+b
+2#bbd  b
+x     a
+2#     b
+x     d
+2#    a
+x    c
 b
 1.abb d
 2ab
 1  b
 bQ
-2#abb dxd2#cxa2# dx b
-b2# aba dx  d2# ax b2# dxa
+2#abb d
+xd
+2#c
+xa
+2# d
+x b
+b
+2# aba d
+x  d
+2# a
+x b
+2# d
+xa
 b
 1bbdd
-2#dxb
+2#d
+xb
 2#a
 x d
 b
@@ -11974,7 +20640,8 @@ b
 2ab
 1  b
 b
-1ab  dY  b
+1ab  d
+Y  b
 b
 B
 
@@ -11984,25 +20651,100 @@ p
 bX
 bX
 Sc
-1bdcdbQ1@dcac2Q cad1dcad1bdcdbQ1dadb1 adb1dadb1bdcdbQ1dcad1bdcd1dadb1acad
-bQ2#bdcdxa2#bxd
+1bdcd
+bQ
+1@dcac
+2Q cad
+1dcad
+1bdcd
+bQ
+1dadb
+1 adb
+1dadb
+1bdcd
+bQ
+1dcad
+1bdcd
+1dadb
+1acad
+bQ
+2#bdcd
+xa
+2#b
+xd
 1bdcd
 bbX
 1bdcd
-bQ2#dcadx d2#acadxd2#dadbx  c2#  ax   bbQ
+bQ
+2#dcad
+x d
+2#acad
+xd
+2#dadb
+x  c
+2#  a
+x   b
+bQ
 
-bQ2#bdcdx  d2#  cx   d2#daabx   a2#  ax   bbQ2#bdcd
+bQ
+2#bdcd
+x  d
+2#  c
+x   d
+2#daab
+x   a
+2#  a
+x   b
+bQ
+2#bdcd
 x  a
-2# dx c2#daaxb2#axd
-bQ1bdcd
-2#  cdx  d
+2# d
+x c
+2#daa
+xb
+2#a
+xd
+bQ
+1bdcd
+2#  cd
+x  d
 1bdcd
 bbX
-2#  ax  cbQ2#dadbx   a2#   bx   d2#dadbx   d2# ax cbQ2#bdcdxa2#bxd2#bdcdx   b2#   dx   abQ
+2#  a
+x  c
+bQ
+2#dadb
+x   a
+2#   b
+x   d
+2#dadb
+x   d
+2# a
+x c
+bQ
+2#bdcd
+xa
+2#b
+xd
+2#bdcd
+x   b
+2#   d
+x   a
+bQ
 
-bQ2#deedxa2#cacx   a2#dQadxb2#acadxd
-bQ1bdcd
-2#  cdx  d
+bQ
+2#deed
+xa
+2#cac
+x   a
+2#dQad
+xb
+2#acad
+xd
+bQ
+1bdcd
+2#  cd
+x  d
 1bdcd
 bbX
 S3
@@ -12010,67 +20752,133 @@ S3
 b
 0dcad
 1dca
-b1acad
-2#bxd
+b
+1acad
+2#b
+xd
 1bdcd
 b
 1.dadb
 2dad
 1   b
-b1dadb1dad1bdcd
+b
+1dadb
+1dad
+1bdcd
 b
 
-b1acad
-2#bxd
+b
+1acad
+2#b
+xd
 1edea
-b1dadb1dad1dcad
+b
+1dadb
+1dad
+1dcad
 b
 1.edea
 2ede
 1   a
-b1edea1ede
-bbX1edea
 b
-2#acadx a2#axb2#d
+1edea
+1ede
+bbX
+1edea
+b
+2#acad
+x a
+2#a
+xb
+2#d
 xe
 b
-2#dadbxa2#bxd2#   ax   c
-b2#edeaxd2#   ax   b2#   dx   a
+2#dadb
+xa
+2#b
+xd
+2#   a
+x   c
+b
+2#edea
+xd
+2#   a
+x   b
+2#   d
+x   a
 b
 
 b
 1daab
-2#   dx   b2#   ax  a
-b2#edeax   d2#   cx   a2#dxb
-b2#acadx a2#axb2#dxa
+2#   d
+x   b
+2#   a
+x  a
+b
+2#edea
+x   d
+2#   c
+x   a
+2#d
+xb
+b
+2#acad
+x a
+2#a
+xb
+2#d
+xa
 b
 1.edea
 2ede
 1   a
-b1edea1ede
+b
+1edea
+1ede
 bbX
-2#dxe
+2#d
+xe
 b
 0dadb
 1dad
 bQ
 
 bQ
-2#dadbxa2#bxd2#   ax   c
+2#dadb
+xa
+2#b
+xd
+2#   a
+x   c
 b
 1.edea
 2ede
 1   a
 b
-2#edeax   d2#   cx   a2#dxb
-b2#acadx a2#axb2#dxe
+2#edea
+x   d
+2#   c
+x   a
+2#d
+xb
 b
-1dadb1dad1dcad
+2#acad
+x a
+2#a
+xb
+2#d
+xe
+b
+1dadb
+1dad
+1dcad
 b
 1.edea
 2f
 1edea
-b1edeaYede
+b
+1edea
+Yede
 bb
 e
 
@@ -12079,72 +20887,201 @@ e
 B
 b
 S3
-3# acc ax  ax  cx  d
+3# acc a
+x  a
+x  c
+x  d
 2  c
-3# ax  dx ax c
+3# a
+x  d
+x a
+x c
 2 a
 b
 bQ
-2# cd ax  d2# dx a2#ax c
-b2#c  ax d2#f
-x-Qc2#e  axf
-b2#e    ax f2#hxe2#fx c
-b2#ea   axa2#cx d2#a cx  d
+2# cd a
+x  d
+2# d
+x a
+2#a
+x c
+b
+2#c  a
+x d
+2#f
+x-Qc
+2#e  a
+xf
+b
+2#e    a
+x f
+2#h
+xe
+2#f
+x c
+b
+2#ea   a
+xa
+2#c
+x d
+2#a c
+x  d
 b
 
 b
 1 cd a
 2a
-3#   cx  ax  cx  d3# ax cx dxa
+3#   c
+x  a
+x  c
+x  d
+3# a
+x c
+x d
+xa
 b
 1c  a
 2f
-3#  dx ax cx d3#axcxexf
+3#  d
+x a
+x c
+x d
+3#a
+xc
+xe
+xf
 b
 1h    a
 2 a
-3#  ax  cx  dx a3# cx dxaxc
+3#  a
+x  c
+x  d
+x a
+3# c
+x d
+xa
+xc
 b
 1e    a
 2a
-3#  cx  dx ax c3# dxaxcxd
+3#  c
+x  d
+x a
+x c
+3# d
+xa
+xc
+xd
 bQ
 b
 
 b
 bQ
 2fc  a
-3#dxc3#ax dx cx a3#  dx  cx  ax   c
+3#d
+xc
+3#a
+x d
+x c
+x a
+3#  d
+x  c
+x  a
+x   c
 b
 2   a
-3#fxd3#cxax dx c3# ax  dx  cx  a
+3#f
+xd
+3#c
+xa
+x d
+x c
+3# a
+x  d
+x  c
+x  a
 b
 2   c
-3# dx c3# ax  dx  cx  a3#   cx  ax  cx  d
+3# d
+x c
+3# a
+x  d
+x  c
+x  a
+3#   c
+x  a
+x  c
+x  d
 b
 2  cc
-3# dx c3# a
-x  dx  cx  a3#   cx   ax    e
+3# d
+x c
+3# a
+x  d
+x  c
+x  a
+3#   c
+x   a
+x    e
 x    c
 b
 
 b
 2 cd a
-3#dxc3#ax dx cx a3#  dx  bx  ax   c
+3#d
+xc
+3#a
+x d
+x c
+x a
+3#  d
+x  b
+x  a
+x   c
 b
 2   a
-3#  dx  c3#  ax   cx   ax    e3#    cx    ax     ex     c
+3#  d
+x  c
+3#  a
+x   c
+x   a
+x    e
+3#    c
+x    a
+x     e
+x     c
 b
 2     a
-3# dx c3# ax  dx  cx  a3#   c
+3# d
+x c
+3# a
+x  d
+x  c
+x  a
+3#   c
 x  Qa
-x  Qcx  d
-bX3# acc ax  ax  cx  d2# ax  c2#  d  abQ
+x  Qc
+x  d
+bX
+3# acc a
+x  a
+x  c
+x  d
+2# a
+x  c
+2#  d  a
+bQ
 bQ
 x a
 b
-3# cd ax ax cx d
-2#ax c2# dxa
+3# cd a
+x a
+x c
+x d
+2#a
+x c
+2# d
+xa
 b
 B
 
@@ -13083,13 +22020,23 @@ B
 b
 Sc
 2#caa - /a
-x ex a2#cx ex a
+x e
+x a
+2#c
+x e
+x a
 b
 1-+ha - a
 2e.
 1 f
 2e.
-b2#*caa - /ax ex a2#*cx ex a
+b
+2#*caa - /a
+x e
+x a
+2#*c
+x e
+x a
 b
 1-*caa - /a
 2 e
@@ -13099,17 +22046,22 @@ bb
 bb
 2. aa - /a
 3 c.
-2 a2. +e
+2 a
+2. +e
 3 c.
-2 ab
+2 a
+b
 2. ce- c
 3 e.
-2 c2. +f
+2 c
+2. +f
 3 e.
-2 cb
+2 c
+b
 2. aa - /a
 3 c.
-2 a1 +e
+2 a
+1 +e
 2a.
 b
 1-*caa - /a
@@ -13138,36 +22090,63 @@ b
 1  a
 bQ
 bQ
-3# e:xa.
+3# e:
+xa.
 bX
 2.caa - /a
 3e.
 2c:
 1 *a
 2 c
-b2 ea-c
+b
+2 ea-c
 1 a.
 1    Qc
-3# exa.
-b3#c  -  axa.xc:xe.
+3# e
+xa.
+b
+3#c  -  a
+xa.
+xc:
+xe.
 2c
 b
 
 b
-3# a:x  e.x a:x c.
+3# a:
+x  e.
+x a:
+x c.
 2 e:
 b
-3# c - cx ax c:x e2 c:
+3# c - c
+x a
+x c:
+x e
+2 c:
 1  a
-3# exa
-b3#c  -  /axa.xcxe.
-3#c:x  d.x a:x  c.3#   cx  d.x a:x c.
+3# e
+xa
+b
+3#c  -  /a
+xa.
+xc
+xe.
+3#c:
+x  d.
+x a:
+x  c.
+3#   c
+x  d.
+x a:
+x c.
 b
 2 ea c
 1 a
 1Q    Qc
 bbX
-3#axc.
+3#a
+xc.
 b
 2.ec- e
 3f.
@@ -13191,7 +22170,8 @@ b
 1Q   c
 1Q     Qa
 bbX
-3#   cx  a.
+3#   c
+x  a.
 b
 2.  c- a
 3  a.
@@ -13203,7 +22183,8 @@ b
 3  c.
 2  d
 1  a.
-3#  c:x  d.
+3#  c:
+x  d.
 b
 2. ac- a
 3 c
@@ -13718,60 +22699,124 @@ B
 b
 Sc
 2#  d!#a
-x a.2# c!#x d - c
-1aac!#-a1   c!#
+x a.
+2# c!#
+x d - c
+1aac!#-a
+1   c!#
 b
-2#aa - axc.!#2#dxf!#  a
+2#aa - a
+xc.!#
+2#d
+xf!#  a
 2. d a
 3a.
-2#c!#xc.
+2#c!#
+xc.
 b
 2. c!# a
 3 d.
-2#a!#xa.
+2#a!#
+xa.
 2. a!#- a
 3 c.
-2# d  cxc!# a
-b2#a - ex c!# a2# d ax acc
-1  d!#a1a.!#
+2# d  c
+xc!# a
+b
+2#a - e
+x c!# a
+2# d a
+x acc
+1  d!#a
+1a.!#
 b
 2. c!# a
 3 d.
-2#a!#xa.
+2#a!#
+xa.
 2. a!#  a
 3 c.
-2# d  cxc!# a
+2# d  c
+xc!# a
 b
 
 b
-2#a - ex c!# a2# d ax acc
-1  d!#a1a.!#
+2#a - e
+x c!# a
+2# d a
+x acc
+1  d!#a
+1a.!#
 bb
-3#  d ax  c.x  dx a.3# cx a.x c - c{x d.  }3#a -- a
+3#  d a
+x  c.
+x  d
+x a.
+3# c
+x a.
+x c - c{
+x d.  }
+3#a -- a
 x d.
-xaxc.
-2#a!#xa.
-b2#aa!#- axc.!#2#dxf!# a
-3# d ax c.x dxa.
-2#c!#xc.
+xa
+xc.
+2#a!#
+xa.
 b
-3# c- ax a.x cx d.
-2#a!#xa.
+2#aa!#- a
+xc.!#
+2#d
+xf!# a
+3# d a
+x c.
+x d
+xa.
+2#c!#
+xc.
+b
+3# c- a
+x a.
+x c
+x d.
+2#a!#
+xa.
 
 4!
-3# a - ax  d.x ax c.3# d  cxa.
+3# a - a
+x  d.
+x a
+x c.
+3# d  c
+xa.
 2c!# a
 bQ
-2#a - ex c!# a2# d!#ax acc
-1  d!#a1a.!#
+2#a - e
+x c!# a
+2# d!#a
+x acc
+1  d!#a
+1a.!#
 b
-3# c- ax a.x cx d.
-2#a!#xa.
-3# a - ax  d.x ax c.3# d  cxa.
+3# c- a
+x a.
+x c
+x d.
+2#a!#
+xa.
+3# a - a
+x  d.
+x a
+x c.
+3# d  c
+xa.
 2c!# a
 b
-2#a - ex c!# a2# d!#ax acc
-1  d!#aYa.!#
+2#a - e
+x c!# a
+2# d!#a
+x acc
+1  d!#a
+Ya.!#
 b
 B
 
@@ -13780,14 +22825,20 @@ B
 B
 b
 Sc
-2.  d a3 a.2# c  ax d
+2.  d a
+3 a.
+2# c  a
+x d
 b
 1aac  a
 2#   c
 xa.
 b
-3#c  axe.
-2f  a2#ea cxcaa c
+3#c  a
+xe.
+2f  a
+2#ea c
+xcaa c
 b
 1aac  a
 2#a.
@@ -13795,39 +22846,89 @@ bQ
 bQ
 x   c
 bX
-3#  d ax  c.x  dx a.3# c  ax a.x cx d.
+3#  d a
+x  c.
+x  d
+x a.
+3# c  a
+x a.
+x c
+x d.
 b
 
-b3#aac  ax d.xaxc.
-2#aac  axa.
 b
-3#c  axe2f  a2#ea cxcaa cbX
 3#aac  a
 x d.
 xa
 xc.
-2#aac  abQ
+2#aac  a
+xa.
+b
+3#c  a
+xe
+2f  a
+2#ea c
+xcaa c
+bX
+3#aac  a
+x d.
+xa
+xc.
+2#aac  a
+bQ
 bQ
 xa.
-bQ2# d ax c.2# ac  ax c.
-b2.  d a
-3 a.2# c  axa.
-b2# d ax c.2# ac  axa.
+bQ
+2# d a
+x c.
+2# ac  a
+x c.
+b
+2.  d a
+3 a.
+2# c  a
+xa.
+b
+2# d a
+x c.
+2# ac  a
+xa.
 b
 
 b
 1  d a
-2#   cbQ
+2#   c
+bQ
 bQ
 xa.
 bX
 2. d a
 3 c.
-2# ac  axa.
+2# ac  a
+xa.
 bQ
-3#  d ax  c.x  dx a.3# c  ax d.xax c.
-b3# d ax c.x ax  d.3# accx  d.x  ax  c.
-b3#  d ax  c.x  dx a.
+3#  d a
+x  c.
+x  d
+x a.
+3# c  a
+x d.
+xa
+x c.
+b
+3# d a
+x c.
+x a
+x  d.
+3# acc
+x  d.
+x  a
+x  c.
+b
+3#  d a
+x  c.
+x  d
+x a.
 2  d a
 Y   c
 b
@@ -13837,50 +22938,89 @@ B
 B
 b
 Sc
-2# dd   axa2#c  axd
+2# dd   a
+xa
+2#c  a
+xd
 b
-2.f   a3h.
-2#f   axf.
+2.f   a
+3h.
+2#f   a
+xf.
 b
-3#h  axk.
-2l:2#k   axh.
+3#h  a
+xk.
+2l:
+2#k   a
+xh.
 b
 2.f   a
 3h
-2#f   axf
+2#f   a
+xf
 bQ
-3# d ax cx dxa3#cxaxcxd
+3# d a
+x c
+x d
+xa
+3#c
+xa
+xc
+xd
 b
 2.fcd a
 3fcd
-2#    ax  d.
+2#    a
+x  d.
 b
-3# a ax c
-2 d2# c  ax ac  a
+3# a a
+x c
+2 d
+2# c  a
+x ac  a
 b
 2.  d a
 3  d
-2#    axf
+2#    a
+xf
 b
 
-b2#da cxc2#a   axc
+b
+2#da c
+xc
+2#a   a
+xc
 bQ
 2. d a
 3a
-2#cx d
-b2#da cxc2#a   axf
+2#c
+x d
+b
+2#da c
+xc
+2#a   a
+xf
 b
 2. dd   a
 3 dd
-2#   axf
-b2#da cxc2#a   axc
+2#   a
+xf
+b
+2#da c
+xc
+2#a   a
+xc
 b
 2. d a
 3a
 2c
-3#axc
+3#a
+xc
 b
-2#da cxc2#a   axf
+2#da c
+xc
+2#a   a
+xf
 bQ
 2. dd   a
 3 dd
@@ -13893,115 +23033,456 @@ B
 B
 b1
 Sc
-2#   c-ax  a2#  ccx  de
-1 acc-a1 acc
+2#   c-a
+x  a
+2#  cc
+x  de
+1 acc-a
+1 acc
 b
-2# acc-ax cd2# daxa-c
+2# acc-a
+x cd
+2# da
+xa-c
 2.  dca
 3 a
-2 c3# ax  d
+2 c
+3# a
+x  d
 b
 2.  cc-a
-3  d3# ax    cx  d-ex  c
-2#  aax  c2#  d-ex   c
-b2# aa-cx a-c-e2#  deax  abc
-1 acc-a1 acc
+3  d
+3# a
+x    c
+x  d-e
+x  c
+2#  aa
+x  c
+2#  d-e
+x   c
+b
+2# aa-c
+x a-c-e
+2#  dea
+x  abc
+1 acc-a
+1 acc
 bb
 
 b2
 b
-2# acc-axa- c2# cdx e-e2#a-cc-ax cd2# acx  de
-b2# acc-ax cd2# dax ac2# cd-ax a-c-e2# cd-ax  db-c
-b2# acc-ax aab2# accx  ece2# aa-cx ca b2# ea-cx a-c-e
-b2# ca-ax a-c-e2 ca-a
-3# aa-cx  d2 acc-a
-3#   cx  a3#  cx  ax  cx  d
+2# acc-a
+xa- c
+2# cd
+x e-e
+2#a-cc-a
+x cd
+2# ac
+x  de
+b
+2# acc-a
+x cd
+2# da
+x ac
+2# cd-a
+x a-c-e
+2# cd-a
+x  db-c
+b
+2# acc-a
+x aab
+2# acc
+x  ece
+2# aa-c
+x ca b
+2# ea-c
+x a-c-e
+b
+2# ca-a
+x a-c-e
+2 ca-a
+3# aa-c
+x  d
+2 acc-a
+3#   c
+x  a
+3#  c
+x  a
+x  c
+x  d
 bb
 
 b3
-b3 a - a
-4# cx d
-3a
-4# dx c
-3 a
-4#  dx  c4#  ax  cx  dx  a4#  c- ax  ax  cx  d4# ax  dx  cx  a4#   cx   bx   cx  a4#  cx  ax  cx  d
 b
 3 a - a
-4# cx d
+4# c
+x d
 3a
-4# dx c
+4# d
+x c
 3 a
-4# dx c4# ax cx dx a
+4#  d
+x  c
+4#  a
+x  c
+x  d
+x  a
+4#  c- a
+x  a
+x  c
+x  d
+4# a
+x  d
+x  c
+x  a
+4#   c
+x   b
+x   c
+x  a
+4#  c
+x  a
+x  c
+x  d
+b
+3 a - a
+4# c
+x d
+3a
+4# d
+x c
+3 a
+4# d
+x c
+4# a
+x c
+x d
+x a
 3 c- a
-4#  ax  c4#  dx  cx  dx a
+4#  a
+x  c
+4#  d
+x  c
+x  d
+x a
 3 c
-4# ax c
-3# ax  d
+4# a
+x c
+3# a
+x  d
 b
 
-b3  c- a
-4#   cx  a4#  cx  ax  cx  d3# ax  dx ax c3 ea c
-4# ax c
-3# ex c3 a - e
-4#  dx a
-3# cx a
-b3 c- a
-4#  ax  c
-3#  dx  c3  acc
-4#   bx   c
-3#   bx  d3# acc-ax  dex acx cd3# eaxa-cx cdx ea
+b
+3  c- a
+4#   c
+x  a
+4#  c
+x  a
+x  c
+x  d
+3# a
+x  d
+x a
+x c
+3 ea c
+4# a
+x c
+3# e
+x c
+3 a - e
+4#  d
+x a
+3# c
+x a
+b
+3 c- a
+4#  a
+x  c
+3#  d
+x  c
+3  acc
+4#   b
+x   c
+3#   b
+x  d
+3# acc-a
+x  de
+x ac
+x cd
+3# ea
+xa-c
+x cd
+x ea
 b4
 b
-2#aaccxfc2#e-fxc-d2#aaccx cd2# acx  de
+2#aacc
+xfc
+2#e-f
+xc-d
+2#aacc
+x cd
+2# ac
+x  de
 b
 
-b2 acc-a
-3#ax   a3#a - ex  dx d- cx  c
-2# c- ax da2 c-c
-3# ax  d
-b3#  c- ax  d- cx a - ex ca-a2# ea-cxa d-e2#c- ax a2#aa- ex  e
-b2# ea-cx a-c-e2# ca-ax ea-c
+b
+2 acc-a
+3#a
+x   a
+3#a - e
+x  d
+x d- c
+x  c
+2# c- a
+x da
+2 c-c
+3# a
+x  d
+b
+3#  c- a
+x  d- c
+x a - e
+x ca-a
+2# ea-c
+xa d-e
+2#c- a
+x a
+2#aa- e
+x  e
+b
+2# ea-c
+x a-c-e
+2# ca-a
+x ea-c
 3a-cc-a
-4# ex c
-4# ax  dx  cx  a
-3#   cx  ax  cx  d
+4# e
+x c
+4# a
+x  d
+x  c
+x  a
+3#   c
+x  a
+x  c
+x  d
 bb
 
 b5
-b3# ax     ax cx  d3# ax     ax  dx  a3#  cx     ax   cx  a3#  cx  dx ax c
-b3# ax     axax    a3#a - ex  dx d- cx  c3# cx    ax   cx a3 c- a
-4# ax c
-3# ax  d
-b3#  c- ax  ax  cx  d3# ax    cx  d-ex  c3#  aax   cx  ax  c3#  dx    ex   cx  d
+b
+3# a
+x     a
+x c
+x  d
+3# a
+x     a
+x  d
+x  a
+3#  c
+x     a
+x   c
+x  a
+3#  c
+x  d
+x a
+x c
+b
+3# a
+x     a
+xa
+x    a
+3#a - e
+x  d
+x d- c
+x  c
+3# c
+x    a
+x   c
+x a
+3 c- a
+4# a
+x c
+3# a
+x  d
+b
+3#  c- a
+x  a
+x  c
+x  d
+3# a
+x    c
+x  d-e
+x  c
+3#  aa
+x   c
+x  a
+x  c
+3#  d
+x    e
+x   c
+x  d
 b
 
-b3# ax    cx     ex   c3#  ax    ax    cx  d3# c-c-ax ax  cx  d3# axax cx e
+b
+3# a
+x    c
+x     e
+x   c
+3#  a
+x    a
+x    c
+x  d
+3# c-c-a
+x a
+x  c
+x  d
+3# a
+xa
+x c
+x e
 b6
 b
-2#aaccxce2#efxfh2#hk - axkl2#hkxfh
-b2#ef
-xcd2#fcxe-f2#fcx  d2    a
-3#cxe
+2#aacc
+xce
+2#ef
+xfh
+2#hk - a
+xkl
+2#hk
+xfh
+b
+2#ef
+xcd
+2#fc
+xe-f
+2#fc
+x  d
+2    a
+3#c
+xe
 b
 2f
-3#eax c
-2#cdxac2# ea-cxa - e2#c  bxaa - e
+3#ea
+x c
+2#cd
+xac
+2# ea-c
+xa - e
+2#c  b
+xaa - e
 b
-3# c- ax e
-2a- ce2# f ecx e
+3# c- a
+x e
+2a- ce
+2# f ec
+x e
 3a-cc-a
-4# ax c
-3# ax  d3#  cx  ax  cx  d
+4# a
+x c
+3# a
+x  d
+3#  c
+x  a
+x  c
+x  d
 b
 
 b
-2# a - ax  dx a2#  cx  dx a2# cx ax  d2#  cx  dx  a2#  c- ax  ax  c2#   cx  ax  c2#  dx ax c2# ax cx  d
-b2# a - ax cx d2#ax dx c2# ax cx d2# cx dx a2# cx ax c2# dx cx a2#  dx ax c2# ax cx  d
+2# a - a
+x  d
+x a
+2#  c
+x  d
+x a
+2# c
+x a
+x  d
+2#  c
+x  d
+x  a
+2#  c- a
+x  a
+x  c
+2#   c
+x  a
+x  c
+2#  d
+x a
+x c
+2# a
+x c
+x  d
+b
+2# a - a
+x c
+x d
+2#a
+x d
+x c
+2# a
+x c
+x d
+2# c
+x d
+x a
+2# c
+x a
+x c
+2# d
+x c
+x a
+2#  d
+x a
+x c
+2# a
+x c
+x  d
 b
 
-b2#  c- ax  ax  c2#   cx  ax  c2#  dx ax c2# cx exa2# e- cx cx e2#ax ex c2# a - ex  dx a2#  cx  dx a
-b2# c- ax ax c2#  dx ax c2# a- cx  dx  c2#  ax  cx  d
-3#  c- ax ax cx e3#ax exaxc
+b
+2#  c- a
+x  a
+x  c
+2#   c
+x  a
+x  c
+2#  d
+x a
+x c
+2# c
+x e
+xa
+2# e- c
+x c
+x e
+2#a
+x e
+x c
+2# a - e
+x  d
+x a
+2#  c
+x  d
+x a
+b
+2# c- a
+x a
+x c
+2#  d
+x a
+x c
+2# a- c
+x  d
+x  c
+2#  a
+x  c
+x  d
+3#  c- a
+x a
+x c
+x e
+3#a
+x e
+xa
+xc
 b8
 b
 3#e -- a
@@ -14022,34 +23503,106 @@ x  c
 x  a
 x  c
 x  d
-b3#e -- axfxhxf3#excxax d3# c- ax dxax c3#  dx a3 c
-4# ax  d
 b
-3#  c- ax  dx ax c3# ex    c
+3#e -- a
+xf
+xh
+xf
+3#e
+xc
+xa
+x d
+3# c- a
+x d
+xa
+x c
+3#  d
+x a
+3 c
+4# a
+x  d
+b
+3#  c- a
+x  d
+x a
+x c
+3# e
+x    c
 2a - e
-3#c- axaxcx a3#a - ex exax  e
-b3# ex    c
-2 a-c-e2 ca-a
-3# e- cx  d
+3#c- a
+xa
+xc
+x a
+3#a - e
+x e
+xa
+x  e
+b
+3# e
+x    c
+2 a-c-e
+2 ca-a
+3# e- c
+x  d
 2a-cc-a
-3# ex c3# ax  dx  cx  a
+3# e
+x c
+3# a
+x  d
+x  c
+x  a
 b
 
 b9
 bQ
 2 acc-a
-3#   bx    e3#    cx    ax     ex     c
+3#   b
+x    e
+3#    c
+x    a
+x     e
+x     c
 2 acc-a
-3# dx c3# ax  dx  cx  a
+3# d
+x c
+3# a
+x  d
+x  c
+x  a
 b
 2 acc-a
-3#ax d3# cx ax  dx  c
+3#a
+x d
+3# c
+x a
+x  d
+x  c
 2  d-a
-3#  cx  a3#   cx   bx   cx  a
-b3#  c- ax  ax  cx  d3# ax    cx  d-ex  c
-2#  aax a- c2# a-cex  e
-b2# aa-cx a-c-e2 cdca
-3# aa-cx  d
+3#  c
+x  a
+3#   c
+x   b
+x   c
+x  a
+b
+3#  c- a
+x  a
+x  c
+x  d
+3# a
+x    c
+x  d-e
+x  c
+2#  aa
+x a- c
+2# a-ce
+x  e
+b
+2# aa-c
+x a-c-e
+2 cdca
+3# aa-c
+x  d
 Yaaccca
 b
 B
@@ -14059,7 +23612,8 @@ B
 b
 Sc
 1aa - a
-2# afx c
+2# af
+x c
 b
 2. ea - /a
 3a
@@ -14067,69 +23621,129 @@ b
 b
 2.aa c a
 3# d
-x ca--cx a
+x ca--c
+x a
 2 c
-b2 aa c
-1      /a
-3#exf
 b
-2#hx a - e2# c--ax a - e
-b2#fc - cxea - a
+2 aa c
+1      /a
+3#e
+xf
+b
+2#h
+x a - e
+2# c--a
+x a - e
+b
+2#fc - c
+xea - a
 1ca  c
 b
 2aa - e
-3#ex    a
-2#caa cx      /a
+3#e
+x    a
+2#caa c
+x      /a
 bQ
-1aac--a1   c
+1aac--a
+1   c
 bb
 2. ea - /a
 3a.
-2#cxea - a
-b2#fc - cxce  c
+2#c
+xea - a
+b
+2#fc - c
+xce  c
 1ef - a
 b
 
 b
-2# a - exa2ccf  c
-3#  exa
+2# a - e
+xa
+2ccf  c
+3#  e
+xa
 b
 2 ea c
-3#      /ax c
-2# ax  d
-b2# ac--ax   c2#ca bx    c
+3#      /a
+x c
+2# a
+x  d
 b
-3#ea - axf.
-2h2#   exg.
+2# ac--a
+x   c
+2#ca b
+x    c
 b
-2#ha gx    h2#f--ex    f
-b2#aa - ex     a2# aa   bxc
-b2#  d exa2#fx   b
-b2ea c
-3#ax     a
-2#caa cx      /a
+3#ea - a
+xf.
+2h
+2#   e
+xg.
+b
+2#ha g
+x    h
+2#f--e
+x    f
+b
+2#aa - e
+x     a
+2# aa   b
+xc
+b
+2#  d e
+xa
+2#f
+x   b
+b
+2ea c
+3#a
+x     a
+2#caa c
+x      /a
 b
 
 b
 1fc e c
-2#haa - /ax f
-b2# ea - /ax a2#cxe
-b2fc
-3#    ax e.
-2#efx     a
+2#haa - /a
+x f
+b
+2# ea - /a
+x a
+2#c
+xe
+b
+2fc
+3#    a
+x e.
+2#ef
+x     a
 b
 2caa   b
 1      /a
-3#exf
+3#e
+xf
 b
-2#hx a - e2# c--ax a - e
-b2#fc - cxea - a
+2#h
+x a - e
+2# c--a
+x a - e
+b
+2#fc - c
+xea - a
 1ca--c
 b
 2aa - e
-3#ex    a
-2#caa cx      /a
-b2#     axaac2#   cx  d
+3#e
+x    a
+2#caa c
+x      /a
+b
+2#     a
+xaac
+2#   c
+x  d
 b
 Yaac--a
 b
@@ -14162,7 +23776,8 @@ b
 3 c
 2 e
 1a    Qa
-bbX2a
+bbX
+2a
 b
 1c   Qc
 2 e
@@ -14205,8 +23820,10 @@ b
 2 e
 1 a Qa
 2 a
-b2 c
-1 e  Qc1a    Qa
+b
+2 c
+1 e  Qc
+1a    Qa
 bbX
 2e
 b
@@ -14214,13 +23831,18 @@ b
 1 e
 1 a   Qa
 2e
-b2h   Qh
-1e1a    Qa
+b
+2h   Qh
+1e
+1a    Qa
 2e
-b2c   Qc
-1 e1 a Qc
+b
+2c   Qc
+1 e
+1 a Qc
 2 a
-b2 c
+b
+2 c
 1 e  Qc
 Ya    Qa
 b


### PR DESCRIPTION
Fixed line endings.   Fixed three 8-bit chars: Mac 0xD5 and UFT-8 0xE2 0x80 0x99 "RIGHT SINGLE QUOTATION MARK" both replaced by us-ascii apostrophe.  Mac 0xC9 "ellipsis" deleted.